### PR TITLE
[Fix] tratamento de erro ao excluir vacinas e transtornos em uso

### DIFF
--- a/apps/apae/src/app/disorders/page.tsx
+++ b/apps/apae/src/app/disorders/page.tsx
@@ -48,13 +48,17 @@ export default function TranstornosPage() {
       const response = await fetch(`/api/transtornos/${id}`, {
         method: "DELETE",
       });
+      
       if (!response.ok) {
-        throw new Error("Falha ao excluir o transtorno.");
+        const errorData = await response.json().catch(() => null);
+        
+        throw new Error(errorData?.message || "Falha ao excluir o transtorno.");
       }
+      
       setTranstornos((current) => current.filter((d) => d.id !== id));
       toast.success("Transtorno excluído com sucesso!");
     } catch (err: any) {
-      toast.error(err.message);
+      toast.error(err.message); 
     }
   };
   const filteredTranstornos = transtornos.filter((transtorno) =>

--- a/apps/apae/src/app/vaccines/page.tsx
+++ b/apps/apae/src/app/vaccines/page.tsx
@@ -68,9 +68,6 @@ function VaccinesList() {
         );
     }
 
-    if (feedback.error) {
-        return <p className="text-center text-red-500">{feedback.message}</p>;
-    }
 
     if (vaccines.length === 0) {
         return (

--- a/apps/apae/src/hooks/use-disorders.tsx
+++ b/apps/apae/src/hooks/use-disorders.tsx
@@ -193,7 +193,8 @@ function DisordersProvider({
         });
 
         if (!response.ok) {
-          throw new Error("Ocorreu um erro ao excluir transtorno.");
+          const errorData = await response.json().catch(() => null);
+          throw new Error(errorData?.message || "Ocorreu um erro ao excluir transtorno.");
         }
 
         fetchDisorders();

--- a/apps/apae/src/hooks/use-vaccines.tsx
+++ b/apps/apae/src/hooks/use-vaccines.tsx
@@ -78,7 +78,7 @@ function withFeedback<TArgs extends readonly unknown[], TReturn>(
                 success: false,
                 error: true,
             });
-            throw error;
+
         } finally {
             setLoading(false);
         }
@@ -194,7 +194,8 @@ function VaccinesProvider({
                 });
 
                 if (!response.ok) {
-                    throw new Error("Ocorreu um erro ao excluir vacina.");
+                    const errorData = await response.json().catch(() => null);
+                    throw new Error(errorData?.message || "Ocorreu um erro ao excluir a vacina.");
                 }
 
                 fetchVaccines();

--- a/apps/api/src/main/java/br/org/apae/api/patient/application/internal/DisorderApplicationServiceImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/application/internal/DisorderApplicationServiceImpl.java
@@ -6,7 +6,9 @@ import br.org.apae.api.common.dto.patient.response.disorder.DisorderResponseDTO;
 import br.org.apae.api.patient.application.interfaces.DisorderApplicationService;
 import br.org.apae.api.patient.application.mappers.DisorderMapper;
 import br.org.apae.api.patient.domain.exceptions.DisorderConflictException;
+import br.org.apae.api.patient.domain.exceptions.DisorderInUseException;
 import br.org.apae.api.patient.domain.exceptions.DisorderNotFoundException;
+import org.springframework.dao.DataIntegrityViolationException;
 import br.org.apae.api.patient.domain.model.Disorder;
 import br.org.apae.api.patient.domain.repository.DisorderRepository;
 import org.springframework.stereotype.Service;
@@ -97,8 +99,16 @@ public class DisorderApplicationServiceImpl implements DisorderApplicationServic
     @Override
     @Transactional
     public void deleteDisorder(UUID id) {
-        Disorder disorder = findDisorderOrThrow(id);
-        repository.delete(disorder);
+        if (!repository.existsById(id)) {
+            throw new DisorderNotFoundException();
+        }
+
+        try {
+            repository.deleteById(id);
+            repository.flush();
+        } catch (DataIntegrityViolationException e) {
+            throw new DisorderInUseException();
+        }
     }
 
     private Disorder findDisorderOrThrow(UUID id) {

--- a/apps/api/src/main/java/br/org/apae/api/patient/application/internal/VaccineApplicationServiceImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/application/internal/VaccineApplicationServiceImpl.java
@@ -1,12 +1,16 @@
 package br.org.apae.api.patient.application.internal;
 
 import br.org.apae.api.patient.domain.exceptions.VaccineConflictException;
+import br.org.apae.api.patient.domain.exceptions.VaccineInUseException;
 import br.org.apae.api.patient.domain.exceptions.VaccineMismatchException;
 import br.org.apae.api.patient.domain.exceptions.VaccineNotFoundException;
 import br.org.apae.api.patient.domain.model.Vaccine;
 import br.org.apae.api.patient.domain.repository.VaccineRepository;
 import br.org.apae.api.common.dto.patient.request.vaccine.CreateVaccineDTO;
 import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -135,6 +139,15 @@ public class VaccineApplicationServiceImpl implements VaccineApplicationService 
         if (!vaccineRepository.existsById(id)) {
             throw new VaccineNotFoundException();
         }
-        vaccineRepository.deleteById(id);
+
+        try {
+            vaccineRepository.deleteById(id);
+            // Oculto, mas poderoso: o flush() obriga o Spring a testar a deleção no banco AGORA,
+            // permitindo que o catch capture o erro de integridade se o banco recusar!
+            vaccineRepository.flush();
+        } catch (DataIntegrityViolationException e) {
+            // Adeus, gambiarra! Olá, código limpo e com semântica.
+            throw new VaccineInUseException();
+        }
     }
 }

--- a/apps/api/src/main/java/br/org/apae/api/patient/domain/exceptions/DisorderInUseException.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/domain/exceptions/DisorderInUseException.java
@@ -1,0 +1,9 @@
+package br.org.apae.api.patient.domain.exceptions;
+
+public class DisorderInUseException extends RuntimeException {
+    private static final String MESSAGE = "Não é possível excluir este transtorno, pois ele está vinculado a um ou mais pacientes.";
+
+    public DisorderInUseException() {
+        super(MESSAGE);
+    }
+}

--- a/apps/api/src/main/java/br/org/apae/api/patient/domain/exceptions/VaccineInUseException.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/domain/exceptions/VaccineInUseException.java
@@ -1,0 +1,9 @@
+package br.org.apae.api.patient.domain.exceptions;
+
+public class VaccineInUseException extends RuntimeException {
+    private static final String MESSAGE = "Não é possível excluir esta vacina, pois ela está vinculada a um ou mais pacientes.";
+
+    public VaccineInUseException() {
+        super(MESSAGE);
+    }
+}


### PR DESCRIPTION
## O que mudou?
Este PR resolve o problema que ocorria ao tentar excluir vacinas ou transtornos que já estavam vinculados a pacientes cadastrados. 

Anteriormente, a violação de chave estrangeira no banco de dados gerava um Erro 500 no back-end. Isso fazia o front-end exibir mensagens genéricas e, no caso das vacinas, causava um erro de renderização que ocultava a tabela da tela. O fluxo foi corrigido de ponta a ponta para exibir notificações amigáveis (Toasts) sem quebrar a interface.

## Tarefas Relacionadas
- Resolves #508

## Mudanças Realizadas
**Back-end (Spring Boot):**
- Criação das exceções `VaccineInUseException` e `DisorderInUseException` para retornar o status HTTP 409 (Conflict).
- Adição de `try-catch` capturando `DataIntegrityViolationException` em `VaccineApplicationServiceImpl` e `DisorderApplicationServiceImpl`.
- Utilização do `.flush()` nos repositórios para forçar a execução e capturar a violação de integridade em tempo real.

**Front-end (React/Next.js):**
- Atualização do parse de erros nas requisições `DELETE` para ler corretamente o `errorData.message` enviado pela API.
- Remoção do `throw error` em `withFeedback` que causava "Uncaught Promise Rejections".
- Remoção da renderização condicional na página de Vacinas que destruía o componente da tabela ao receber um erro, mantendo a listagem intacta.


https://github.com/user-attachments/assets/86ba1751-e1b8-40f4-a978-9b6e31a18a8d

