### PR TITLE
Ajuste na seção 'Parentes', retirando a nomeação 'mãe' que estava como padrão

### DIFF
--- a/apps/apae/src/app/person/[id]/page.tsx
+++ b/apps/apae/src/app/person/[id]/page.tsx
@@ -252,9 +252,10 @@ export default function PersonDetailsPage() {
             )}
             {pessoa.parents?.map((parent: any) => (
               <div key={parent.id} className="mb-2 p-2 border-t border-gray-200">
-                <p className="font-bold text-base">{parent.kinship === "PAI" ? "Pai" : "Mãe"}</p>
+                <p className="font-bold text-base">Parentes</p>
                 <InfoRow label="Nome" value={parent.name} />
                 <InfoRow label="CPF" value={parent.cpf} />
+                <InfoRow label="Parentesco" value={parent.kinship}/>
                 <InfoRow label="Profissão" value={parent.profession} />
                 <InfoRow label="Vivo?" value={parent.isAlive} />
               </div>


### PR DESCRIPTION
**O que foi feito?**

Com base na descrição da issue, foi alterado a page.ts do caminho: app -> person -> [id] -> page.ts.

Realizando a adição do título "Parentes" e campo "Parentesco" na seção de descrição e exibição dos parentes adicionado no cadastro de pessoas.

<img width="1894" height="856" alt="Captura de tela 2026-03-23 222508" src="https://github.com/user-attachments/assets/3fea224c-4ee7-4dff-bed5-403e5479db3c" />

<img width="830" height="264" alt="Captura de tela 2026-03-23 222528" src="https://github.com/user-attachments/assets/bfc77e61-318a-46e7-a040-20f4a19764f5" />
