### PR TITLE
fix: remover toasts duplicados no carregamento de vacinas e transtornos (#524)

### DIFF
--- a/apps/apae/src/hooks/use-vaccines.tsx
+++ b/apps/apae/src/hooks/use-vaccines.tsx
@@ -65,7 +65,6 @@ function withFeedback<TArgs extends readonly unknown[], TReturn>(
         try {
             const result = await fn(...args);
             
-            // 2. A MÁGICA: Só dispara o feedback se a mensagem foi enviada!
             if (messages?.success) {
                 setFeedback({
                     message: messages.success,

--- a/apps/apae/src/hooks/use-vaccines.tsx
+++ b/apps/apae/src/hooks/use-vaccines.tsx
@@ -51,24 +51,31 @@ const VaccinesContext = createContext<VaccinesContextData | undefined>(
 );
 
 type WithFeedbackMessages = {
-    success: string;
+    success?: string;
 };
 
 function withFeedback<TArgs extends readonly unknown[], TReturn>(
     fn: (...args: TArgs) => Promise<TReturn>,
     setLoading: (loading: boolean) => void,
     setFeedback: (feedback: Feedback) => void,
-    messages: WithFeedbackMessages,
+    messages?: WithFeedbackMessages,
 ) {
     return async (...args: TArgs): Promise<TReturn | void> => {
         setLoading(true);
         try {
             const result = await fn(...args);
-            setFeedback({
-                message: messages.success,
-                success: true,
-                error: false,
-            });
+            
+            // 2. A MÁGICA: Só dispara o feedback se a mensagem foi enviada!
+            if (messages?.success) {
+                setFeedback({
+                    message: messages.success,
+                    success: true,
+                    error: false,
+                });
+            } else {
+                setFeedback({ message: "", success: false, error: false });
+            }
+            
             return result;
         } catch (error) {
             const message =
@@ -111,10 +118,7 @@ function VaccinesProvider({
                 setVaccines(data);
             },
             setLoading,
-            setFeedback,
-            {
-                success: "Vacinas carregadas com sucesso.",
-            },
+            setFeedback
         ),
         [],
     );
@@ -124,7 +128,6 @@ function VaccinesProvider({
             async (params: FetchVaccineParams) => {
                 const response = await fetch(`/api/vacinas/${params.id}`);
 
-                console.log("TESTE");
                 if (!response.ok) {
                     throw Error("Ocorreu um erro ao carregar vacina.");
                 }
@@ -132,10 +135,7 @@ function VaccinesProvider({
                 return response.json();
             },
             setLoading,
-            setFeedback,
-            {
-                success: "Vacina carregada com sucesso.",
-            },
+            setFeedback
         ),
         [],
     );
@@ -157,7 +157,7 @@ function VaccinesProvider({
             },
             setLoading,
             setFeedback,
-            { success: "Vacina criada com sucesso." },
+            { success: "Vacina criada com sucesso." }, 
         ),
         [],
     );
@@ -202,7 +202,7 @@ function VaccinesProvider({
             setLoading,
             setFeedback,
             {
-                success: "Vacina excluída com sucesso.",
+                success: "Vacina excluída com sucesso.", 
             },
         ),
         [],


### PR DESCRIPTION
Descrição
Resolve o problema de poluição visual onde toasts de "sucesso" eram exibidos desnecessariamente ao carregar as listagens de vacinas e transtornos. Também corrige a duplicidade de toasts causada pelo Strict Mode do React.

Alterações
- Tornada opcional a mensagem de sucesso na função `withFeedback` dentro dos hooks de vacinas e transtornos.
- Adicionada verificação para disparar o feedback apenas quando houver uma mensagem definida.
- Removidas as mensagens de sucesso dos métodos de busca (GET).

https://github.com/user-attachments/assets/4d45b9af-9f63-4067-b0db-725c9e615bc4



