### PR TITLE
feat(auth): adiciona suporte a CPF na validação do campo de login

### DIFF
--- a/apps/apae/src/schemas/authSchema.ts
+++ b/apps/apae/src/schemas/authSchema.ts
@@ -50,16 +50,18 @@ export const loginSchema = z.object({
     .trim()
     .refine(
       (value) => {
-        const isEmail = z.email().safeParse(value).success;
-        return isEmail;
+        const isEmail = z.string().email().safeParse(value).success;
+        const isCpf = cpfSchema.safeParse(value).success;
+
+        return isEmail || isCpf;
       },
       {
-        message: "Digite um email válido",
+        message: "Digite um email ou CPF válido.",
       }
     ),
   password: z
     .string()
-    .min(6, { message: "Senha deve ter pelo menos 6 caracteres" }),
+    .min(6, { message: "Senha deve ter pelo menos 6 caracteres." }),
 });
 
 export type FormLogin = z.infer<typeof loginSchema>;


### PR DESCRIPTION
## O que mudou?
A validação do campo de login foi ajustada para aceitar tanto e-mail quanto CPF, conforme indicado na interface de login.

Antes, o sistema validava apenas e-mails, impedindo que usuários utilizassem CPF para autenticação.

Agora, o campo `username` aceita:
- E-mail válido
- CPF válido (via `cpfSchema`)

## Tarefas Relacionadas
Issue: https://github.com/IFPBEsp/APAE/issues/539

## Mudanças Realizadas
- Atualizada validação do campo `username` para aceitar CPF ou e-mail
- Integração com `cpfSchema` para validação de CPF
- Ajustada mensagem de erro para contemplar ambos os formatos
