### PR TITLE
514 implementar funcionalidade de recuperação de senha no backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+MAIL_HOST=smtp.gmail.com
+MAIL_PORT=587
+# Preencha apenas se quiser testar envio de e-mails (senha sem espaços)
+MAIL_USERNAME=
+MAIL_PASSWORD=
+
+APP_FRONTEND_RESET_PASSWORD_URL=http://localhost:3000/reset-password

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 MAIL_HOST=smtp.gmail.com
 MAIL_PORT=587
-# Preencha apenas se quiser testar envio de e-mails (senha sem espaços)
+# Use aspas se a senha contiver espaços
 MAIL_USERNAME=
 MAIL_PASSWORD=
 

--- a/.scripts/run-app.sh
+++ b/.scripts/run-app.sh
@@ -6,6 +6,18 @@ FRONTEND_TARGET=${2:-apae}
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 MAVEN_CMD="$ROOT_DIR/apps/api/mvnw"
+ENV_FILE="$ROOT_DIR/.env"
+
+load_env() {
+  if [ -f "$ENV_FILE" ]; then
+    echo "Carregando variáveis de ambiente de $ENV_FILE..."
+    set -a
+    . "$ENV_FILE"
+    set +a
+  else
+    echo "Arquivo .env não encontrado em $ENV_FILE. Seguindo sem variáveis locais."
+  fi
+}
 
 DB_HOST="localhost"
 DB_PORT=5200
@@ -43,6 +55,7 @@ check_db_up() {
 }
 
 run_backend() {
+  load_env
   check_db_up || exit 1
   echo "Iniciando backend..."
   cd "$ROOT_DIR/apps/api" || exit 1
@@ -59,6 +72,7 @@ run_frontend() {
 }
 
 run_both() {
+  load_env
   check_db_up || exit 1
   echo "Rodando backend e frontend..."
   npx concurrently -k -n backend,frontend -c red,blue "bash ./.scripts/run-app.sh backend" "bash ./.scripts/run-app.sh frontend $FRONTEND_TARGET"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Projeto em desenvolvimento, fruto de uma parceria entre o IFPB (Campus Esperanç
    - [Criação de Branches](#criação-de-branches)
    - [Labels](#labels)
    - [Raia do Kanban](#raia-do-kanban)
-3. [Configuração do Projeto](#configuração-do-projeto)
+4. [Configuração do Projeto](#configuração-do-projeto)
 
 ---
 
@@ -39,6 +39,8 @@ O projeto foi automatizado para rodar com o mínimo de comandos utilizando **pnp
     1.1. Caso esteja no Windows, acessar terminal via **GitBash**
 2. **Setup Inicial**: `pnpm install`
 3. **Rodar Tudo (Docker + Back + Front)**: `pnpm dev`
+
+> ℹ️ Algumas funcionalidades, como envio de e-mails, utilizam configuração opcional de variáveis de ambiente. Veja a seção **Configuração do Projeto**.
 
 #### Outros Comandos:
 - `pnpm dev:backend`: Executa apenas o backend (api).
@@ -182,6 +184,60 @@ O Kanban é usado para organizar as **issues** no processo de desenvolvimento. A
 ---
 
 ## Configuração do Projeto
+
+### Variáveis de Ambiente (Opcional)
+
+O projeto utiliza variáveis de ambiente para configurar serviços externos, como envio de e-mails (SMTP), banco de dados e integrações.
+
+ **Importante:** A configuração dessas variáveis é opcional durante o desenvolvimento.  
+O sistema funciona normalmente sem elas, porém funcionalidades como envio de e-mails não serão executadas.
+
+---
+
+### Como configurar
+
+1. Copie o arquivo de exemplo:
+
+```bash
+cp .env.example .env
+```
+
+2. Preencha:
+
+```env
+MAIL_HOST=smtp.gmail.com
+MAIL_PORT=587
+MAIL_USERNAME=seu-email@gmail.com
+MAIL_PASSWORD=sua_senha_de_app
+APP_FRONTEND_RESET_PASSWORD_URL=http://localhost:3000/reset-password
+```
+
+3. Agora pode seguir com a execução normal do projeto, indo para seção **Como Executar**
+
+---
+
+### Envio de e-mails
+
+- Sem configuração: sistema funciona normalmente, mas não envia e-mails  
+- Com configuração: envio de e-mails ativo
+
+---
+
+### Segurança
+
+Adicionar no `.gitignore`:
+
+```gitignore
+.env
+```
+
+---
+
+### Observações
+
+- Cada dev pode ter seu próprio `.env`
+- SMTP é opcional
+- Apenas necessário para testar envio de e-mails
 
 Obs. Ainda em desenvolvimento...
 (Incluir as instruções de como configurar o ambiente de desenvolvimento, instalar dependências, rodar o projeto, etc.)

--- a/apps/api/pom.xml
+++ b/apps/api/pom.xml
@@ -91,6 +91,10 @@
             <version>1.10.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/apps/api/src/main/java/br/org/apae/api/auth/application/interfaces/AuthApplicationService.java
+++ b/apps/api/src/main/java/br/org/apae/api/auth/application/interfaces/AuthApplicationService.java
@@ -1,5 +1,7 @@
 package br.org.apae.api.auth.application.interfaces;
 
+import br.org.apae.api.common.dto.auth.request.PasswordRecoveryRequestDTO;
+import br.org.apae.api.common.dto.auth.request.PasswordResetDTO;
 import br.org.apae.api.common.dto.auth.request.SignInDTO;
 import br.org.apae.api.common.dto.auth.request.SignUpDTO;
 import br.org.apae.api.common.dto.auth.response.TokenResponseDTO;
@@ -8,4 +10,8 @@ public interface AuthApplicationService {
   void signUp(SignUpDTO signUpDto);
 
   TokenResponseDTO signIn(SignInDTO signInDto);
+
+  void requestPasswordRecovery(PasswordRecoveryRequestDTO dto);
+
+  void resetPassword(PasswordResetDTO dto);
 }

--- a/apps/api/src/main/java/br/org/apae/api/auth/application/internal/AuthApplicationServiceImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/auth/application/internal/AuthApplicationServiceImpl.java
@@ -4,9 +4,11 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.time.LocalDateTime;
 import java.util.HexFormat;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
@@ -14,8 +16,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import br.org.apae.api.auth.application.interfaces.AuthApplicationService;
 import br.org.apae.api.auth.domain.exceptions.AuthenticationException;
@@ -30,10 +30,11 @@ import br.org.apae.api.common.dto.auth.request.PasswordResetDTO;
 import br.org.apae.api.common.dto.auth.request.SignInDTO;
 import br.org.apae.api.common.dto.auth.request.SignUpDTO;
 import br.org.apae.api.common.dto.auth.response.TokenResponseDTO;
+import br.org.apae.api.notification.domain.interfaces.EmailSender;
+import br.org.apae.api.notification.domain.model.EmailMessage;
 
 @Service
 public class AuthApplicationServiceImpl implements AuthApplicationService {
-  private static final Logger logger = LoggerFactory.getLogger(AuthApplicationServiceImpl.class);
   private static final int PASSWORD_RECOVERY_EXPIRATION_MINUTES = 30;
 
   private final UserService userService;
@@ -41,18 +42,24 @@ public class AuthApplicationServiceImpl implements AuthApplicationService {
   private final TokenProvider tokenProvider;
   private final AuthenticationConfiguration authenticationConfiguration;
   private final PasswordRecoveryTokenRepository passwordRecoveryTokenRepository;
+  private final EmailSender emailSender;
+
+  @Value("${app.frontend.reset-password-url}")
+  private String resetPasswordUrl;
 
   public AuthApplicationServiceImpl(
       UserService userService,
       PasswordEncoder passwordEncoder,
       AuthenticationConfiguration authenticationConfiguration,
       TokenProvider tokenProvider,
-      PasswordRecoveryTokenRepository passwordRecoveryTokenRepository) {
+      PasswordRecoveryTokenRepository passwordRecoveryTokenRepository,
+      EmailSender emailSender) {
     this.userService = userService;
     this.passwordEncoder = passwordEncoder;
     this.authenticationConfiguration = authenticationConfiguration;
     this.tokenProvider = tokenProvider;
     this.passwordRecoveryTokenRepository = passwordRecoveryTokenRepository;
+    this.emailSender = emailSender;
   }
 
   @Override
@@ -100,17 +107,28 @@ public class AuthApplicationServiceImpl implements AuthApplicationService {
     String rawToken = UUID.randomUUID().toString() + UUID.randomUUID();
     String tokenHash = hashToken(rawToken);
 
-    logger.warn("PASSWORD RECOVERY TOKEN (DEV) - email: {}, token: {}", dto.email(), rawToken);
-
     PasswordRecoveryToken passwordRecoveryToken = new PasswordRecoveryToken(
         tokenHash,
         user,
         LocalDateTime.now().plusMinutes(PASSWORD_RECOVERY_EXPIRATION_MINUTES));
 
     passwordRecoveryTokenRepository.save(passwordRecoveryToken);
+
+    String recoveryLink = resetPasswordUrl + "?token=" + rawToken;
+
+    EmailMessage emailMessage = new EmailMessage(
+        List.of(dto.email()),
+        "Recuperação de senha",
+        "Olá,\n\n" +
+            "Recebemos uma solicitação para redefinição da sua senha.\n" +
+            "Clique no link abaixo para continuar:\n\n" +
+            recoveryLink +
+            "\n\nSe você não solicitou esta alteração, ignore este e-mail.");
+
+    emailSender.send(emailMessage);
   }
 
- @Override
+  @Override
   @Transactional
   public void resetPassword(PasswordResetDTO dto) {
     if (!dto.newPassword().equals(dto.confirmPassword())) {

--- a/apps/api/src/main/java/br/org/apae/api/auth/application/internal/AuthApplicationServiceImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/auth/application/internal/AuthApplicationServiceImpl.java
@@ -1,36 +1,58 @@
 package br.org.apae.api.auth.application.internal;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.LocalDateTime;
+import java.util.HexFormat;
+import java.util.Optional;
+import java.util.UUID;
+
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import br.org.apae.api.auth.application.interfaces.AuthApplicationService;
 import br.org.apae.api.auth.domain.exceptions.AuthenticationException;
 import br.org.apae.api.auth.domain.exceptions.InvalidPasswordException;
 import br.org.apae.api.auth.domain.exceptions.UserNotFoundException;
 import br.org.apae.api.auth.domain.interfaces.TokenProvider;
+import br.org.apae.api.auth.domain.model.PasswordRecoveryToken;
 import br.org.apae.api.auth.domain.model.User;
+import br.org.apae.api.auth.domain.repository.PasswordRecoveryTokenRepository;
+import br.org.apae.api.common.dto.auth.request.PasswordRecoveryRequestDTO;
+import br.org.apae.api.common.dto.auth.request.PasswordResetDTO;
 import br.org.apae.api.common.dto.auth.request.SignInDTO;
 import br.org.apae.api.common.dto.auth.request.SignUpDTO;
 import br.org.apae.api.common.dto.auth.response.TokenResponseDTO;
 
 @Service
 public class AuthApplicationServiceImpl implements AuthApplicationService {
+  private static final Logger logger = LoggerFactory.getLogger(AuthApplicationServiceImpl.class);
+  private static final int PASSWORD_RECOVERY_EXPIRATION_MINUTES = 30;
+
   private final UserService userService;
   private final PasswordEncoder passwordEncoder;
   private final TokenProvider tokenProvider;
   private final AuthenticationConfiguration authenticationConfiguration;
+  private final PasswordRecoveryTokenRepository passwordRecoveryTokenRepository;
 
-  public AuthApplicationServiceImpl(UserService userService, PasswordEncoder passwordEncoder,
+  public AuthApplicationServiceImpl(
+      UserService userService,
+      PasswordEncoder passwordEncoder,
       AuthenticationConfiguration authenticationConfiguration,
-      TokenProvider tokenProvider) {
+      TokenProvider tokenProvider,
+      PasswordRecoveryTokenRepository passwordRecoveryTokenRepository) {
     this.userService = userService;
     this.passwordEncoder = passwordEncoder;
     this.authenticationConfiguration = authenticationConfiguration;
     this.tokenProvider = tokenProvider;
+    this.passwordRecoveryTokenRepository = passwordRecoveryTokenRepository;
   }
 
   @Override
@@ -61,6 +83,70 @@ public class AuthApplicationServiceImpl implements AuthApplicationService {
       throw e;
     } catch (Exception e) {
       throw new AuthenticationException();
+    }
+  }
+
+  @Override
+  @Transactional
+  public void requestPasswordRecovery(PasswordRecoveryRequestDTO dto) {
+    Optional<User> optionalUser = userService.findUserByEmail(dto.email());
+
+    if (optionalUser.isEmpty()) {
+      return;
+    }
+
+    User user = optionalUser.get();
+
+    String rawToken = UUID.randomUUID().toString() + UUID.randomUUID();
+    String tokenHash = hashToken(rawToken);
+
+    logger.warn("PASSWORD RECOVERY TOKEN (DEV) - email: {}, token: {}", dto.email(), rawToken);
+
+    PasswordRecoveryToken passwordRecoveryToken = new PasswordRecoveryToken(
+        tokenHash,
+        user,
+        LocalDateTime.now().plusMinutes(PASSWORD_RECOVERY_EXPIRATION_MINUTES));
+
+    passwordRecoveryTokenRepository.save(passwordRecoveryToken);
+  }
+
+ @Override
+  @Transactional
+  public void resetPassword(PasswordResetDTO dto) {
+    if (!dto.newPassword().equals(dto.confirmPassword())) {
+      throw new AuthenticationException("As senhas não coincidem.");
+    }
+
+    String tokenHash = hashToken(dto.token());
+
+    PasswordRecoveryToken recoveryToken = passwordRecoveryTokenRepository.findByTokenHash(tokenHash)
+        .orElseThrow(() -> new AuthenticationException("Token inválido."));
+
+    if (recoveryToken.isUsed()) {
+      throw new AuthenticationException("Token já utilizado.");
+    }
+
+    if (recoveryToken.getExpiresAt().isBefore(LocalDateTime.now())) {
+      throw new AuthenticationException("Token expirado.");
+    }
+
+    User user = recoveryToken.getUser();
+    String encodedPassword = passwordEncoder.encode(dto.newPassword());
+
+    user.updatePassword(encodedPassword);
+    userService.save(user);
+
+    recoveryToken.markAsUsed();
+    passwordRecoveryTokenRepository.save(recoveryToken);
+  }
+
+  private String hashToken(String rawToken) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hashBytes = digest.digest(rawToken.getBytes(StandardCharsets.UTF_8));
+      return HexFormat.of().formatHex(hashBytes);
+    } catch (Exception e) {
+      throw new AuthenticationException("Erro ao processar token de recuperação.", e);
     }
   }
 }

--- a/apps/api/src/main/java/br/org/apae/api/auth/application/internal/UserService.java
+++ b/apps/api/src/main/java/br/org/apae/api/auth/application/internal/UserService.java
@@ -1,5 +1,6 @@
 package br.org.apae.api.auth.application.internal;
 
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 import org.springframework.stereotype.Service;
@@ -44,5 +45,13 @@ public class UserService {
     }
 
     throw new UserNotFoundException();
+  }
+
+  public Optional<User> findUserByEmail(String email) {
+    return userRepository.findByEmail(email);
+  }
+
+  public User save(User user) {
+    return userRepository.save(user);
   }
 }

--- a/apps/api/src/main/java/br/org/apae/api/auth/domain/exceptions/AuthenticationException.java
+++ b/apps/api/src/main/java/br/org/apae/api/auth/domain/exceptions/AuthenticationException.java
@@ -1,13 +1,21 @@
 package br.org.apae.api.auth.domain.exceptions;
 
 public class AuthenticationException extends RuntimeException {
-  private static final String MESSAGE = "Falha na autenticação.";
+  private static final String DEFAULT_MESSAGE = "Falha na autenticação.";
 
   public AuthenticationException() {
-    super(MESSAGE);
+    super(DEFAULT_MESSAGE);
+  }
+
+  public AuthenticationException(String message) {
+    super(message);
   }
 
   public AuthenticationException(Throwable cause) {
-    super(MESSAGE, cause);
+    super(DEFAULT_MESSAGE, cause);
+  }
+
+  public AuthenticationException(String message, Throwable cause) {
+    super(message, cause);
   }
 }

--- a/apps/api/src/main/java/br/org/apae/api/auth/domain/model/PasswordRecoveryToken.java
+++ b/apps/api/src/main/java/br/org/apae/api/auth/domain/model/PasswordRecoveryToken.java
@@ -1,0 +1,82 @@
+package br.org.apae.api.auth.domain.model;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "password_recovery_token")
+public class PasswordRecoveryToken {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private UUID id;
+
+  @Column(name = "token_hash", nullable = false, unique = true)
+  private String tokenHash;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @Column(name = "expires_at", nullable = false)
+  private LocalDateTime expiresAt;
+
+  @Column(nullable = false)
+  private boolean used;
+
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt;
+
+  @Column(name = "used_at")
+  private LocalDateTime usedAt;
+
+  protected PasswordRecoveryToken() {
+  }
+
+  public PasswordRecoveryToken(String tokenHash, User user, LocalDateTime expiresAt) {
+    this.tokenHash = tokenHash;
+    this.user = user;
+    this.expiresAt = expiresAt;
+    this.used = false;
+  }
+
+  @PrePersist
+  public void prePersist() {
+    this.createdAt = LocalDateTime.now();
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public String getTokenHash() {
+    return tokenHash;
+  }
+
+  public User getUser() {
+    return user;
+  }
+
+  public LocalDateTime getExpiresAt() {
+    return expiresAt;
+  }
+
+  public boolean isUsed() {
+    return used;
+  }
+
+  public LocalDateTime getCreatedAt() {
+    return createdAt;
+  }
+
+  public LocalDateTime getUsedAt() {
+    return usedAt;
+  }
+
+  public void markAsUsed() {
+    this.used = true;
+    this.usedAt = LocalDateTime.now();
+  }
+}

--- a/apps/api/src/main/java/br/org/apae/api/auth/domain/model/User.java
+++ b/apps/api/src/main/java/br/org/apae/api/auth/domain/model/User.java
@@ -83,6 +83,10 @@ public class User implements UserDetails {
     return fullName;
   }
 
+  public void updatePassword(String password) {
+    this.password = password;
+  }
+
   @Override
   public Collection<? extends GrantedAuthority> getAuthorities() {
     return role == UserRole.ADMIN

--- a/apps/api/src/main/java/br/org/apae/api/auth/domain/repository/PasswordRecoveryTokenRepository.java
+++ b/apps/api/src/main/java/br/org/apae/api/auth/domain/repository/PasswordRecoveryTokenRepository.java
@@ -1,0 +1,12 @@
+package br.org.apae.api.auth.domain.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import br.org.apae.api.auth.domain.model.PasswordRecoveryToken;
+
+public interface PasswordRecoveryTokenRepository extends JpaRepository<PasswordRecoveryToken, UUID> {
+  Optional<PasswordRecoveryToken> findByTokenHash(String tokenHash);
+}

--- a/apps/api/src/main/java/br/org/apae/api/auth/exceptions/AuthExceptionHandler.java
+++ b/apps/api/src/main/java/br/org/apae/api/auth/exceptions/AuthExceptionHandler.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import br.org.apae.api.notification.domain.exceptions.EmailSendingException;
 
 import br.org.apae.api.auth.domain.exceptions.AuthenticationException;
 import br.org.apae.api.auth.domain.exceptions.InvalidPasswordException;
@@ -75,5 +76,15 @@ public class AuthExceptionHandler {
         ex.getMessage(),
         request.getRequestURI());
     return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler(EmailSendingException.class)
+  public ResponseEntity<ErrorResponse> handleEmailSending(EmailSendingException ex, HttpServletRequest request) {
+    ErrorResponse error = new ErrorResponse(
+        HttpStatus.INTERNAL_SERVER_ERROR.value(),
+        HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(),
+        ex.getMessage(),
+        request.getRequestURI());
+    return new ResponseEntity<>(error, HttpStatus.INTERNAL_SERVER_ERROR);
   }
 }

--- a/apps/api/src/main/java/br/org/apae/api/auth/interfaces/controllers/AuthController.java
+++ b/apps/api/src/main/java/br/org/apae/api/auth/interfaces/controllers/AuthController.java
@@ -5,8 +5,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import br.org.apae.api.common.dto.auth.request.PasswordRecoveryRequestDTO;
+import br.org.apae.api.common.dto.auth.request.PasswordResetDTO;
 import br.org.apae.api.common.dto.auth.request.SignInDTO;
 import br.org.apae.api.common.dto.auth.request.SignUpDTO;
+import br.org.apae.api.common.dto.auth.response.MessageResponseDTO;
 import br.org.apae.api.common.dto.auth.response.TokenResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -25,4 +28,18 @@ public interface AuthController {
   @ApiResponse(responseCode = "401", description = "Credenciais inválidas")
   @PostMapping("/signin")
   ResponseEntity<TokenResponseDTO> signIn(@Valid @RequestBody SignInDTO signInDto);
+
+  @Operation(summary = "Solicita recuperação de senha", description = "Recebe o e-mail do usuário e inicia o fluxo de recuperação.")
+  @ApiResponse(responseCode = "200", description = "Solicitação processada com sucesso")
+  @ApiResponse(responseCode = "400", description = "Dados inválidos")
+  @PostMapping("/password-recovery/request")
+  ResponseEntity<MessageResponseDTO> requestPasswordRecovery(
+      @Valid @RequestBody PasswordRecoveryRequestDTO dto);
+
+  @Operation(summary = "Redefine a senha", description = "Valida o token de recuperação e redefine a senha do usuário.")
+  @ApiResponse(responseCode = "200", description = "Senha redefinida com sucesso")
+  @ApiResponse(responseCode = "400", description = "Token inválido ou senha inválida")
+  @PostMapping("/password-recovery/reset")
+  ResponseEntity<MessageResponseDTO> resetPassword(
+      @Valid @RequestBody PasswordResetDTO dto);
 }

--- a/apps/api/src/main/java/br/org/apae/api/common/dto/auth/request/PasswordRecoveryRequestDTO.java
+++ b/apps/api/src/main/java/br/org/apae/api/common/dto/auth/request/PasswordRecoveryRequestDTO.java
@@ -1,0 +1,10 @@
+package br.org.apae.api.common.dto.auth.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record PasswordRecoveryRequestDTO(
+    @NotBlank(message = "E-mail é obrigatório.")
+    @Email(message = "E-mail inválido.")
+    String email) {
+}

--- a/apps/api/src/main/java/br/org/apae/api/common/dto/auth/request/PasswordResetDTO.java
+++ b/apps/api/src/main/java/br/org/apae/api/common/dto/auth/request/PasswordResetDTO.java
@@ -1,0 +1,16 @@
+package br.org.apae.api.common.dto.auth.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record PasswordResetDTO(
+    @NotBlank(message = "Token é obrigatório.")
+    String token,
+
+    @NotBlank(message = "Nova senha é obrigatória.")
+    @Size(min = 8, message = "A senha deve ter no mínimo 8 caracteres.")
+    String newPassword,
+
+    @NotBlank(message = "Confirmação de senha é obrigatória.")
+    String confirmPassword) {
+}

--- a/apps/api/src/main/java/br/org/apae/api/common/dto/auth/response/MessageResponseDTO.java
+++ b/apps/api/src/main/java/br/org/apae/api/common/dto/auth/response/MessageResponseDTO.java
@@ -1,0 +1,4 @@
+package br.org.apae.api.common.dto.auth.response;
+
+public record MessageResponseDTO(String message) {
+}

--- a/apps/api/src/main/java/br/org/apae/api/controllers/auth/AuthControllerImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/controllers/auth/AuthControllerImpl.java
@@ -2,12 +2,16 @@ package br.org.apae.api.controllers.auth;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 
 import br.org.apae.api.auth.application.interfaces.AuthApplicationService;
 import br.org.apae.api.auth.interfaces.controllers.AuthController;
+import br.org.apae.api.common.dto.auth.request.PasswordRecoveryRequestDTO;
+import br.org.apae.api.common.dto.auth.request.PasswordResetDTO;
 import br.org.apae.api.common.dto.auth.request.SignInDTO;
 import br.org.apae.api.common.dto.auth.request.SignUpDTO;
+import br.org.apae.api.common.dto.auth.response.MessageResponseDTO;
 import br.org.apae.api.common.dto.auth.response.TokenResponseDTO;
 import jakarta.validation.Valid;
 
@@ -29,5 +33,20 @@ public class AuthControllerImpl implements AuthController {
   public ResponseEntity<TokenResponseDTO> signIn(@Valid @RequestBody SignInDTO signInDto) {
     TokenResponseDTO tokenResponse = authService.signIn(signInDto);
     return ResponseEntity.ok(tokenResponse);
+  }
+
+  @Override
+  public ResponseEntity<MessageResponseDTO> requestPasswordRecovery(
+      @Valid @RequestBody PasswordRecoveryRequestDTO dto) {
+    authService.requestPasswordRecovery(dto);
+    return ResponseEntity.ok(
+        new MessageResponseDTO("Se o e-mail estiver cadastrado, as instruções de recuperação foram enviadas."));
+  }
+
+  @Override
+  public ResponseEntity<MessageResponseDTO> resetPassword(
+      @Valid @RequestBody PasswordResetDTO dto) {
+    authService.resetPassword(dto);
+    return ResponseEntity.ok(new MessageResponseDTO("Senha redefinida com sucesso."));
   }
 }

--- a/apps/api/src/main/java/br/org/apae/api/notification/domain/exceptions/EmailSendingException.java
+++ b/apps/api/src/main/java/br/org/apae/api/notification/domain/exceptions/EmailSendingException.java
@@ -1,0 +1,21 @@
+package br.org.apae.api.notification.domain.exceptions;
+
+public class EmailSendingException extends RuntimeException {
+  private static final String DEFAULT_MESSAGE = "Erro ao enviar e-mail.";
+
+  public EmailSendingException() {
+    super(DEFAULT_MESSAGE);
+  }
+
+  public EmailSendingException(String message) {
+    super(message);
+  }
+
+  public EmailSendingException(Throwable cause) {
+    super(DEFAULT_MESSAGE, cause);
+  }
+
+  public EmailSendingException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/apps/api/src/main/java/br/org/apae/api/notification/domain/interfaces/EmailSender.java
+++ b/apps/api/src/main/java/br/org/apae/api/notification/domain/interfaces/EmailSender.java
@@ -1,0 +1,7 @@
+package br.org.apae.api.notification.domain.interfaces;
+
+import br.org.apae.api.notification.domain.model.EmailMessage;
+
+public interface EmailSender {
+  void send(EmailMessage emailMessage);
+}

--- a/apps/api/src/main/java/br/org/apae/api/notification/domain/model/EmailMessage.java
+++ b/apps/api/src/main/java/br/org/apae/api/notification/domain/model/EmailMessage.java
@@ -1,0 +1,27 @@
+package br.org.apae.api.notification.domain.model;
+
+import java.util.List;
+
+public class EmailMessage {
+  private final List<String> to;
+  private final String subject;
+  private final String body;
+
+  public EmailMessage(List<String> to, String subject, String body) {
+    this.to = to;
+    this.subject = subject;
+    this.body = body;
+  }
+
+  public List<String> getTo() {
+    return to;
+  }
+
+  public String getSubject() {
+    return subject;
+  }
+
+  public String getBody() {
+    return body;
+  }
+}

--- a/apps/api/src/main/java/br/org/apae/api/notification/infrastructure/email/SmtpEmailSender.java
+++ b/apps/api/src/main/java/br/org/apae/api/notification/infrastructure/email/SmtpEmailSender.java
@@ -1,0 +1,62 @@
+package br.org.apae.api.notification.infrastructure.email;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import br.org.apae.api.notification.domain.exceptions.EmailSendingException;
+import br.org.apae.api.notification.domain.interfaces.EmailSender;
+import br.org.apae.api.notification.domain.model.EmailMessage;
+
+@Service
+public class SmtpEmailSender implements EmailSender {
+
+  private static final Logger logger = LoggerFactory.getLogger(SmtpEmailSender.class);
+
+  private final JavaMailSender mailSender;
+
+  @Value("${spring.mail.host:}")
+  private String mailHost;
+
+  @Value("${spring.mail.port:0}")
+  private int mailPort;
+
+  @Value("${spring.mail.username:}")
+  private String mailUsername;
+
+  @Value("${spring.mail.password:}")
+  private String mailPassword;
+
+  public SmtpEmailSender(JavaMailSender mailSender) {
+    this.mailSender = mailSender;
+  }
+
+  @Override
+  public void send(EmailMessage emailMessage) {
+    if (!isConfigured()) {
+      logger.info("SMTP não configurado. Envio de e-mail ignorado.");
+      return;
+    }
+
+    try {
+      SimpleMailMessage message = new SimpleMailMessage();
+      message.setTo(emailMessage.getTo().toArray(new String[0]));
+      message.setSubject(emailMessage.getSubject());
+      message.setText(emailMessage.getBody());
+
+      mailSender.send(message);
+    } catch (Exception e) {
+      throw new EmailSendingException("Não foi possível enviar o e-mail de recuperação de senha.", e);
+    }
+  }
+
+  private boolean isConfigured() {
+    return mailHost != null && !mailHost.isBlank()
+        && mailPort > 0
+        && mailUsername != null && !mailUsername.isBlank()
+        && mailPassword != null && !mailPassword.isBlank();
+  }
+}

--- a/apps/api/src/main/resources/application.yaml
+++ b/apps/api/src/main/resources/application.yaml
@@ -27,6 +27,18 @@ spring:
       max-file-size: 10MB
       max-request-size: 50MB
 
+  mail:
+    host: ${MAIL_HOST:}
+    port: ${MAIL_PORT:0}
+    username: ${MAIL_USERNAME:}
+    password: ${MAIL_PASSWORD:}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 logging:
   level:
     org:
@@ -40,6 +52,8 @@ logging:
 app:
   token:
     secret: "U29tZVNlY3JldEF0TGVhc3QtMjU2Qml0cw=="
+  frontend:
+    reset-password-url: ${APP_FRONTEND_RESET_PASSWORD_URL:http://localhost:3000/reset-password}
 
 minio:
   access:


### PR DESCRIPTION
### O que foi feito inicialmente

-   Criação dos endpoints:
    -   `POST /auth/password-recovery/request`
    -   `POST /auth/password-recovery/reset`
-   Geração de token seguro
-   Persistência do token (hash) no banco
-   Definição de expiração
-   Marcação de token como utilizado

------------------------------------------------------------------------

###  Segurança

-   Token armazenado como hash
-   Token com tempo de expiração
-   Token real utilizado apenas na validação

------------------------------------------------------------------------

###  Estratégia de teste

Nesta fase, o envio de e-mail foi simulado via **logger**, permitindo:

-   Testar o fluxo sem SMTP
-   Visualizar o token diretamente no console

------------------------------------------------------------------------

### Limitações

-   Não há envio real de e-mails
-   Token visível apenas no log (ambiente dev)


---------------------------------------------------------------------

###  O que foi feito a partir da criação da #535 

####  Mecanismo de e-mail

-   Interface `EmailSender`
-   Modelo `EmailMessage`
-   Implementação `SmtpEmailSender`
-   Exceção `EmailSendingException`

------------------------------------------------------------------------

####  Integração com recovery

-   Remoção do logger de token
-   Envio de link de redefinição:

    http://localhost:3000/reset-password?token=...

------------------------------------------------------------------------

####  Variáveis de ambiente

``` env
MAIL_HOST
MAIL_PORT
MAIL_USERNAME
MAIL_PASSWORD
APP_FRONTEND_RESET_PASSWORD_URL
```

------------------------------------------------------------------------

####  Comportamento

-   Sem `.env`: sistema funciona sem envio de e-mail
-   Com `.env`: envio de e-mail habilitado

------------------------------------------------------------------------

###  Segurança

-   Credenciais fora do código
-   Uso de `.env`
-   Token continua sendo armazenado como hash