### PR TITLE
493 restringir a seleção de horários para agendar de acordo com os horários dos profissionais da saúde

### DIFF
--- a/apps/apae/src/components/forms/AppointmentForm.tsx
+++ b/apps/apae/src/components/forms/AppointmentForm.tsx
@@ -1,151 +1,248 @@
 "use client";
 
+import { format, getDay, isBefore, startOfDay, isValid } from "date-fns";
+import { ptBR } from "date-fns/locale";
+import { CalendarIcon } from "lucide-react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+
 import {
   Appointment,
   getPacientes,
   getProfissionaisDaSaude,
-  Patient,
-  Professional,
   saveAppointment,
-  updateAppointmentRule
+  updateAppointmentRule,
 } from "@/app/services/appointmentService";
 import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
 import { Card, CardContent } from "@/components/ui/card";
 import { Combobox } from "@/components/ui/combobox";
-import { DateTimePicker } from "@/components/ui/date-time-picker";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { cn, separaETransformaEmNumero } from '@/lib/utils';
-import { format } from "date-fns";
-import React, { useEffect, useState } from "react";
-import { Input } from '../ui/input';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
 
-
-type selectItem = {
+interface Option {
   value: string;
   label: string;
-};
+}
 
-interface PageProps {
+interface AppointmentFormProps {
   editAppointment?: Appointment;
 }
 
-export function AppointmentForm({ editAppointment }: PageProps) {
-  const [year, month, day] = separaETransformaEmNumero(
-    editAppointment?.initialDate,
-    '-'
-  );
-  const [hour, minute] = separaETransformaEmNumero(
-    editAppointment?.hour,
-    ':'
-  );
-  const existingAppointmentDate =
-    !isNaN(year) &&
-    !isNaN(month) &&
-    !isNaN(day) &&
-    !isNaN(hour) &&
-    !isNaN(minute)
-      ? new Date(year, month, day, hour, minute)
-      : undefined;
+const mapDayOfWeek: Record<number, string> = {
+  1: "SEGUNDA",
+  2: "TERCA",
+  3: "QUARTA",
+  4: "QUINTA",
+  5: "SEXTA",
+};
 
-  const [dateHour, setDateHour] = useState<Date | undefined>(existingAppointmentDate);
+const morningSlots = [
+  "08:00",
+  "08:30",
+  "09:00",
+  "09:30",
+  "10:00",
+  "10:30",
+  "11:00",
+  "11:30",
+];
+const afternoonSlots = [
+  "13:00",
+  "13:30",
+  "14:00",
+  "14:30",
+  "15:00",
+  "15:30",
+  "16:00",
+  "16:30",
+  "17:00",
+];
 
-  const [patient, setPatient] = useState<selectItem>(() => {
-      const patient = editAppointment?.annualRegistration.patient;
-      return patient ? { value: patient.id,  label: patient.fullName } : { value: "", label: "" }
+export function AppointmentForm({ editAppointment }: AppointmentFormProps) {
+  const isInitialMount = useRef(true);
+  const prevProfessionalId = useRef(editAppointment?.professional?.id || "");
+
+  const [date, setDate] = useState<Date | undefined>(() => {
+    if (editAppointment?.initialDate) {
+      const parts = editAppointment.initialDate.split("-").map(Number);
+      const d = new Date(parts[0], parts[1] - 1, parts[2]);
+
+      return isValid(d) ? d : undefined;
     }
-  );
 
-  const [professional, setProfessional] = useState<selectItem>(() => {
-      const professional = editAppointment?.professional;
-      return professional ? {value: professional.id, label: professional.name } : { value: "", label: "" }
+    return undefined;
+  });
+
+  const [selectedTime, setSelectedTime] = useState<string>(() => {
+    if (editAppointment?.hour) {
+      return editAppointment.hour.slice(0, 5);
     }
-  );
 
-  const [listPatients, setListPatients] = useState<selectItem[]>([]);
-  const [listaProfessional, setListaProfessionals] = useState<selectItem[]>([]);
+    return "";
+  });
 
+  const [isCalendarOpen, setIsCalendarOpen] = useState(false);
+  const [patient, setPatient] = useState<Option>(() => {
+    const p = editAppointment?.annualRegistration.patient;
+    return p ? { value: p.id, label: p.fullName } : { value: "", label: "" };
+  });
+  const [professional, setProfessional] = useState<Option>(() => {
+    const prof = editAppointment?.professional;
+
+    return prof
+      ? { value: prof.id, label: prof.name }
+      : { value: "", label: "" };
+  });
+
+  const [listPatients, setListPatients] = useState<Option[]>([]);
+  const [listaProfessional, setListaProfessionals] = useState<Option[]>([]);
   const [frequencyDays, setFrequencyDays] = useState<number>(
-    editAppointment?.frequencyDays || 0
+    editAppointment?.frequencyDays || 0,
   );
-
-  useEffect(() => {
-    const fetchPatientsAndProfessionals = async () => {
-      const registeredPatients: Patient[] = await getPacientes();
-      const registeredProfessionals: Professional[] = await getProfissionaisDaSaude();
-      setListPatients(
-        registeredPatients.map(
-          p => ({ value: p.id, label: p.fullName } as selectItem)
-        )
-      );
-      setListaProfessionals(
-        registeredProfessionals.map(
-          p => ({ value: p.id, label: p.name } as selectItem)
-        )
-      );
-    };
-    fetchPatientsAndProfessionals();
-  }, []);
-
-  // Apenas necessário devido à existência de duplicatas nos dados mockados
-  //useEffect(() => {
-    //const redefineProfissional = async () => {
-      //if (editAppointment) {
-        //const nameProfessional = (await getProfissionalDaSaude(professional.value))
-          //.name;
-        //const idProfessional = listaProfessional.find(
-          //p => p.label === nameProfessional
-        //)?.value;
-        //setProfessional(idProfessional || professional.value);
-      //}
-    //};
-    //redefineProfissional();
-  //}, [listaProfessional]);
+  const [availabilities, setAvailabilities] = useState<
+    { day: string; shift: string }[]
+  >([]);
 
   const [validationErrors, setValidationErrors] = useState({
-    dateHour: false,
+    date: false,
+    time: false,
     patient: false,
     professional: false,
     frequencyDays: false,
   });
 
+  useEffect(() => {
+    const fetchData = async () => {
+      const [patients, professionals] = await Promise.all([
+        getPacientes(),
+        getProfissionaisDaSaude(),
+      ]);
+
+      setListPatients(
+        patients.map((p) => ({ value: p.id, label: p.fullName })),
+      );
+
+      setListaProfessionals(
+        professionals.map((p) => ({ value: p.id, label: p.name })),
+      );
+    };
+    fetchData();
+  }, []);
+
+  useEffect(() => {
+    const loadProfessionalData = async () => {
+      if (professional.value) {
+        try {
+          const res = await fetch(`/api/professionals/${professional.value}`);
+          const data = await res.json();
+          setAvailabilities(data.availabilities || []);
+        } catch {
+          setAvailabilities([]);
+        }
+      } else {
+        setAvailabilities([]);
+      }
+    };
+
+    loadProfessionalData();
+
+    if (!isInitialMount.current) {
+      if (professional.value !== prevProfessionalId.current) {
+        setSelectedTime("");
+      }
+    }
+
+    prevProfessionalId.current = professional.value;
+    isInitialMount.current = false;
+  }, [professional.value]);
+
+  const availableTimeSlots = useMemo(() => {
+    if (!date || !isValid(date)) return [];
+
+    const dayOfWeek = getDay(date);
+    const dayName = mapDayOfWeek[dayOfWeek];
+    if (!dayName) return [];
+
+    const activeShifts = availabilities
+      .filter((a) => a.day === dayName)
+      .map((a) => a.shift);
+
+    let slots: string[] = [];
+    if (activeShifts.includes("MANHA")) slots = [...slots, ...morningSlots];
+    if (activeShifts.includes("TARDE")) slots = [...slots, ...afternoonSlots];
+
+    return Array.from(new Set(slots)).sort();
+  }, [date, availabilities]);
+
+  const isDayDisabled = (day: Date) => {
+    const today = startOfDay(new Date());
+    const dayOfWeek = getDay(day);
+
+    if (dayOfWeek === 0 || dayOfWeek === 6) return true;
+
+    const dayName = mapDayOfWeek[dayOfWeek];
+    const isPast = isBefore(day, today);
+    const professionalWorksThisDay = availabilities.some(
+      (a) => a.day === dayName,
+    );
+
+    if (editAppointment?.initialDate) {
+      const [y, m, d] = editAppointment.initialDate.split("-").map(Number);
+      const editDate = new Date(y, m - 1, d);
+
+      if (format(day, "yyyy-MM-dd") === format(editDate, "yyyy-MM-dd")) {
+        return false;
+      }
+    }
+
+    return isPast || !professionalWorksThisDay;
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
     const errors = {
-      dateHour: !dateHour,
+      date: !date || !isValid(date),
+      time: !selectedTime,
       patient: !patient.value,
       professional: !professional.value,
       frequencyDays:
-        !frequencyDays ||
-        isNaN(frequencyDays) ||
-        frequencyDays <= 0,
+        !frequencyDays || isNaN(frequencyDays) || frequencyDays <= 0,
     };
 
     setValidationErrors(errors);
+    if (Object.values(errors).some(Boolean)) return;
 
-    if (Object.values(errors).some(Boolean)) {
-      return;
-    }
+    const initialDate = format(date!, "yyyy-MM-dd");
+    const hourStr = `${selectedTime}:00`;
 
-    if (patient.value && professional.value && dateHour && frequencyDays > 0) {
-      const initialDate = format(dateHour, "yyyy-MM-dd");   
-      const hour = format(dateHour, "HH:mm:ss");  
-      
-      if (editAppointment?.id) {
-        await updateAppointmentRule(editAppointment.id, {
-          newFrequency: frequencyDays,
-          newTime: hour,
-        });
-      } else {
-        await saveAppointment({
-          patientId: patient.value,
-          professionalId: professional.value,
-          serviceId: "ea4c3a4d-c3f4-4a83-ab29-ff24c50e844c",
-          initialDate,
-          hour,
-          frequencyDays,
-        });
-      }
+    if (editAppointment?.id) {
+      await updateAppointmentRule(editAppointment.id, {
+        newFrequency: frequencyDays,
+        newTime: hourStr,
+      });
+    } else {
+      await saveAppointment({
+        patientId: patient.value,
+        professionalId: professional.value,
+        serviceId: "ea4c3a4d-c3f4-4a83-ab29-ff24c50e844c",
+        initialDate,
+        hour: hourStr,
+        frequencyDays,
+      });
     }
     window.location.reload();
   };
@@ -154,85 +251,162 @@ export function AppointmentForm({ editAppointment }: PageProps) {
     <Card className="w-full mx-auto border-none shadow-none">
       <form onSubmit={handleSubmit}>
         <CardContent className="space-y-6">
-          <div className="space-y-2">
-            <Label htmlFor="data-hora">
-              Data de Início e Horário <span className="text-red-500">*</span>
-            </Label>
-            <DateTimePicker value={dateHour} onChange={setDateHour} />
-            {validationErrors.dateHour && (
-              <p className="text-sm text-red-500">Este campo é obrigatório.</p>
-            )}
-          </div>
           {!editAppointment && (
             <div className="space-y-2">
-              <Label htmlFor="paciente">
+              <Label>
                 Paciente <span className="text-red-500">*</span>
               </Label>
+
               <Combobox
                 options={listPatients}
                 value={patient.value}
-                onChange={(value) => {
-                  const selected = listPatients.find((p) => p.value === value);
+                onChange={(val) => {
+                  const selected = listPatients.find((p) => p.value === val);
                   if (selected) setPatient(selected);
                 }}
                 placeholder="Pesquisar paciente"
-                className={cn(
-                  validationErrors.patient && 'border-red-500',
-                  'font-normal',
-                  'text-gray-400'
-                )}
+                className="w-full"
               />
+
               {validationErrors.patient && (
-                <p className="text-sm text-red-500">
-                  Este campo é obrigatório.
-                </p>
+                <p className="text-sm text-red-500">Obrigatório.</p>
               )}
             </div>
           )}
+
           <div className="space-y-2">
-            <Label htmlFor="profissional">
+            <Label>
               Profissional da Saúde <span className="text-red-500">*</span>
             </Label>
+
             <Combobox
               options={listaProfessional}
               value={professional.value}
-              onChange={(value) => {
-                const selected = listaProfessional.find((p) => p.value == value);
+              onChange={(val) => {
+                const selected = listaProfessional.find((p) => p.value === val);
                 if (selected) setProfessional(selected);
               }}
-              placeholder="Pesquisar área de atendimento"
-              className={cn(
-                validationErrors.professional && 'border-red-500',
-                'font-normal',
-                'text-gray-400'
-              )}
+              placeholder="Pesquisar profissional"
+              className="w-full"
             />
+
             {validationErrors.professional && (
-              <p className="text-sm text-red-500">Este campo é obrigatório.</p>
+              <p className="text-sm text-red-500">Obrigatório.</p>
             )}
           </div>
+
+          <div className="space-y-4">
+            <Label className="font-bold">
+              Data de Início e Horário <span className="text-red-500">*</span>
+            </Label>
+
+            {!professional.value ? (
+              <div className="p-4 border rounded-md bg-slate-50 text-sm text-muted-foreground">
+                Selecione um profissional.
+              </div>
+            ) : (
+              <div className="flex flex-col gap-4">
+                <div className="flex flex-col space-y-2">
+                  <Label className="text-xs">Data de Início</Label>
+
+                  <Popover
+                    open={isCalendarOpen}
+                    onOpenChange={setIsCalendarOpen}
+                  >
+                    <PopoverTrigger asChild>
+                      <Button
+                        variant={"outline"}
+                        className={cn(
+                          "w-full justify-start text-left font-normal",
+                          !date && "text-muted-foreground",
+                          validationErrors.date && "border-red-500",
+                        )}
+                      >
+                        <CalendarIcon className="mr-2 h-4 w-4" />
+
+                        {date && isValid(date) ? (
+                          format(date, "PPP", { locale: ptBR })
+                        ) : (
+                          <span>Selecione uma data</span>
+                        )}
+                      </Button>
+                    </PopoverTrigger>
+
+                    <PopoverContent className="w-auto p-0" align="start">
+                      <Calendar
+                        mode="single"
+                        selected={date}
+                        onSelect={(d) => {
+                          if (d && isValid(d)) {
+                            setDate(d);
+                            setSelectedTime("");
+                          }
+                          setIsCalendarOpen(false);
+                        }}
+                        disabled={isDayDisabled}
+                        initialFocus
+                      />
+                    </PopoverContent>
+                  </Popover>
+                </div>
+
+                <div className="flex flex-col space-y-2">
+                  <Label className="text-xs">Horário</Label>
+
+                  <Select
+                    disabled={!date}
+                    onValueChange={setSelectedTime}
+                    value={selectedTime}
+                  >
+                    <SelectTrigger
+                      className={cn(
+                        "w-full",
+                        validationErrors.time && "border-red-500",
+                      )}
+                    >
+                      <SelectValue
+                        placeholder={
+                          date
+                            ? "Escolha o horário"
+                            : "Selecione a data primeiro"
+                        }
+                      />
+                    </SelectTrigger>
+
+                    <SelectContent>
+                      {availableTimeSlots.map((slot) => (
+                        <SelectItem key={slot} value={slot}>
+                          {slot}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            )}
+          </div>
+
           <div className="space-y-2">
-            <Label htmlFor="frequencia">
+            <Label>
               Frequência (dias) <span className="text-red-500">*</span>
             </Label>
+
             <Input
-              id="frequencia"
               type="number"
               min="1"
-              placeholder="Adicionar frequência"
               value={frequencyDays < 1 ? "" : frequencyDays}
-              onChange={e => setFrequencyDays(Number(e.target.value))}
-              className={cn(validationErrors.frequencyDays && 'border-red-500')}
+              onChange={(e) => setFrequencyDays(Number(e.target.value))}
+              placeholder="Ex: 7"
+              className="w-full"
             />
             {validationErrors.frequencyDays && (
-              <p className="text-sm text-red-500">
-                Frequência é obrigatória e deve ser maior que 0.
-              </p>
+              <p className="text-sm text-red-500">Maior que 0.</p>
             )}
           </div>
-          <div className="flex justify-end">
-            <Button className="w-full bg-[#0D4F97]  text-white hover:bg-blue-900 text-xs sm:w-auto sm:text-sm">
-              {editAppointment ? 'Atualizar' : 'Cadastrar'}
+
+          <div className="flex justify-end pt-4">
+            <Button className="w-full bg-[#0D4F97] text-white hover:bg-blue-900 sm:w-auto">
+              {editAppointment ? "Atualizar" : "Cadastrar"}
             </Button>
           </div>
         </CardContent>

--- a/apps/api/src/main/java/br/org/apae/api/appointment/application/internal/AppointmentApplicationServiceImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/appointment/application/internal/AppointmentApplicationServiceImpl.java
@@ -3,24 +3,25 @@ import br.org.apae.api.appointment.application.interfaces.AppointmentApplication
 import br.org.apae.api.appointment.domain.exceptions.AnnualRegistrationNotFound;
 import br.org.apae.api.appointment.domain.exceptions.AppointmentAlreadyCancelledException;
 import br.org.apae.api.appointment.domain.exceptions.AppointmentNotFoundException;
+import br.org.apae.api.appointment.domain.exceptions.ProfessionalUnavailableException;
 import br.org.apae.api.appointment.domain.model.Absence;
 import br.org.apae.api.appointment.mapper.AppointmentMapper;
 import br.org.apae.api.patient.domain.model.AnnualRegistry;
 import br.org.apae.api.patient.domain.repository.AnnualRegistryRepository;
 import br.org.apae.api.professional.domain.exceptions.HealthProfessionalNotFoundException;
 import br.org.apae.api.professional.domain.model.HealthProfessional;
+import br.org.apae.api.professional.domain.model.enums.Day;
+import br.org.apae.api.professional.domain.model.enums.Shift;
 import br.org.apae.api.professional.domain.repository.HealthProfessionalRepository;
 import jakarta.transaction.Transactional;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.Year;
+import java.time.*;
 import java.util.*;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import br.org.apae.api.appointment.domain.model.Appointment;
@@ -45,6 +46,7 @@ import br.org.apae.api.patient.domain.repository.GuardianRepository;
 import br.org.apae.api.patient.domain.repository.ParentRepository;
 import br.org.apae.api.patient.domain.repository.PatientRepository;
 import jakarta.persistence.EntityNotFoundException;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service
 @Transactional
@@ -65,15 +67,15 @@ public class AppointmentApplicationServiceImpl implements AppointmentApplication
 
 
   public AppointmentApplicationServiceImpl(
-      AppointmentRepository appointmentRepo,
-      GeneratedAppointmentRepository generatedRepo,
-      AnnualRegistryRepository registryRepo,
-      HealthProfessionalRepository professionalRepo,
-      AbsenceRepository absenceRepo,
-      PatientRepository patientRepo,
-      GuardianRepository guardianRepo,
-      ParentRepository parentRepo,
-      AppointmentMapper mapper) {
+          AppointmentRepository appointmentRepo,
+          GeneratedAppointmentRepository generatedRepo,
+          AnnualRegistryRepository registryRepo,
+          HealthProfessionalRepository professionalRepo,
+          AbsenceRepository absenceRepo,
+          PatientRepository patientRepo,
+          GuardianRepository guardianRepo,
+          ParentRepository parentRepo,
+          AppointmentMapper mapper) {
     this.appointmentRepo = appointmentRepo;
     this.generatedRepo = generatedRepo;
     this.registryRepo = registryRepo;
@@ -89,18 +91,22 @@ public class AppointmentApplicationServiceImpl implements AppointmentApplication
 
   @Override
   public void create(CreateAppointmentDTO dto) {
-     AnnualRegistry annualRegistry = this.registryRepo.findByPatientIdAndYear(dto.patientId(), Year.now().getValue())
-        .orElseThrow(AnnualRegistrationNotFound::new);
+    AnnualRegistry annualRegistry = this.registryRepo
+            .findByPatientIdAndYear(dto.patientId(), Year.now().getValue())
+            .orElseThrow(AnnualRegistrationNotFound::new);
 
-    HealthProfessional professional = this.professionalRepo.findById(dto.professionalId())
-        .orElseThrow(HealthProfessionalNotFoundException::new);
+    HealthProfessional professional = this.professionalRepo
+            .findById(dto.professionalId())
+            .orElseThrow(HealthProfessionalNotFoundException::new);
+
+    validateProfessionalAvailability(professional, dto.initialDate(), dto.hour());
 
     Appointment appointment = mapper.toEntity(dto, professional, annualRegistry);
-
     appointmentRepo.save(appointment);
 
     Integer year = annualRegistry.getYear();
     LocalDate end = LocalDate.of(year, 12, 31);
+
     generateAppointments(annualRegistry.getId(), appointment.getInitialDate(), end);
   }
 
@@ -108,15 +114,15 @@ public class AppointmentApplicationServiceImpl implements AppointmentApplication
   public Page<AppointmentResponseDTO> findAll(Pageable pageable) {
     return this.appointmentRepo.findAll(pageable).map(appointment -> {
       Patient patient = patientRepo
-                .findById(appointment.getAnnualRegistration().getPatientId())
-                .orElseThrow(() -> new EntityNotFoundException(
-                    "Paciente não encontrado para o agendamento " + appointment.getId()
+              .findById(appointment.getAnnualRegistration().getPatientId())
+              .orElseThrow(() -> new EntityNotFoundException(
+                      "Paciente não encontrado para o agendamento " + appointment.getId()
               ));
 
-              Guardian guardian = guardianRepo
-                  .findByPatientId(patient.getId())
-                  .orElseThrow(() -> new EntityNotFoundException(
-                    "Responsável não encontrado para o paciente " + patient.getId() + ", no agendamento " + appointment.getId()
+      Guardian guardian = guardianRepo
+              .findByPatientId(patient.getId())
+              .orElseThrow(() -> new EntityNotFoundException(
+                      "Responsável não encontrado para o paciente " + patient.getId() + ", no agendamento " + appointment.getId()
               ));
       List<Parent> pais = parentRepo.findAllByPatientId(patient.getId());
 
@@ -124,11 +130,11 @@ public class AppointmentApplicationServiceImpl implements AppointmentApplication
       Set<Vaccine> vaccines = patient.getVaccines();
 
       PatientResponseDTO pdto = new PatientResponseDTO(
-        patient,
-        adto,
-        new GuardianResponseDTO(guardian, adto),
-        pais.stream().map(parentMapper::toResponseDTO).toList(),
-        vaccines.stream().map(vaccineMapper::toResponseDTO).collect(Collectors.toSet()), null);
+              patient,
+              adto,
+              new GuardianResponseDTO(guardian, adto),
+              pais.stream().map(parentMapper::toResponseDTO).toList(),
+              vaccines.stream().map(vaccineMapper::toResponseDTO).collect(Collectors.toSet()), null);
 
       return mapper.toResponse(appointment, pdto);
     });
@@ -136,66 +142,66 @@ public class AppointmentApplicationServiceImpl implements AppointmentApplication
 
   @Override
   public Page<AppointmentResponseDTO> findAllByDate(LocalDate date, Pageable pageable) {
-      return this.appointmentRepo.findAllByInitialDate(date, pageable)
-          .map(appointment -> {
+    return this.appointmentRepo.findAllByInitialDate(date, pageable)
+            .map(appointment -> {
               Patient patient = patientRepo
-                .findById(appointment.getAnnualRegistration().getPatientId())
-                .orElseThrow(() -> new EntityNotFoundException(
-                    "Paciente não encontrado para o agendamento " + appointment.getId()
-              ));
+                      .findById(appointment.getAnnualRegistration().getPatientId())
+                      .orElseThrow(() -> new EntityNotFoundException(
+                              "Paciente não encontrado para o agendamento " + appointment.getId()
+                      ));
 
               Guardian guardian = guardianRepo
-                  .findByPatientId(patient.getId())
-                  .orElseThrow(() -> new EntityNotFoundException(
-                    "Responsável não encontrado para o paciente " + patient.getId() + ", no agendamento " + appointment.getId()
-              ));
+                      .findByPatientId(patient.getId())
+                      .orElseThrow(() -> new EntityNotFoundException(
+                              "Responsável não encontrado para o paciente " + patient.getId() + ", no agendamento " + appointment.getId()
+                      ));
               List<Parent> pais = parentRepo.findAllByPatientId(patient.getId());
 
               AddressResponseDTO adto = new AddressResponseDTO(patient.getAddress());
               Set<Vaccine> vaccines = patient.getVaccines();
 
               PatientResponseDTO pdto = new PatientResponseDTO(
-                  patient,
-                  adto,
-                  new GuardianResponseDTO(guardian, adto),
-                  pais.stream().map(parentMapper::toResponseDTO).collect(Collectors.toList()),
-                  vaccines.stream().map(vaccineMapper::toResponseDTO).collect(Collectors.toSet()), null
+                      patient,
+                      adto,
+                      new GuardianResponseDTO(guardian, adto),
+                      pais.stream().map(parentMapper::toResponseDTO).collect(Collectors.toList()),
+                      vaccines.stream().map(vaccineMapper::toResponseDTO).collect(Collectors.toSet()), null
               );
 
               return mapper.toResponse(appointment, pdto);
-          });
+            });
   }
 
   @Override
   public Page<AppointmentResponseDTO> findAllByDateAndTime(LocalDate date, LocalTime time, Pageable pageable) {
-      return this.appointmentRepo.findAllByInitialDateAndHour(date, time, pageable)
-          .map(appointment -> {
+    return this.appointmentRepo.findAllByInitialDateAndHour(date, time, pageable)
+            .map(appointment -> {
               Patient patient = patientRepo
-                .findById(appointment.getAnnualRegistration().getPatientId())
-                .orElseThrow(() -> new EntityNotFoundException(
-                    "Paciente não encontrado para o agendamento " + appointment.getId()
-              ));
+                      .findById(appointment.getAnnualRegistration().getPatientId())
+                      .orElseThrow(() -> new EntityNotFoundException(
+                              "Paciente não encontrado para o agendamento " + appointment.getId()
+                      ));
 
               Guardian guardian = guardianRepo
-                  .findByPatientId(patient.getId())
-                  .orElseThrow(() -> new EntityNotFoundException(
-                    "Responsável não encontrado para o paciente " + patient.getId() + ", no agendamento " + appointment.getId()
-              ));
+                      .findByPatientId(patient.getId())
+                      .orElseThrow(() -> new EntityNotFoundException(
+                              "Responsável não encontrado para o paciente " + patient.getId() + ", no agendamento " + appointment.getId()
+                      ));
               List<Parent> pais = parentRepo.findAllByPatientId(patient.getId());
 
               AddressResponseDTO adto = new AddressResponseDTO(patient.getAddress());
               Set<Vaccine> vaccines = patient.getVaccines();
 
               PatientResponseDTO pdto = new PatientResponseDTO(
-                  patient,
-                  adto,
-                  new GuardianResponseDTO(guardian, adto),
-                  pais.stream().map(parentMapper::toResponseDTO).collect(Collectors.toList()),
-                  vaccines.stream().map(vaccineMapper::toResponseDTO).collect(Collectors.toSet()), null
+                      patient,
+                      adto,
+                      new GuardianResponseDTO(guardian, adto),
+                      pais.stream().map(parentMapper::toResponseDTO).collect(Collectors.toList()),
+                      vaccines.stream().map(vaccineMapper::toResponseDTO).collect(Collectors.toSet()), null
               );
 
               return mapper.toResponse(appointment, pdto);
-          });
+            });
   }
 
   @Override
@@ -214,28 +220,28 @@ public class AppointmentApplicationServiceImpl implements AppointmentApplication
             .orElseThrow(AppointmentNotFoundException::new);
 
     Patient patient = patientRepo
-      .findById(appointment.getAnnualRegistration().getPatientId())
-      .orElseThrow(() -> new EntityNotFoundException(
-          "Paciente não encontrado para o agendamento " + appointment.getId()
-    ));
+            .findById(appointment.getAnnualRegistration().getPatientId())
+            .orElseThrow(() -> new EntityNotFoundException(
+                    "Paciente não encontrado para o agendamento " + appointment.getId()
+            ));
 
     Guardian guardian = guardianRepo
-        .findByPatientId(patient.getId())
-        .orElseThrow(() -> new EntityNotFoundException(
-          "Responsável não encontrado para o paciente " + patient.getId() + ", no agendamento " + appointment.getId()
-    ));
+            .findByPatientId(patient.getId())
+            .orElseThrow(() -> new EntityNotFoundException(
+                    "Responsável não encontrado para o paciente " + patient.getId() + ", no agendamento " + appointment.getId()
+            ));
     List<Parent> pais = parentRepo.findAllByPatientId(patient.getId());
 
     AddressResponseDTO adto = new AddressResponseDTO(patient.getAddress());
     Set<Vaccine> vaccines = patient.getVaccines();
 
     PatientResponseDTO pdto = new PatientResponseDTO(
-      patient,
-      adto,
-      new GuardianResponseDTO(guardian, adto),
-      pais.stream().map(parentMapper::toResponseDTO).collect(Collectors.toList()),
-      vaccines.stream().map(vaccineMapper::toResponseDTO).collect(Collectors.toSet()), null);
-      
+            patient,
+            adto,
+            new GuardianResponseDTO(guardian, adto),
+            pais.stream().map(parentMapper::toResponseDTO).collect(Collectors.toList()),
+            vaccines.stream().map(vaccineMapper::toResponseDTO).collect(Collectors.toSet()), null);
+
     return mapper.toResponse(appointment, pdto);
   }
 
@@ -362,7 +368,7 @@ public class AppointmentApplicationServiceImpl implements AppointmentApplication
    * @throws IllegalArgumentException if the rule is not found
    * @throws IllegalStateException if the rule is not active
    */
-    public AppointmentResponseDTO updateAppointment(UUID appointmentId, Integer newFrequency, LocalTime newTime) {
+  public AppointmentResponseDTO updateAppointment(UUID appointmentId, Integer newFrequency, LocalTime newTime) {
     Appointment current = appointmentRepo.findById(appointmentId)
             .orElseThrow(() -> new IllegalArgumentException("Rule not found"));
 
@@ -370,28 +376,28 @@ public class AppointmentApplicationServiceImpl implements AppointmentApplication
       throw new IllegalStateException("Only active rules can be edited");
     }
 
-    LocalDate editDate = LocalDate.now();
+    LocalDate editDate = current.getInitialDate();
+    LocalTime timeToCheck = newTime != null ? newTime : current.getHour();
 
-    // Deactivate old rule
+    validateProfessionalAvailability(current.getProfessional(), editDate, timeToCheck);
+
     current.setActive(false);
     current.setEndDate(editDate.minusDays(1));
     appointmentRepo.save(current);
 
-    // Create new rule
     Appointment newRule = new Appointment(
             current.getProfessional(),
             current.getAnnualRegistration(),
             newFrequency != null ? newFrequency : current.getFrequencyDays(),
-            newTime != null ? newTime : current.getHour(),
-            editDate,
-            null // end date will be set on next edit
+            timeToCheck,
+            current.getInitialDate(),
+            null
     );
     newRule = appointmentRepo.save(newRule);
 
     int year = current.getAnnualRegistration().getYear();
     LocalDate end = LocalDate.of(year, 12, 31);
 
-    // Regenerate future appointments and clean up old ones
     generateAppointments(current.getAnnualRegistration().getId(), editDate, end);
     generatedRepo.deleteFutureByAppointmentId(current.getId(), editDate.atStartOfDay());
 
@@ -403,11 +409,11 @@ public class AppointmentApplicationServiceImpl implements AppointmentApplication
     Set<Vaccine> vaccines = patient.getVaccines();
 
     PatientResponseDTO pdto = new PatientResponseDTO(
-      patient,
-      adto,
-      new GuardianResponseDTO(guardian, adto),
-      pais.stream().map(parentMapper::toResponseDTO).collect(Collectors.toList()),
-      vaccines.stream().map(vaccineMapper::toResponseDTO).collect(Collectors.toSet()), null);
+            patient,
+            adto,
+            new GuardianResponseDTO(guardian, adto),
+            pais.stream().map(parentMapper::toResponseDTO).collect(Collectors.toList()),
+            vaccines.stream().map(vaccineMapper::toResponseDTO).collect(Collectors.toSet()), null);
 
     return mapper.toResponse(newRule, pdto);
   }
@@ -510,5 +516,34 @@ public class AppointmentApplicationServiceImpl implements AppointmentApplication
     );
 
     return mapper.toTodayResponseDTO(appointment, pdto, hasAbsence);
+  }
+
+  private void validateProfessionalAvailability(HealthProfessional professional, LocalDate date, LocalTime time) {
+    DayOfWeek dayOfWeek = date.getDayOfWeek();
+
+    if (dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) {
+      throw new ProfessionalUnavailableException();
+    }
+
+    Day requestedDay = switch (dayOfWeek) {
+      case MONDAY -> Day.SEGUNDA;
+      case TUESDAY -> Day.TERCA;
+      case WEDNESDAY -> Day.QUARTA;
+      case THURSDAY -> Day.QUINTA;
+      case FRIDAY -> Day.SEXTA;
+      default -> throw new ProfessionalUnavailableException();
+    };
+
+    Shift requestedShift = time.getHour() < 12 ? Shift.MANHA : Shift.TARDE;
+
+    boolean isAvailable = professional.getAvailabilities().stream()
+            .anyMatch(availability ->
+                    availability.getDay().equals(requestedDay) &&
+                            availability.getShift().equals(requestedShift)
+            );
+
+    if (!isAvailable) {
+      throw new ProfessionalUnavailableException();
+    }
   }
 }

--- a/apps/api/src/main/java/br/org/apae/api/appointment/domain/exceptions/ProfessionalUnavailableException.java
+++ b/apps/api/src/main/java/br/org/apae/api/appointment/domain/exceptions/ProfessionalUnavailableException.java
@@ -1,0 +1,12 @@
+package br.org.apae.api.appointment.domain.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class ProfessionalUnavailableException extends RuntimeException {
+
+    public ProfessionalUnavailableException() {
+        super("O profissional não possui disponibilidade para este dia e turno.");
+    }
+}

--- a/apps/api/src/main/java/br/org/apae/api/appointment/exceptions/AppointmentExceptionHandler.java
+++ b/apps/api/src/main/java/br/org/apae/api/appointment/exceptions/AppointmentExceptionHandler.java
@@ -1,6 +1,10 @@
 package br.org.apae.api.appointment.exceptions;
 
 import br.org.apae.api.appointment.domain.exceptions.AppointmentAlreadyCancelledException;
+import br.org.apae.api.appointment.domain.exceptions.AppointmentNotFoundException;
+import br.org.apae.api.appointment.domain.exceptions.ProfessionalUnavailableException;
+import br.org.apae.api.common.exceptions.types.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -9,72 +13,83 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
-import br.org.apae.api.appointment.domain.exceptions.AppointmentNotFoundException;
-import br.org.apae.api.common.exceptions.types.ErrorResponse;
-import jakarta.servlet.http.HttpServletRequest;
-
 @ControllerAdvice
 public class AppointmentExceptionHandler {
+
   @ExceptionHandler(AppointmentNotFoundException.class)
-  public ResponseEntity<ErrorResponse> handleAppointmentNotFoundException(AppointmentNotFoundException ex,
-      HttpServletRequest request) {
+  public ResponseEntity<ErrorResponse> handleAppointmentNotFound(
+          AppointmentNotFoundException ex,
+          HttpServletRequest request) {
+
     ErrorResponse error = new ErrorResponse(
-        HttpStatus.NOT_FOUND.value(),
-        HttpStatus.NOT_FOUND.getReasonPhrase(),
-        ex.getMessage(),
-        request.getRequestURI());
+            HttpStatus.NOT_FOUND.value(),
+            HttpStatus.NOT_FOUND.getReasonPhrase(),
+            ex.getMessage(),
+            request.getRequestURI());
+
     return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
   }
 
-
   @ExceptionHandler(AppointmentAlreadyCancelledException.class)
-  public ResponseEntity<ErrorResponse> handleAppointmentAlreadyCancelled(AppointmentAlreadyCancelledException ex,
-                                                                          HttpServletRequest request) {
+  public ResponseEntity<ErrorResponse> handleAppointmentAlreadyCancelled(
+          AppointmentAlreadyCancelledException ex,
+          HttpServletRequest request) {
+
     ErrorResponse error = new ErrorResponse(
-        HttpStatus.BAD_REQUEST.value(),
-        HttpStatus.BAD_REQUEST.getReasonPhrase(),
-        ex.getMessage(),
-        request.getRequestURI());
+            HttpStatus.BAD_REQUEST.value(),
+            HttpStatus.BAD_REQUEST.getReasonPhrase(),
+            ex.getMessage(),
+            request.getRequestURI());
+
     return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
   }
 
+  @ExceptionHandler(ProfessionalUnavailableException.class)
+  public ResponseEntity<ErrorResponse> handleProfessionalUnavailable(
+          ProfessionalUnavailableException ex,
+          HttpServletRequest request) {
+
+    ErrorResponse error = new ErrorResponse(
+            HttpStatus.BAD_REQUEST.value(),
+            HttpStatus.BAD_REQUEST.getReasonPhrase(),
+            ex.getMessage(),
+            request.getRequestURI());
+
+    return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+  }
 
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(
-      MethodArgumentNotValidException ex,
-      HttpServletRequest request
-  ) {
+          MethodArgumentNotValidException ex,
+          HttpServletRequest request) {
+
     String message = ex.getBindingResult()
-        .getFieldErrors()
-        .stream()
-        .findFirst()
-        .map(FieldError::getDefaultMessage)
-        .orElse("Validation error");
+            .getFieldErrors()
+            .stream()
+            .findFirst()
+            .map(FieldError::getDefaultMessage)
+            .orElse("Validation error");
 
     ErrorResponse error = new ErrorResponse(
-        HttpStatus.BAD_REQUEST.value(),
-        HttpStatus.BAD_REQUEST.getReasonPhrase(),
-        message,
-        request.getRequestURI()
-    );
+            HttpStatus.BAD_REQUEST.value(),
+            HttpStatus.BAD_REQUEST.getReasonPhrase(),
+            message,
+            request.getRequestURI());
 
     return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
   }
 
   @ExceptionHandler(HttpMessageNotReadableException.class)
   public ResponseEntity<ErrorResponse> handleHttpMessageNotReadable(
-      HttpMessageNotReadableException ex,
-      HttpServletRequest request
-  ) {
+          HttpMessageNotReadableException ex,
+          HttpServletRequest request) {
+
     ErrorResponse error = new ErrorResponse(
-        HttpStatus.BAD_REQUEST.value(),
-        HttpStatus.BAD_REQUEST.getReasonPhrase(),
-        ex.getMessage(),
-        request.getRequestURI()
-    );
+            HttpStatus.BAD_REQUEST.value(),
+            HttpStatus.BAD_REQUEST.getReasonPhrase(),
+            ex.getMessage(),
+            request.getRequestURI());
 
     return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
   }
-
-
 }


### PR DESCRIPTION
# O que esse PR forneceu?

- Restrição de agendamentos conforme disponibilidade do profissional: foi implementada uma validação no backend que impede a criação ou edição de agendamentos em dias ou horários fora da agenda definida para o profissional da saúde.

- Verificação de dia e turno do profissional: o sistema agora valida se o dia da semana e o turno selecionados correspondem aos períodos em que o profissional realmente atende, evitando registros inconsistentes.

- Nova exceção para indisponibilidade: foi criada a exceção `ProfessionalUnavailableException`, responsável por sinalizar tentativas de agendamento em horários não permitidos.

- Tratamento de erro padronizado: foi adicionado tratamento no `AppointmentExceptionHandler` para capturar essa exceção e retornar uma resposta **HTTP 400**, informando que o horário selecionado não está disponível.

- Maior consistência nos dados de agendamento: com essa validação, o sistema passa a garantir que todos os atendimentos cadastrados respeitem a agenda configurada para cada profissional.

# Coletando Evidências Locais:

https://github.com/user-attachments/assets/9a0b572f-b489-415b-a785-216b50f0a5a6

https://github.com/user-attachments/assets/22a37137-d70b-4102-a745-fd4a42eef4ee
