### PR TITLE
[Refactor] Retirando cards de informacoes completas do agendamento

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_issue.md
+++ b/.github/ISSUE_TEMPLATE/new_issue.md
@@ -25,6 +25,8 @@ Descreva o que se espera como solução ou melhoria.
 * [ ] {critério_1}
 * [ ] {critério_2}
 * [ ] {critério_3}
+* [ ] {critério_4}
+
 
 ## Artefatos
 

--- a/.github/ISSUE_TEMPLATE/new_issue.md
+++ b/.github/ISSUE_TEMPLATE/new_issue.md
@@ -25,7 +25,6 @@ Descreva o que se espera como solução ou melhoria.
 * [ ] {critério_1}
 * [ ] {critério_2}
 * [ ] {critério_3}
-* [ ] {critério_4}
 
 
 ## Artefatos

--- a/apps/apae/src/app/appointments/today/[id]/page.tsx
+++ b/apps/apae/src/app/appointments/today/[id]/page.tsx
@@ -74,7 +74,7 @@ export default function ViewTodayAppointment() {
         </Badge>
       </header>
 
-      {/* AGENDAMENTO */}
+      {/* AGENDAMENTO GERADO */}
       <Card className="border border-blue-100">
         <CardHeader>
           <CardTitle className="text-center text-[#0D4F97]">
@@ -102,75 +102,6 @@ export default function ViewTodayAppointment() {
           <div className="space-y-2">
             <p><strong>Data:</strong> {format(new Date(appointment.effectiveDateTime), 'dd/MM/yyyy')}</p>
             <p><strong>Horário:</strong> {format(new Date(appointment.effectiveDateTime), 'HH:mm')}</p>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* PROFISSIONAL */}
-      <Card className="border border-blue-100">
-        <CardHeader>
-          <CardTitle className="text-center text-[#0D4F97]">
-            Profissional da Saúde
-          </CardTitle>
-        </CardHeader>
-
-        <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-6 text-sm text-[#0D4F97]">
-          <div className="space-y-2">
-            <p><strong>Nome:</strong> {appointment.professional.name}</p>
-            <p><strong>Email:</strong> {appointment.professional.email || '—'}</p>
-            <p><strong>Telefone:</strong> {appointment.professional.phoneNumber || '—'}</p>
-          </div>
-
-          <div className="space-y-2">
-            <p><strong>Documento médico:</strong> {appointment.professional.professionalDocument || '—'}</p>
-            <p><strong>RG:</strong> {appointment.professional.identityDocument || '—'}</p>
-            <p><strong>Cidade:</strong> {appointment.professional.address?.city || '—'}</p>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* PACIENTE */}
-      <Card className="border border-blue-100">
-        <CardHeader>
-          <CardTitle className="text-center text-[#0D4F97]">
-            Dados do Paciente
-          </CardTitle>
-        </CardHeader>
-
-        <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-6 text-sm text-[#0D4F97]">
-          <div className="space-y-2">
-            <p><strong>CPF:</strong> {appointment.patient.cpf || '—'}</p>
-            <p><strong>RG:</strong> {appointment.patient.rg || '—'}</p>
-            <p><strong>Contato:</strong> {appointment.patient.contact || '—'}</p>
-          </div>
-
-          <div className="space-y-2">
-            <p><strong>NIS:</strong> {appointment.patient.birthDate || '—'}</p>
-            <p><strong>Alergias:</strong> {appointment.patient.allergies || '—'}</p>
-            <p><strong>Estudante:</strong> {appointment.patient.isStudent ? 'Sim' : 'Não'}</p>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* ENDEREÇO */}
-      <Card className="border border-blue-100">
-        <CardHeader>
-          <CardTitle className="text-center text-[#0D4F97]">
-            Dados Residenciais
-          </CardTitle>
-        </CardHeader>
-
-        <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-6 text-sm text-[#0D4F97]">
-          <div className="space-y-2">
-            <p><strong>Rua:</strong> {appointment.patient.address?.street || '—'}</p>
-            <p><strong>Número:</strong> {appointment.patient.address?.number || '—'}</p>
-            <p><strong>Bairro:</strong> {appointment.patient.address?.neighborhood || '—'}</p>
-          </div>
-
-          <div className="space-y-2">
-            <p><strong>Cidade:</strong> {appointment.patient.address?.city || '—'}</p>
-            <p><strong>Estado:</strong> {appointment.patient.address?.state || '—'}</p>
-            <p><strong>CEP:</strong> {appointment.patient.address?.cep || '—'}</p>
           </div>
         </CardContent>
       </Card>


### PR DESCRIPTION
# O que mudou?

Foi removido os cards referentes ao agendamento completo, referentes aos campos de Profissional da saude, dados do paciente e Dados Residenciais.

## Tarefas Relacionadas

* Issue: #505 

## Mudanças Realizadas

* Remocao dos cards de agendamento

## Evidências


**Detalhes do Agendamento do Dia:**

<img width="1440" height="900" alt="Captura de Tela 2026-03-22 às 18 12 10" src="https://github.com/user-attachments/assets/8efb67cc-ec2d-485d-976f-5856b897e422" />

**Detalhes da pagina de todos os agendamentos:**

<img width="1440" height="900" alt="Captura de Tela 2026-03-22 às 18 13 06" src="https://github.com/user-attachments/assets/be29bb5d-358d-42cc-93dc-501cd97c2889" />


