### PR TITLE
[FRONTEND] Criar testes de validação de campos no frontend

### DIFF
--- a/apps/agendamento/package.json
+++ b/apps/agendamento/package.json
@@ -9,11 +9,14 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.1",
     "@primer/octicons-react": "^19.15.5",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-collapsible": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.14",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-popover": "^1.1.14",
     "@radix-ui/react-scroll-area": "^1.2.9",
@@ -21,6 +24,7 @@
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tooltip": "^1.2.7",
+    "@react-input/mask": "^2.0.4",
     "axios": "^1.11.0",
     "chrono-node": "^2.8.4",
     "class-variance-authority": "^0.7.1",
@@ -32,7 +36,11 @@
     "react": "19.1.0",
     "react-day-picker": "^9.8.1",
     "react-dom": "19.1.0",
-    "tailwind-merge": "^3.3.1"
+    "react-hook-form": "^7.62.0",
+    "react-toastify": "^11.0.5",
+    "tailwind-merge": "^3.3.1",
+    "use-mask-input": "^3.5.1",
+    "zod": "^4.0.17"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -40,6 +48,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/react-toastify": "^4.1.0",
     "eslint": "^9",
     "eslint-config-next": "15.4.5",
     "tailwindcss": "^4",

--- a/apps/agendamento/src/app/register-profissional/page.tsx
+++ b/apps/agendamento/src/app/register-profissional/page.tsx
@@ -1,72 +1,82 @@
 "use client";
 
-import { useForm } from "react-hook-form";
+import { useForm, Controller, type SubmitHandler, type Control, type Resolver } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";  
+import * as z from "zod";
+import { InputMask } from "@react-input/mask";
+
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { useRouter } from "next/navigation";
-
 import { useCreateProfissional } from "@/hooks/profissional/use-create-profissional";
+import { cadastroSchema } from "@/schemas/profissional.schema";
+import { HEALTH_AREAS } from "@/lib/health-areas";
+import { STATES } from "@/lib/states";
+import { JSX } from "react";
 
-export default function CadastroProfissional() {
+type CadastroFormValues = z.infer<typeof cadastroSchema>;
+
+export default function CadastroProfissional(): JSX.Element {
   const { create, loading, error, success } = useCreateProfissional();
   const router = useRouter();
 
-  const form = useForm({
-    defaultValues: {
-      nomeCompleto: "",
-      email: "",
-      documentoProfissional: "",
-      areaSaude: "",
-      cpf: "",
-      telefone: "",
-    },
-  });
+  const defaultValues: CadastroFormValues = {
+    nomeCompleto: "",
+    email: "",
+    documentoProfissional: "",
+    areaSaude: "",
+    telefone: "",
+    cpf: "",
+    rg: "",
+    estado: "",
+    cidade: "",
+    bairro: "",
+    rua: "",
+    numero: "",
+    complemento: "",
+    cep: "",
+  };
+
+  const resolver = zodResolver(cadastroSchema) as unknown as Resolver<CadastroFormValues>;
+  const form = useForm<CadastroFormValues>({ resolver, defaultValues });
+  const typedControl = form.control as unknown as Control<CadastroFormValues>;
 
   function onCancel() {
     router.push("/visualization-professional");
   }
 
-  async function onSubmit(values: any) {
-    try {
-      const payload = {
-        nome: values.nomeCompleto,
-        email: values.email,
-        docProfissional: values.documentoProfissional,
-        areaDaSaude: values.areaSaude,
-        telefone: values.telefone,
-      };
+  const onSubmit: SubmitHandler<CadastroFormValues> = async (values) => {
+    const payload = {
+      nome: values.nomeCompleto.trim(),
+      email: values.email.trim(),
+      docProfissional: values.documentoProfissional.trim(),
+      areaDaSaude: values.areaSaude,
+      telefone: values.telefone,
+      cpf: values.cpf,
+      rg: values.rg.trim(),
+      endereco: {
+        estado: values.estado,
+        cidade: values.cidade.trim(),
+        bairro: values.bairro.trim(),
+        rua: values.rua.trim(),
+        numero: values.numero?.trim(),
+        complemento: values.complemento?.trim(),
+        cep: values.cep,
+      },
+    };
+    
+    await create(payload);
+  };
 
-      await create(payload);
-    } catch (e) {
-      console.error("Erro ao criar profissional", e);
-    }
-  }
   return (
     <div className="p-6">
       <h1 className="text-2xl font-bold mb-6">Cadastrar Profissional</h1>
-
       <Form {...form}>
-        <form
-          onSubmit={form.handleSubmit(onSubmit)}
-          className="space-y-6 max-w-2xl"
-        >
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6 w-lg">
           <FormField
-            control={form.control}
+            control={typedControl}
             name="nomeCompleto"
             render={({ field }) => (
               <FormItem>
@@ -78,27 +88,21 @@ export default function CadastroProfissional() {
               </FormItem>
             )}
           />
-
           <FormField
-            control={form.control}
+            control={typedControl}
             name="email"
             render={({ field }) => (
               <FormItem>
                 <FormLabel>Email</FormLabel>
                 <FormControl>
-                  <Input
-                    type="email"
-                    placeholder="profissional@exemplo.com"
-                    {...field}
-                  />
+                  <Input type="email" placeholder="profissional@exemplo.com" {...field} />
                 </FormControl>
                 <FormMessage />
               </FormItem>
             )}
           />
-
           <FormField
-            control={form.control}
+            control={typedControl}
             name="documentoProfissional"
             render={({ field }) => (
               <FormItem>
@@ -110,65 +114,205 @@ export default function CadastroProfissional() {
               </FormItem>
             )}
           />
-
           <div className="grid grid-cols-2 gap-4">
-            <FormField
-              control={form.control}
-              name="areaSaude"
-              render={({ field }) => (
+            <Controller
+              control={typedControl}
+              name="cpf"
+              render={({ field, fieldState }) => (
                 <FormItem>
-                  <FormLabel>Área da saúde</FormLabel>
-                  <Select onValueChange={field.onChange} value={field.value}>
-                    <FormControl>
-                      <SelectTrigger className="w-full">
-                        <SelectValue placeholder="Selecione uma opção" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      <SelectItem value="Medicina">Medicina</SelectItem>
-                      <SelectItem value="Enfermagem">Enfermagem</SelectItem>
-                      <SelectItem value="Fisioterapia">Fisioterapia</SelectItem>
-                      <SelectItem value="Psicologia">Psicologia</SelectItem>
-                      <SelectItem value="Nutrição">Nutrição</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
+                  <FormLabel>CPF</FormLabel>
+                  <FormControl className="w-full">
+                    <InputMask
+                      mask="___.___.___-__"
+                      replacement={{ _: /\d/ }}
+                      value={field.value ?? ""}
+                      onChange={(e) => field.onChange(e.target.value)}
+                      onBlur={field.onBlur}
+                      placeholder="123.456.789-00"
+                      className={`w-full rounded-md border px-3 py-1 ${fieldState.invalid ? "border-red-500" : "border-gray-300"}`}
+                    />
+                  </FormControl>
+                  <FormMessage>{fieldState.error?.message}</FormMessage>
                 </FormItem>
               )}
             />
-
             <FormField
-              control={form.control}
-              name="telefone"
+              control={typedControl}
+              name="rg"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Telefone</FormLabel>
+                  <FormLabel>RG</FormLabel>
                   <FormControl>
-                    <Input placeholder="(11) 98765-4321" {...field} />
+                    <Input placeholder="Ex: 1234567" {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
               )}
             />
           </div>
-
+          <div className="grid grid-cols-2 gap-4">
+            <Controller
+              control={typedControl}
+              name="areaSaude"
+              render={({ field, fieldState }) => (
+                <FormItem>
+                  <FormLabel>Área da saúde</FormLabel>
+                  <FormControl>
+                    <Select onValueChange={field.onChange} value={field.value}>
+                      <SelectTrigger className={`w-full ${fieldState.invalid ? "border-red-500" : "border-gray-300"}`}>
+                        <SelectValue placeholder="Selecione uma opção" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {HEALTH_AREAS.map((a) => (
+                          <SelectItem key={a} value={a}>{a}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </FormControl>
+                  <FormMessage>{fieldState.error?.message}</FormMessage>
+                </FormItem>
+              )}
+            />
+            <Controller
+              control={typedControl}
+              name="telefone"
+              render={({ field, fieldState }) => (
+                <FormItem>
+                  <FormLabel>Telefone</FormLabel>
+                  <FormControl>
+                    <InputMask
+                      mask="(__) _____-____"
+                      replacement={{ _: /\d/ }}
+                      value={field.value ?? ""}
+                      onChange={(e) => field.onChange(e.target.value)}
+                      onBlur={field.onBlur}
+                      placeholder="(xx) xxxxx-xxxx"
+                      className="w-full rounded-md border px-3 py-2"
+                    />
+                  </FormControl>
+                  <FormMessage>{fieldState.error?.message}</FormMessage>
+                </FormItem>
+              )}
+            />
+          </div>
+          <div className="grid grid-cols-3 gap-4">
+            <Controller
+              control={typedControl}
+              name="estado"
+              render={({ field, fieldState }) => (
+                <FormItem>
+                  <FormLabel>Estado</FormLabel>
+                  <FormControl>
+                    <Select onValueChange={field.onChange} value={field.value}>
+                      <SelectTrigger className={`w-full ${fieldState.invalid ? "border-red-500" : "border-gray-300"}`}>
+                        <SelectValue placeholder="Selecione um estado" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {STATES.map((s) => (
+                          <SelectItem key={s} value={s}>{s}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </FormControl>
+                  <FormMessage>{fieldState.error?.message}</FormMessage>
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={typedControl}
+              name="cidade"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Cidade</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Ex: João Pessoa" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={typedControl}
+              name="bairro"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Bairro</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Ex: Centro" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <FormField
+              control={typedControl}
+              name="rua"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Endereço</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Ex: Rua das Flores" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={typedControl}
+              name="numero"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Número</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Ex: 123" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+          <FormField
+            control={typedControl}
+            name="complemento"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Complemento</FormLabel>
+                <FormControl>
+                  <Input placeholder="Ex: Apt 101" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Controller
+            control={typedControl}
+            name="cep"
+            render={({ field, fieldState }) => (
+              <FormItem>
+                <FormLabel>CEP</FormLabel>
+                <FormControl>
+                  <InputMask
+                    mask="_____-___"
+                    replacement={{ _: /\d/ }}
+                    value={field.value ?? ""}
+                    onChange={(e) => field.onChange(e.target.value)}
+                    onBlur={field.onBlur}
+                    placeholder="12345-678"
+                    className="w-full rounded-md border px-3 py-2"
+                  />
+                </FormControl>
+                <FormMessage>{fieldState.error?.message}</FormMessage>
+              </FormItem>
+            )}
+          />
           {loading && <p className="text-blue-500">Salvando...</p>}
-          {error && <p className="text-red-500">Erro: {error}</p>}
-          {success && (
-            <p className="text-green-600">Profissional criado com sucesso!</p>
-          )}
-
+          {error && <p className="text-red-500">{error}</p>}
+          {success && <p className="text-green-600">Profissional criado com sucesso!</p>}
           <div className="flex justify-end gap-4">
-            <Button type="button" variant="outline" onClick={onCancel}>
-              Cancelar
-            </Button>
-            <Button
-              type="submit"
-              className="bg-blue-800 hover:bg-blue-900"
-              disabled={loading}
-            >
-              Cadastrar
-            </Button>
+            <Button type="button" variant="outline" onClick={onCancel}>Cancelar</Button>
+            <Button type="submit" className="bg-blue-800 hover:bg-blue-900" disabled={form.formState.isSubmitting || loading}>Cadastrar</Button>
           </div>
         </form>
       </Form>

--- a/apps/agendamento/src/app/update-profissional/[id]/page.tsx
+++ b/apps/agendamento/src/app/update-profissional/[id]/page.tsx
@@ -1,77 +1,95 @@
 "use client";
 
-import { useEffect } from "react";
-import { useForm } from "react-hook-form";
+import { JSX, useEffect } from "react";
+import { useForm, Controller, type SubmitHandler, type Control, type Resolver } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+import { InputMask } from "@react-input/mask";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
-
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { useGetByIdProfissional } from "@/hooks/profissional/use-get-by-id-profissional";
 import { useUpdateProfissional } from "@/hooks/profissional/use-update-profissional";
 import { useRouter } from "next/navigation";
+import { cadastroSchema } from "@/schemas/profissional.schema"; // Reutilizamos o mesmo schema
+import { HEALTH_AREAS } from "@/lib/health-areas";
+import { STATES } from "@/lib/states";
 
-export type FormData = {
-  nome: string;
-  email: string;
-  docProfissional: string;
-  areaDaSaude: string;
-  telefone: string;
-};
+type UpdateFormValues = z.infer<typeof cadastroSchema>;
 
-export default function AtualizarProfissional() {
+export default function AtualizarProfissional(): JSX.Element {
   const router = useRouter();
-  const {
-    profissional,
-    loading: loadingProf,
-    error: errorProf,
-  } = useGetByIdProfissional();
-  const { updateProfissional, loading, error, success } =
-    useUpdateProfissional();
+  const { profissional, loading: loadingProf, error: errorProf } = useGetByIdProfissional();
+  const { updateProfissional, loading, error, success } = useUpdateProfissional();
 
-  const form = useForm<FormData>({
+  const resolver = zodResolver(cadastroSchema) as unknown as Resolver<UpdateFormValues>;
+  const form = useForm<UpdateFormValues>({
+    resolver,
     defaultValues: {
-      nome: "",
+      nomeCompleto: "",
       email: "",
-      docProfissional: "",
-      areaDaSaude: "",
+      documentoProfissional: "",
+      areaSaude: "",
       telefone: "",
+      cpf: "",
+      rg: "",
+      estado: "",
+      cidade: "",
+      bairro: "",
+      rua: "",
+      numero: "",
+      complemento: "",
+      cep: "",
     },
   });
+
+  const typedControl = form.control as unknown as Control<UpdateFormValues>;
 
   useEffect(() => {
     if (profissional) {
       form.reset({
-        nome: profissional.nome,
-        email: profissional.email,
-        docProfissional: profissional.docProfissional,
-        areaDaSaude: profissional.areaDaSaude,
-        telefone: profissional.telefone,
+        nomeCompleto: profissional.nome ?? "",
+        email: profissional.email ?? "",
+        documentoProfissional: profissional.docProfissional ?? "",
+        areaSaude: profissional.areaDaSaude ?? "",
+        telefone: profissional.telefone ?? "",
+        cpf: profissional.cpf ?? "",
+        rg: profissional.rg ?? "",
+        estado: profissional.endereco?.estado ?? "",
+        cidade: profissional.endereco?.cidade ?? "",
+        bairro: profissional.endereco?.bairro ?? "",
+        rua: profissional.endereco?.rua ?? "",
+        numero: profissional.endereco?.numero ?? "",
+        complemento: profissional.endereco?.complemento ?? "",
+        cep: profissional.endereco?.cep ?? "",
       });
     }
   }, [profissional, form]);
 
-  async function onSubmit(data: FormData) {
-    if (!profissional?.id) {
-      console.error("ID do profissional não encontrado");
-      return;
-    }
-    await updateProfissional(profissional.id, data);
-  }
+  const onSubmit: SubmitHandler<UpdateFormValues> = async (values) => {
+    if (!profissional?.id) return;
+    const payload = {
+      nome: values.nomeCompleto.trim(),
+      email: values.email.trim(),
+      docProfissional: values.documentoProfissional.trim(),
+      areaDaSaude: values.areaSaude,
+      telefone: values.telefone,
+      cpf: values.cpf,
+      rg: values.rg.trim(),
+      endereco: {
+        estado: values.estado,
+        cidade: values.cidade.trim(),
+        bairro: values.bairro.trim(),
+        rua: values.rua.trim(),
+        numero: values.numero?.trim(),
+        complemento: values.complemento?.trim(),
+        cep: values.cep,
+      },
+    };
+    await updateProfissional(profissional.id, payload);
+  };
 
   function onCancel() {
     router.push("/visualization-professional");
@@ -83,116 +101,203 @@ export default function AtualizarProfissional() {
   return (
     <div className="p-6">
       <h1 className="text-2xl font-bold mb-6">Atualizar Profissional</h1>
-
       <Form {...form}>
-        <form
-          onSubmit={form.handleSubmit(onSubmit)}
-          className="space-y-6 max-w-2xl"
-        >
-          <FormField
-            control={form.control}
-            name="nome"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Nome completo</FormLabel>
-                <FormControl>
-                  <Input placeholder="Ex: Maria da Silva" {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6 max-w-2xl">
+          <FormField control={typedControl} name="nomeCompleto" render={({ field }) => (
+            <FormItem>
+              <FormLabel>Nome completo</FormLabel>
+              <FormControl>
+                <Input placeholder="Ex: Maria da Silva" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )} />
 
-          <FormField
-            control={form.control}
-            name="email"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Email</FormLabel>
-                <FormControl>
-                  <Input
-                    type="email"
-                    placeholder="profissional@exemplo.com"
-                    {...field}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
+          <FormField control={typedControl} name="email" render={({ field }) => (
+            <FormItem>
+              <FormLabel>Email</FormLabel>
+              <FormControl>
+                <Input type="email" placeholder="profissional@exemplo.com" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )} />
 
-          <FormField
-            control={form.control}
-            name="docProfissional"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Documento profissional</FormLabel>
-                <FormControl>
-                  <Input placeholder="Ex: CRM/SP 123456" {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
+          <FormField control={typedControl} name="documentoProfissional" render={({ field }) => (
+            <FormItem>
+              <FormLabel>Documento profissional</FormLabel>
+              <FormControl>
+                <Input placeholder="Ex: CRM/SP 123456" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )} />
 
           <div className="grid grid-cols-2 gap-4">
-            <FormField
-              control={form.control}
-              name="areaDaSaude"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Área da saúde</FormLabel>
-                  <Select onValueChange={field.onChange} value={field.value}>
-                    <FormControl>
-                      <SelectTrigger className="w-full">
-                        <SelectValue placeholder="Selecione uma opção" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      <SelectItem value="Medicina">Medicina</SelectItem>
-                      <SelectItem value="Enfermagem">Enfermagem</SelectItem>
-                      <SelectItem value="Fisioterapia">Fisioterapia</SelectItem>
-                      <SelectItem value="Psicologia">Psicologia</SelectItem>
-                      <SelectItem value="Nutrição">Nutrição</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+            <Controller control={typedControl} name="cpf" render={({ field, fieldState }) => (
+              <FormItem>
+                <FormLabel>CPF</FormLabel>
+                <FormControl className="w-full">
+                  <InputMask
+                    mask="___.___.___-__"
+                    replacement={{ _: /\d/ }}
+                    value={field.value ?? ""}
+                    onChange={(e) => field.onChange(e.target.value)}
+                    onBlur={field.onBlur}
+                    placeholder="123.456.789-00"
+                    className={`w-full rounded-md border px-3 py-1 ${fieldState.invalid ? "border-red-500" : "border-gray-300"}`}
+                  />
+                </FormControl>
+                <FormMessage>{fieldState.error?.message}</FormMessage>
+              </FormItem>
+            )} />
 
-            <FormField
-              control={form.control}
-              name="telefone"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Telefone</FormLabel>
-                  <FormControl>
-                    <Input placeholder="(11) 98765-4321" {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+            <FormField control={typedControl} name="rg" render={({ field }) => (
+              <FormItem>
+                <FormLabel>RG</FormLabel>
+                <FormControl>
+                  <Input placeholder="Ex: 1234567" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )} />
           </div>
 
+          <div className="grid grid-cols-2 gap-4">
+            <Controller control={typedControl} name="areaSaude" render={({ field, fieldState }) => (
+              <FormItem>
+                <FormLabel>Área da saúde</FormLabel>
+                <FormControl>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <SelectTrigger className={`w-full ${fieldState.invalid ? "border-red-500" : "border-gray-300"}`}>
+                      <SelectValue placeholder="Selecione uma opção" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {HEALTH_AREAS.map(a => <SelectItem key={a} value={a}>{a}</SelectItem>)}
+                    </SelectContent>
+                  </Select>
+                </FormControl>
+                <FormMessage>{fieldState.error?.message}</FormMessage>
+              </FormItem>
+            )} />
+
+            <Controller control={typedControl} name="telefone" render={({ field, fieldState }) => (
+              <FormItem>
+                <FormLabel>Telefone</FormLabel>
+                <FormControl>
+                  <InputMask
+                    mask="(__) _____-____"
+                    replacement={{ _: /\d/ }}
+                    value={field.value ?? ""}
+                    onChange={(e) => field.onChange(e.target.value)}
+                    onBlur={field.onBlur}
+                    placeholder="(xx) xxxxx-xxxx"
+                    className={`w-full rounded-md border px-3 py-2 ${fieldState.invalid ? "border-red-500" : "border-gray-300"}`}
+                  />
+                </FormControl>
+                <FormMessage>{fieldState.error?.message}</FormMessage>
+              </FormItem>
+            )} />
+          </div>
+
+          <div className="grid grid-cols-3 gap-4">
+            <Controller control={typedControl} name="estado" render={({ field, fieldState }) => (
+              <FormItem>
+                <FormLabel>Estado</FormLabel>
+                <FormControl>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <SelectTrigger className={`w-full ${fieldState.invalid ? "border-red-500" : "border-gray-300"}`}>
+                      <SelectValue placeholder="Selecione um estado" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {STATES.map(s => <SelectItem key={s} value={s}>{s}</SelectItem>)}
+                    </SelectContent>
+                  </Select>
+                </FormControl>
+                <FormMessage>{fieldState.error?.message}</FormMessage>
+              </FormItem>
+            )} />
+
+            <FormField control={typedControl} name="cidade" render={({ field }) => (
+              <FormItem>
+                <FormLabel>Cidade</FormLabel>
+                <FormControl>
+                  <Input placeholder="Ex: João Pessoa" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )} />
+
+            <FormField control={typedControl} name="bairro" render={({ field }) => (
+              <FormItem>
+                <FormLabel>Bairro</FormLabel>
+                <FormControl>
+                  <Input placeholder="Ex: Centro" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )} />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <FormField control={typedControl} name="rua" render={({ field }) => (
+              <FormItem>
+                <FormLabel>Endereço</FormLabel>
+                <FormControl>
+                  <Input placeholder="Ex: Rua das Flores" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )} />
+
+            <FormField control={typedControl} name="numero" render={({ field }) => (
+              <FormItem>
+                <FormLabel>Número</FormLabel>
+                <FormControl>
+                  <Input placeholder="Ex: 123" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )} />
+          </div>
+
+          <FormField control={typedControl} name="complemento" render={({ field }) => (
+            <FormItem>
+              <FormLabel>Complemento</FormLabel>
+              <FormControl>
+                <Input placeholder="Ex: Apt 101" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )} />
+
+          <Controller control={typedControl} name="cep" render={({ field, fieldState }) => (
+            <FormItem>
+              <FormLabel>CEP</FormLabel>
+              <FormControl>
+                <InputMask
+                  mask="_____-___"
+                  replacement={{ _: /\d/ }}
+                  value={field.value ?? ""}
+                  onChange={(e) => field.onChange(e.target.value)}
+                  onBlur={field.onBlur}
+                  placeholder="12345-678"
+                  className={`w-full rounded-md border px-3 py-2 ${fieldState.invalid ? "border-red-500" : "border-gray-300"}`}
+                />
+              </FormControl>
+              <FormMessage>{fieldState.error?.message}</FormMessage>
+            </FormItem>
+          )} />
+
           {loading && <p className="text-blue-500">Salvando...</p>}
-          {error && <p className="text-red-500">Erro: {error}</p>}
-          {success && (
-            <p className="text-green-600">
-              Profissional atualizado com sucesso!
-            </p>
-          )}
+          {error && <p className="text-red-500">{error}</p>}
+          {success && <p className="text-green-600">Profissional atualizado com sucesso!</p>}
 
           <div className="flex justify-end gap-4">
             <Button type="button" variant="outline" onClick={onCancel}>
               Cancelar
             </Button>
-            <Button
-              type="submit"
-              className="bg-blue-800 hover:bg-blue-900"
-              disabled={loading}
-            >
+            <Button type="submit" className="bg-blue-800 hover:bg-blue-900" disabled={form.formState.isSubmitting || loading}>
               Salvar
             </Button>
           </div>

--- a/apps/agendamento/src/hooks/profissional/use-create-profissional.ts
+++ b/apps/agendamento/src/hooks/profissional/use-create-profissional.ts
@@ -12,10 +12,26 @@ export function useCreateProfissional() {
     setLoading(true);
     setError(null);
     setSuccess(false);
+
     try {
-      await createProfissional(data);
+      const response = await createProfissional(data);
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        let message = errorData?.mensagem || "Erro desconhecido";
+        if (errorData?.detalhes) {
+          const detailsStr = Object.entries(errorData.detalhes)
+            .map(([campo, msg]) => `${campo}: ${msg}`)
+            .join("\n");
+          message += "\n" + detailsStr;
+        }
+        throw new Error(message);
+      }
+
+      await response.json();
       setSuccess(true);
       router.push("/visualization-professional");
+
     } catch (err) {
       setError(err instanceof Error ? err.message : "Erro desconhecido");
       throw err;

--- a/apps/agendamento/src/lib/health-areas.ts
+++ b/apps/agendamento/src/lib/health-areas.ts
@@ -1,0 +1,11 @@
+export const HEALTH_AREAS = [
+  "Medicina",
+  "Enfermagem",
+  "Fisioterapia",
+  "Psicologia",
+  "Nutrição",
+] as const;
+
+export type HealthArea = (typeof HEALTH_AREAS)[number];
+
+export const HEALTH_AREAS_OPTIONS = HEALTH_AREAS.map((h) => ({ value: h, label: h }));

--- a/apps/agendamento/src/lib/states.ts
+++ b/apps/agendamento/src/lib/states.ts
@@ -1,0 +1,5 @@
+export const STATES = [
+  "AC", "AL", "AP", "AM", "BA", "CE", "DF", "ES", "GO", "MA",
+  "MT", "MS", "MG", "PA", "PB", "PR", "PE", "PI", "RJ", "RN",
+  "RS", "RO", "RR", "SC", "SP", "SE", "TO"
+] as const;

--- a/apps/agendamento/src/schemas/profissional.schema.ts
+++ b/apps/agendamento/src/schemas/profissional.schema.ts
@@ -1,0 +1,34 @@
+import * as z from "zod";
+import { HEALTH_AREAS } from "@/lib/health-areas";
+
+const nomeRegex = /^[A-Za-zÀ-ÖØ-öø-ÿ ]{3,100}$/;
+const telefoneRegex = /^\(\d{2}\) \d{5}-\d{4}$/;
+const docProfissionalRegex = /^(CRM|COREN|CREFITO|CRFa|CRP|CRESS)([-/][A-Z0-9]{1,2}|\s\d{2})?\s?\d{1,6}$/;
+const rgRegex = /^(\d\.\d{3}\.\d{3}|\d{7,8}[\dXx]?|\d{2}\.\d{3}\.\d{3}-[\dXx])$/;
+const estadoRegex = /^[A-Z]{2}$/;
+const cidadeRegex = /^[A-Za-zÀ-ÿ\s]+$/;
+const bairroRegex = /^[A-Za-zÀ-ÿ\s]+$/;
+const ruaRegex = /^[A-Za-zÀ-ÿ0-9\s]+$/;
+const numeroRegex = /^[0-9]{1,6}$/;
+
+export const cadastroSchema = z.object({
+  nomeCompleto: z.string().regex(nomeRegex, "Nome inválido. Use apenas letras e espaços, 3-100 caracteres"),
+  email: z.string().email("Email inválido"),
+  documentoProfissional: z.string().regex(docProfissionalRegex, "Documento profissional inválido"),
+  areaSaude: z.string()
+    .min(1, "Selecione uma área válida")
+    .refine((v) => (HEALTH_AREAS as readonly string[]).includes(v), { message: "Selecione uma área válida" }),
+  cpf: z.preprocess((val) => typeof val === "string" ? val.replace(/\D/g, "") : val,
+    z.string().length(11, "CPF deve conter exatamente 11 dígitos")),
+  rg: z.preprocess((val) => typeof val === "string" ? val.replace(/\W/g, "") : val,
+    z.string().regex(rgRegex, "RG inválido")),
+  estado: z.string().regex(estadoRegex, "Estado inválido"),
+  cidade: z.string().regex(cidadeRegex, "Cidade inválida"),
+  bairro: z.string().regex(bairroRegex, "Bairro inválido"),
+  rua: z.string().regex(ruaRegex, "Rua inválida"),
+  numero: z.string().regex(numeroRegex, "Número inválido"),
+  complemento: z.string().optional(),
+  cep: z.string().regex(/^\d{5}-\d{3}$/, "CEP inválido. Formato esperado: XXXXX-XXX"),
+  telefone: z.preprocess((val) => typeof val === "string" ? val.trim() : val,
+    z.string().regex(telefoneRegex, "Telefone inválido. Formato esperado: (xx) xxxxx-xxxx")),
+});

--- a/apps/agendamento/src/services/profissional-service.ts
+++ b/apps/agendamento/src/services/profissional-service.ts
@@ -22,6 +22,7 @@ export async function createProfissional(data: any) {
     },
     body: JSON.stringify(data),
   });
+
   return response;
 }
 

--- a/apps/agendamento/src/types/profissional.ts
+++ b/apps/agendamento/src/types/profissional.ts
@@ -1,3 +1,13 @@
+export interface Endereco {
+  estado: string;
+  cidade: string;
+  bairro: string;
+  rua: string;
+  numero?: string;
+  complemento?: string;
+  cep: string;
+}
+
 export interface Profissional {
   id: string;
   nome: string;
@@ -5,4 +15,7 @@ export interface Profissional {
   docProfissional: string;
   areaDaSaude: string;
   telefone: string;
+  cpf: string;
+  rg: string;
+  endereco: Endereco;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^19.15.5
         version: 19.15.5(react@19.1.0)
       '@radix-ui/react-alert-dialog':
-        specifier: ^1.1.14
-        version: 1.1.14(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-avatar':
         specifier: ^1.1.10
         version: 1.1.10(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -34,10 +34,10 @@ importers:
         version: 1.1.11(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-dialog':
         specifier: ^1.1.14
-        version: 1.1.14(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.1.15(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-dropdown-menu':
-        specifier: ^2.1.15
-        version: 2.1.15(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^2.1.16
+        version: 2.1.16(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-label':
         specifier: ^2.1.7
         version: 2.1.7(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -59,6 +59,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.2.7
         version: 1.2.7(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@react-input/mask':
+        specifier: ^2.0.4
+        version: 2.0.4(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       axios:
         specifier: ^1.11.0
         version: 1.11.0
@@ -95,15 +98,15 @@ importers:
       react-hook-form:
         specifier: ^7.62.0
         version: 7.62.0(react@19.1.0)
-      react-icons:
-        specifier: ^5.5.0
-        version: 5.5.0(react@19.1.0)
-      react-router-dom:
-        specifier: ^7.8.0
-        version: 7.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react-toastify:
+        specifier: ^11.0.5
+        version: 11.0.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
+      use-mask-input:
+        specifier: ^3.5.1
+        version: 3.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       zod:
         specifier: ^4.0.17
         version: 4.0.17
@@ -123,6 +126,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.1.3(@types/react@19.1.2)
+      '@types/react-toastify':
+        specifier: ^4.1.0
+        version: 4.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       eslint:
         specifier: ^9
         version: 9.26.0(jiti@2.4.2)
@@ -149,7 +155,7 @@ importers:
         version: 1.1.10(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-dialog':
         specifier: ^1.1.14
-        version: 1.1.14(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.1.15(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.16
         version: 2.1.16(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -243,7 +249,7 @@ importers:
         version: 1.1.11(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-dialog':
         specifier: ^1.1.14
-        version: 1.1.14(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.1.15(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-label':
         specifier: ^2.1.7
         version: 2.1.7(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -805,6 +811,19 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
+  '@radix-ui/react-alert-dialog@1.1.15':
+    resolution: {integrity: sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
     peerDependencies:
@@ -833,19 +852,6 @@ packages:
 
   '@radix-ui/react-checkbox@1.3.3':
     resolution: {integrity: sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-checkbox@1.3.2':
-    resolution: {integrity: sha512-yd+dI56KZqawxKZrJ31eENUwqc1QSqg4OZ15rybGjF2ZNwMO+wCyHzAVLRp9qoYJf7kYy0YpZ2b0JCzJ42HZpA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -901,8 +907,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-dialog@1.1.14':
-    resolution: {integrity: sha512-+CpweKjqpzTmwRwcYECQcNYbI8V9VSQt0SNFKeEBLgfucbsLssU6Ppq7wUdNXEGb573bMjFhVjKVll8rmV6zMw==}
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1290,6 +1296,26 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@react-input/core@2.0.2':
+    resolution: {integrity: sha512-xLLBueYFbant9308uv3cIJQz5NYSixeGspjP3Nt6jogRHTcHYMRmlVFUuSzQiP8Z8/5BdnPkudRSsN0/AJ1fbw==}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      react: '>=16.8 || ^19.0.0-rc'
+      react-dom: '>=16.8 || ^19.0.0-rc'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@react-input/mask@2.0.4':
+    resolution: {integrity: sha512-NOielvQSBOlGLVuEcxtkjaGneC0GJFXjC7KOF99ed9H9XSDruWnQirjht5uSbWqLeeiOup0VD2YjM+6FH+aWBg==}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      react: '>=16.8 || ^19.0.0-rc'
+      react-dom: '>=16.8 || ^19.0.0-rc'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -1412,6 +1438,10 @@ packages:
     resolution: {integrity: sha512-rJXC08OG0h3W6wDMFxQrZF00Kq6qQvw0djHRdzl3U5DnIERz0MRce3WVc7IS6JYBwtaP/DwYtRRjVlvivNveKg==}
     peerDependencies:
       '@types/react': ^19.0.0
+
+  '@types/react-toastify@4.1.0':
+    resolution: {integrity: sha512-u7Ie/7LHBsPVz/iJxi/WlRDS7Gh9csCJACTDXx+pSLuZCm94xpkwzhM3jV1L5ZxP/in0Gp2tFbJ91VrSGr1gyQ==}
+    deprecated: This is a stub types definition. react-toastify provides its own type definitions, so you do not need this installed.
 
   '@types/react@19.1.2':
     resolution: {integrity: sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==}
@@ -1754,10 +1784,6 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
-
-  cookie@1.0.2:
-    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
-    engines: {node: '>=18'}
 
   cors@2.8.5:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
@@ -2772,23 +2798,6 @@ packages:
       '@types/react':
         optional: true
 
-  react-router-dom@7.8.0:
-    resolution: {integrity: sha512-ntInsnDVnVRdtSu6ODmTQ41cbluak/ENeTif7GBce0L6eztFg6/e1hXAysFQI8X25C8ipKmT9cClbJwxx3Kaqw==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-
-  react-router@7.8.0:
-    resolution: {integrity: sha512-r15M3+LHKgM4SOapNmsH3smAizWds1vJ0Z9C4mWaKnT9/wD7+d/0jYcj6LmOvonkrO4Rgdyp4KQ/29gWN2i1eg==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-    peerDependenciesMeta:
-      react-dom:
-        optional: true
-
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
@@ -2893,9 +2902,6 @@ packages:
   serve-static@2.2.0:
     resolution: {integrity: sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==}
     engines: {node: '>= 18'}
-
-  set-cookie-parser@2.7.1:
-    resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -3126,6 +3132,13 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  use-mask-input@3.5.1:
+    resolution: {integrity: sha512-ml/B71s8oRdyB2taW8Ii6lGwr28VtHwqdkA1YAdQPHz1Xw/WP9/lE/gsdSgLf/sUmKMtvl97Z3c5wq7HWaKHlg==}
+    engines: {node: '>=16', npm: '>=7'}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
 
   use-sidecar@1.1.3:
     resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
@@ -3581,6 +3594,20 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.2)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.2
+      '@types/react-dom': 19.1.3(@types/react@19.1.2)
+
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -3659,17 +3686,17 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.2
 
-  '@radix-ui/react-dialog@1.1.14(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/primitive': 1.1.3
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.2)(react@19.1.0)
       '@radix-ui/react-context': 1.1.2(@types/react@19.1.2)(react@19.1.0)
-      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-focus-guards': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.1.2)(react@19.1.0)
       '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-id': 1.1.1(@types/react@19.1.2)(react@19.1.0)
       '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.1.2)(react@19.1.0)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.2)(react@19.1.0)
@@ -4062,6 +4089,21 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@react-input/core@2.0.2(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.2
+
+  '@react-input/mask@2.0.4(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@react-input/core': 2.0.2(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.2
+
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.11.0': {}
@@ -4158,6 +4200,13 @@ snapshots:
   '@types/react-dom@19.1.3(@types/react@19.1.2)':
     dependencies:
       '@types/react': 19.1.2
+
+  '@types/react-toastify@4.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      react-toastify: 11.0.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
   '@types/react@19.1.2':
     dependencies:
@@ -4494,7 +4543,7 @@ snapshots:
   cmdk@1.1.1(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.2)(react@19.1.0)
-      '@radix-ui/react-dialog': 1.1.14(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-id': 1.1.1(@types/react@19.1.2)(react@19.1.0)
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
@@ -4545,8 +4594,6 @@ snapshots:
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
-
-  cookie@1.0.2: {}
 
   cors@2.8.5:
     dependencies:
@@ -5704,20 +5751,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.2
 
-  react-router-dom@7.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      react-router: 7.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-
-  react-router@7.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      cookie: 1.0.2
-      react: 19.1.0
-      set-cookie-parser: 2.7.1
-    optionalDependencies:
-      react-dom: 19.1.0(react@19.1.0)
-
   react-style-singleton@2.2.3(@types/react@19.1.2)(react@19.1.0):
     dependencies:
       get-nonce: 1.0.1
@@ -5847,8 +5880,6 @@ snapshots:
       send: 1.2.0
     transitivePeerDependencies:
       - supports-color
-
-  set-cookie-parser@2.7.1: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -6182,6 +6213,11 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.2
+
+  use-mask-input@3.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   use-sidecar@1.1.3(@types/react@19.1.2)(react@19.1.0):
     dependencies:


### PR DESCRIPTION
Objetivo:
Mapear as validações já existentes e criar as faltantes nos campos do formulário de cadastro de profissional.

Tarefas:
- Mapear campos existentes com validação
- Criar validações faltantes (Nome, Email, Documento, Área da saúde, CPF, RG, Estado, Cidade, Endereço, CEP, Telefone)
- Garantir mensagens de erro claras e bloqueio de submissão com dados inválidos

Branch base: dev-profissional-da-saude
Branch de comparação: 207-criar-testes-validacao-campos

#207 

<img width="730" height="906" alt="image" src="https://github.com/user-attachments/assets/94a85670-63d1-4fb7-b12a-5473dda365dc" />

<img width="916" height="902" alt="image" src="https://github.com/user-attachments/assets/aeb9ba78-435f-4fb0-ab0b-9decece61ce3" />
