### PR TITLE
423 testes profissional saude

### DIFF
--- a/apps/api/pom.xml
+++ b/apps/api/pom.xml
@@ -104,6 +104,7 @@
                 <version>3.2.5</version>
                 <configuration>
                     <useModulePath>false</useModulePath>
+                    <argLine>${jacoco.agent.argLine}</argLine>
 
                     <includes>
                         <include>**/*Test.java</include>
@@ -114,7 +115,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.11</version>
+                <version>0.8.12</version>
 
                 <executions>
                     <execution>
@@ -122,6 +123,13 @@
                         <goals>
                             <goal>prepare-agent</goal>
                         </goals>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/*$MockitoMock*</exclude>
+                                <exclude>**/*$MockitoMock$*</exclude>
+                                <exclude>**/*$ByteBuddy*</exclude>
+                            </excludes>
+                        </configuration>
                     </execution>
 
                     <execution>

--- a/apps/api/src/test/java/br/org/apae/api/controllers/professional/HealthProfessionalControllerTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/professional/HealthProfessionalControllerTest.java
@@ -1,12 +1,16 @@
 package br.org.apae.api.controllers.professional;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.List;
+import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -29,11 +33,18 @@ import br.org.apae.api.auth.application.internal.UserService;
 import br.org.apae.api.auth.infrastructure.security.JwtProvider;
 import br.org.apae.api.auth.infrastructure.security.SecurityConfiguration;
 import br.org.apae.api.common.dto.professional.request.CreateHealthProfessionalDTO;
+import br.org.apae.api.common.dto.professional.request.UpdateHealthProfessionalDTO;
 import br.org.apae.api.common.dto.professional.request.documents.CreateProfessionalDocumentsDTO;
 import br.org.apae.api.controllers.mocks.professional.HealthProfessionalMockDto;
 import br.org.apae.api.helpers.AuthTestHelper;
 import br.org.apae.api.professional.application.interfaces.HealthProfessionalApplicationService;
 import br.org.apae.api.documents.application.interfaces.DocumentApplicationService;
+import br.org.apae.api.common.dto.servicearea.request.UpdateServiceAreaDTO;
+import br.org.apae.api.professional.application.exceptions.HealthProfessionalExceptionHandler;
+import br.org.apae.api.professional.domain.exceptions.EmailConflictException;
+import br.org.apae.api.professional.domain.exceptions.HealthProfessionalNotFoundException;
+import br.org.apae.api.professional.domain.exceptions.IdentityDocumentConflictException;
+import br.org.apae.api.professional.domain.exceptions.ProfessionalDocumentConflictException;
 
 
 @Tag("controller")
@@ -42,7 +53,8 @@ import br.org.apae.api.documents.application.interfaces.DocumentApplicationServi
 @AutoConfigureMockMvc(addFilters = true)
 @Import({
     SpringDataWebConfiguration.class,
-    SecurityConfiguration.class
+    SecurityConfiguration.class,
+    HealthProfessionalExceptionHandler.class
 })
 class HealthProfessionalControllerTest {
 
@@ -108,6 +120,117 @@ class HealthProfessionalControllerTest {
     }
 
     @Test
+    void shouldReturnConflictWhenProfessionalDocumentAlreadyExists() throws Exception {
+        var request =
+            HealthProfessionalMockDto.createHealthProfessionalRequest();
+
+        Mockito.when(
+            service.createProfessional(
+                any(CreateHealthProfessionalDTO.class),
+                any(CreateProfessionalDocumentsDTO.class)
+            )
+        ).thenThrow(new ProfessionalDocumentConflictException());
+
+        var professionalPart =
+            new MockMultipartFile(
+                "professional",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(request)
+            );
+
+        mockMvc.perform(
+                multipart("/professionals")
+                    .file(professionalPart)
+                    .file(HealthProfessionalMockDto.volunteerAgreementFile())
+                    .file(HealthProfessionalMockDto.curriculumFile())
+                    .file(HealthProfessionalMockDto.attachmentAnyFile())
+                    .header("Authorization", AuthTestHelper.bearerToken())
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+            )
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.message")
+                .value("Documento profissional já cadastrado."));
+
+        Mockito.verify(service)
+            .createProfessional(any(), any());
+    }
+
+    @Test
+    void shouldReturnConflictWhenEmailAlreadyExists() throws Exception {
+        var request =
+            HealthProfessionalMockDto.createHealthProfessionalRequest();
+
+        Mockito.when(
+            service.createProfessional(
+                any(CreateHealthProfessionalDTO.class),
+                any(CreateProfessionalDocumentsDTO.class)
+            )
+        ).thenThrow(new EmailConflictException());
+
+        var professionalPart =
+            new MockMultipartFile(
+                "professional",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(request)
+            );
+
+        mockMvc.perform(
+                multipart("/professionals")
+                    .file(professionalPart)
+                    .file(HealthProfessionalMockDto.volunteerAgreementFile())
+                    .file(HealthProfessionalMockDto.curriculumFile())
+                    .file(HealthProfessionalMockDto.attachmentAnyFile())
+                    .header("Authorization", AuthTestHelper.bearerToken())
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+            )
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.message")
+                .value("Email já cadastrado."));
+
+        Mockito.verify(service)
+            .createProfessional(any(), any());
+    }
+
+    @Test
+    void shouldReturnConflictWhenIdentityDocumentAlreadyExists() throws Exception {
+        var request =
+            HealthProfessionalMockDto.createHealthProfessionalRequest();
+
+        Mockito.when(
+            service.createProfessional(
+                any(CreateHealthProfessionalDTO.class),
+                any(CreateProfessionalDocumentsDTO.class)
+            )
+        ).thenThrow(new IdentityDocumentConflictException());
+
+        var professionalPart =
+            new MockMultipartFile(
+                "professional",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(request)
+            );
+
+        mockMvc.perform(
+                multipart("/professionals")
+                    .file(professionalPart)
+                    .file(HealthProfessionalMockDto.volunteerAgreementFile())
+                    .file(HealthProfessionalMockDto.curriculumFile())
+                    .file(HealthProfessionalMockDto.attachmentAnyFile())
+                    .header("Authorization", AuthTestHelper.bearerToken())
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+            )
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.message")
+                .value("O documento de identidade  já cadastrado."));
+
+        Mockito.verify(service)
+            .createProfessional(any(), any());
+    }
+
+    @Test
     void shouldReturnAllProfessionals() throws Exception {
         var responses = HealthProfessionalMockDto.createProfessionalResponseList();
 
@@ -117,11 +240,11 @@ class HealthProfessionalControllerTest {
             responses.size()
         );
 
-        Mockito.when(service.findAllProfessionals(isNull(), any(Pageable.class)))
+        Mockito.when(service.findAllProfessionals(eq(true), any(Pageable.class)))
             .thenReturn(page);
 
         mockMvc.perform(get("/professionals")
-                .param("Ativo", "true")
+            .param("ativo", "true")
                 .header("Authorization", AuthTestHelper.bearerToken()))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.content").isArray())
@@ -140,5 +263,82 @@ class HealthProfessionalControllerTest {
                 .value("Maria Souza"))
             .andExpect(jsonPath("$.content[1].address.neighborhood")
                 .value("Santana"));
+    }
+
+    @Test
+    void shouldReturnProfessionalById() throws Exception {
+        var response = HealthProfessionalMockDto.createProfessionalResponse1();
+
+        Mockito.when(service.findProfessionalById(HealthProfessionalMockDto.PROFESSIONAL_ID_1))
+            .thenReturn(response);
+
+        mockMvc.perform(get("/professionals/{id}", HealthProfessionalMockDto.PROFESSIONAL_ID_1)
+                .header("Authorization", AuthTestHelper.bearerToken()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id")
+                .value("11111111-1111-1111-1111-111111111111"))
+            .andExpect(jsonPath("$.name")
+                .value("João da Silva"))
+            .andExpect(jsonPath("$.healthSector")
+                .value("Fisioterapia"));
+
+        Mockito.verify(service).findProfessionalById(HealthProfessionalMockDto.PROFESSIONAL_ID_1);
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenProfessionalDoesNotExist() throws Exception {
+        var missingId = UUID.fromString("99999999-9999-9999-9999-999999999999");
+
+        Mockito.when(service.findProfessionalById(missingId))
+            .thenThrow(new HealthProfessionalNotFoundException());
+
+        mockMvc.perform(get("/professionals/{id}", missingId)
+                .header("Authorization", AuthTestHelper.bearerToken()))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message")
+                .value("Profissional não encontrado."));
+
+        Mockito.verify(service).findProfessionalById(missingId);
+    }
+
+    @Test
+    void shouldUpdateProfessionalSuccessfully() throws Exception {
+        var request = new UpdateHealthProfessionalDTO(
+            new UpdateServiceAreaDTO("Psicologia"),
+            "11999999999",
+            "CREFITO-12345",
+            "teste@apae.org.br",
+            "João da Silva",
+            "123456789",
+            HealthProfessionalMockDto.createAddressRequest(),
+            List.of()
+        );
+
+        var response = HealthProfessionalMockDto.createProfessionalResponse1();
+
+        Mockito.when(service.updateProfessional(eq(HealthProfessionalMockDto.PROFESSIONAL_ID_1),
+                any(UpdateHealthProfessionalDTO.class)))
+            .thenReturn(response);
+
+        mockMvc.perform(put("/professionals/{id}", HealthProfessionalMockDto.PROFESSIONAL_ID_1)
+                .header("Authorization", AuthTestHelper.bearerToken())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(request)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id")
+                .value("11111111-1111-1111-1111-111111111111"))
+            .andExpect(jsonPath("$.email")
+                .value("teste@apae.org.br"));
+
+        Mockito.verify(service).updateProfessional(eq(HealthProfessionalMockDto.PROFESSIONAL_ID_1), any());
+    }
+
+    @Test
+    void shouldInactivateProfessionalSuccessfully() throws Exception {
+        mockMvc.perform(put("/professionals/{id}/inactivate", HealthProfessionalMockDto.PROFESSIONAL_ID_1)
+                .header("Authorization", AuthTestHelper.bearerToken()))
+            .andExpect(status().isNoContent());
+
+        Mockito.verify(service).inactivateProfessional(HealthProfessionalMockDto.PROFESSIONAL_ID_1);
     }
 }


### PR DESCRIPTION
Sistema rodando

<img width="1120" height="383" alt="Captura de tela de 2026-01-20 15-19-55" src="https://github.com/user-attachments/assets/6e55b615-e395-47ac-8957-df44a8ba49e7" />

Testes Unitários:
- Criar novo profissional
<img width="1117" height="703" alt="Captura de tela de 2026-01-20 16-13-50" src="https://github.com/user-attachments/assets/242d2453-09da-4d46-a5b0-54ed903b56d8" />

- Validar duplicidade de documento
<img width="1117" height="703" alt="Captura de tela de 2026-01-20 16-16-46" src="https://github.com/user-attachments/assets/2be8f0d0-feaf-4d81-81ac-ec09fa9f06a7" />

- Listar todos cadastrados
[Gravação de tela de 20-01-2026 16:17:25.webm](https://github.com/user-attachments/assets/3f4f566a-6c2c-4714-9dde-a0e791c285f9)

- Retornar profissional existente
<img width="1117" height="703" alt="Captura de tela de 2026-01-20 16-18-11" src="https://github.com/user-attachments/assets/6ec0dbad-b1a8-416a-b2e0-a0da0338f680" />

- ID inexistente
<img width="1117" height="703" alt="Captura de tela de 2026-01-20 16-18-25" src="https://github.com/user-attachments/assets/25d13064-a33c-4c9e-9401-696044b998e8" />

-  Atualização (email)
<img width="1117" height="703" alt="Captura de tela de 2026-01-20 16-32-44" src="https://github.com/user-attachments/assets/9d97bf88-ab17-4fe8-bfaa-03a1bc5e39aa" />

- Excluir profissional existente
<img width="1117" height="703" alt="Captura de tela de 2026-01-20 16-24-32" src="https://github.com/user-attachments/assets/66643171-57b5-4e0c-8d82-79d3c0418e27" />


