### PR TITLE
[Fix] Validação do campo de endereço no cadastro de paciente

### DIFF
--- a/apps/api/src/main/java/br/org/apae/api/common/dto/address/CreateAddressDTO.java
+++ b/apps/api/src/main/java/br/org/apae/api/common/dto/address/CreateAddressDTO.java
@@ -5,17 +5,28 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record CreateAddressDTO(
-    @NotBlank(message = "A cidade não pode estar em branco") String city,
+        @NotBlank(message = "A cidade não pode estar em branco")
+        String city,
 
-    @NotBlank(message = "O CEP não pode estar em branco") @Pattern(regexp = "^\\d{5}-\\d{3}$", message = "O CEP deve estar no formato 99999-999") String cep,
+        @NotBlank(message = "O CEP não pode estar em branco")
+        @Pattern(regexp = "^\\d{5}-\\d{3}$", message = "O CEP deve estar no formato 99999-999")
+        String cep,
 
-    @NotBlank(message = "O estado não pode estar em branco") String state,
+        @NotBlank(message = "O estado não pode estar em branco")
+        String state,
 
-    @NotBlank(message = "O bairro não pode estar em branco") @Size(min = 2, max = 60, message = "O bairro deve ter entre 2 e 60 caracteres") @Pattern(regexp = "^[A-Za-zÀ-ÖØ-öø-ÿ0-9\\s'-]+$", message = "O bairro deve conter apenas letras, números e espaços") String neighborhood,
+        @NotBlank(message = "O bairro não pode estar em branco")
+        @Size(min = 2, max = 60, message = "O bairro deve ter entre 2 e 60 caracteres")
+        String neighborhood,
 
-    @NotBlank(message = "A rua não pode estar em branco") @Size(min = 2, max = 80, message = "A rua deve ter entre 2 e 80 caracteres") @Pattern(regexp = "^[A-Za-zÀ-ÖØ-öø-ÿ0-9\\s'.,-]+$", message = "A rua deve conter apenas letras, números e espaços") String street,
+        @NotBlank(message = "A rua não pode estar em branco")
+        @Size(min = 2, max = 80, message = "A rua deve ter entre 2 e 80 caracteres")
+        String street,
 
-    @NotBlank(message = "O número não pode estar em branco") @Pattern(regexp = "^[0-9A-Za-z/-]{1,10}$", message = "O número deve conter apenas letras, números, / ou -") String number,
+        @NotBlank(message = "O número não pode estar em branco")
+        @Size(max = 20, message = "O número deve ter no máximo 20 caracteres")
+        String number,
 
-    @Size(max = 60, message = "O complemento deve ter no máximo 60 caracteres") @Pattern(regexp = "^[A-Za-zÀ-ÖØ-öø-ÿ0-9\\s'°º.,-]*$", message = "O complemento contém caracteres inválidos") String complement) {
-}
+        @Size(max = 60, message = "O complemento deve ter no máximo 60 caracteres")
+        String complement
+) {}


### PR DESCRIPTION
# O que mudou?

Este PR ajusta as regras de validação do campo de endereço na criação de pacientes no back-end. As mudanças focam em flexibilizar o recebimento dos dados, visto que as expressões regulares (Regex) anteriores estavam muito restritas e bloqueando cadastros válidos que continham caracteres comuns (como "nº", vírgulas, espaços e hifens).

# Tarefas Relacionadas

- Issue: #479 Revisar validação do campo endereço no cadastro de paciente

# Mudanças Realizadas

- Remoção das validações rigorosas de Regex (`@Pattern`) nos campos `street`, `number`, `neighborhood` e `complement` no arquivo `CreateAddressDTO`.
- Manutenção das anotações `@NotBlank` e dos limites de `@Size` para garantir a integridade e evitar estouro de limite no banco de dados.
-Testes manuais realizados diretamente pelo formulário de cadastro de paciente no front-end validaram a aceitação e persistência no banco de dados para variações de endereços. O sistema agora processa com sucesso formatos como:
 - Rua João Pessoa, 123
 - Av. Floriano Peixoto 456
 - Rua das Flores, nº 89
 - Rua A, 45 - Centro

https://github.com/user-attachments/assets/76b564b4-7b76-490f-b63b-e0e8905f2369

