### PR TITLE
581 padronizar exibição dos tipos de documentos médicos em português

### DIFF
--- a/apps/apae/src/app/person/[id]/documents/[type]/page.tsx
+++ b/apps/apae/src/app/person/[id]/documents/[type]/page.tsx
@@ -7,6 +7,23 @@ import { Button } from "@/components/ui/button";
 import FileCard from "@/components/fileCard";
 import { toast } from "react-toastify";
 
+const documentTypeTranslations: Record<string, string> = {
+  MEDICAL_REPORT: "Laudo Médico",
+  REFERRAL: "Encaminhamento",
+  PRESCRIPTION: "Receita Médica",
+  EXAM: "Exame",
+  VACCINE_CARD: "Cartão de Vacina",
+  PERSONAL_DOCUMENT: "Documento Pessoal",
+  SCHOOL_DOCUMENT: "Documento Escolar",
+  PHOTO: "Foto",
+};
+
+const translateDocumentType = (typeOrName: string) => {
+  if (!typeOrName) return "Documento";
+  const cleanType = typeOrName.split(".")[0];
+  return documentTypeTranslations[cleanType] || cleanType;
+};
+
 export interface FileItem {
   id: string;
   name: string;
@@ -99,16 +116,18 @@ export default function DocumentTypePage() {
         <h1 className="text-xl font-bold whitespace-nowrap">{pageTitle}</h1>
       </div>
 
-      {/* --- Lista de Arquivos --- */}
+     {/* --- Lista de Arquivos --- */}
       <div className="grid grid-cols-2 lg:grid-cols-6 gap-4 mt-4">
         {files.length === 0 ? (
-          <p>Nenhum arquivo encontrado.</p>
+          <p className="col-span-full text-center text-gray-500">
+            Nenhum arquivo encontrado.
+          </p>
         ) : (
           files.map((file: FileItem) => (
             <FileCard
               key={file.id}
               file={{
-                fileName: file.name,
+                fileName: translateDocumentType(file.type || file.name),
                 link: file.url,
               }}
             />

--- a/apps/apae/src/app/person/[id]/documents/[type]/page.tsx
+++ b/apps/apae/src/app/person/[id]/documents/[type]/page.tsx
@@ -16,6 +16,8 @@ const documentTypeTranslations: Record<string, string> = {
   PERSONAL_DOCUMENT: "Documento Pessoal",
   SCHOOL_DOCUMENT: "Documento Escolar",
   PHOTO: "Foto",
+  EXAMINATION: "Exame", 
+  OTHER: "Outro",
 };
 
 const translateDocumentType = (typeOrName: string) => {

--- a/apps/apae/src/components/AnnualRegistryEditModal.tsx
+++ b/apps/apae/src/components/AnnualRegistryEditModal.tsx
@@ -44,6 +44,13 @@ const MEDICAL_DOC_TYPES = [
     { value: "OTHER", label: "Outro" }
 ];
 
+const docTypeTranslations: Record<string, string> = {
+    MEDICAL_REPORT: "Laudo Médico",
+    EXAMINATION: "Exame",
+    REFERRAL: "Encaminhamento",
+    OTHER: "Outro",
+    VACCINE_CARD: "Cartão de Vacina"
+};
 
 export default function AnnualRegistryEditModal({
                                                     isOpen,
@@ -471,7 +478,10 @@ export default function AnnualRegistryEditModal({
                                                         <div key={doc.id} className="group flex items-center justify-between p-3 bg-white border border-slate-100 rounded-xl shadow-sm hover:shadow-md hover:border-[#0D4F97]/20 transition-all duration-200">
                                                             <div className="flex items-center gap-3 overflow-hidden">
                                                                 <div className="bg-blue-50 p-2 rounded-lg group-hover:bg-[#0D4F97] group-hover:text-white transition-colors duration-300"><FileText className="h-4 w-4" /></div>
-                                                                <div className="flex flex-col min-w-0"><span className="text-sm font-semibold truncate text-slate-700 group-hover:text-[#0D4F97] transition-colors" title={doc.name}>{doc.name}</span><span className="text-[10px] text-slate-400 font-bold uppercase tracking-wide mt-0.5">{doc.type}</span></div>
+                                                                <div className="flex flex-col min-w-0">
+                                                                <span className="text-sm font-semibold truncate text-slate-700 group-hover:text-[#0D4F97] transition-colors" 
+                                                                title={doc.name}>{doc.name}</span>
+                                                                <span className="text-[10px] text-slate-400 font-bold uppercase tracking-wide mt-0.5">{docTypeTranslations[doc.type] || doc.type}</span></div>
                                                             </div>
                                                             {doc.url && (<a href={doc.url} target="_blank" rel="noreferrer" className="p-2 text-slate-400 hover:text-[#0D4F97] hover:bg-blue-50 rounded-full transition-all" title="Abrir em nova aba"><ExternalLink className="h-4 w-4" /></a>)}
                                                         </div>


### PR DESCRIPTION
Descrição
Traduzidos os termos técnicos dos tipos de documentos (ex: MEDICAL_REPORT, REFERRAL) para o português, visando uma melhor experiência do usuário e acessibilidade.

Alterações
- Adicionado dicionário de tradução `docTypeTranslations` nos componentes de listagem e no modal de edição de saúde.
- Aplicada a lógica de mapeamento para exibir os nomes amigáveis em português.

Evidências
<img width="546" height="185" alt="Captura de tela 2026-03-26 175729" src="https://github.com/user-attachments/assets/b0dcfd26-c5ed-4cf4-b19a-828fe7f9f0a4" />


