### PR TITLE
feat: implementa a criação do .env com base no .env.example

### DIFF
--- a/.scripts/run-app.sh
+++ b/.scripts/run-app.sh
@@ -7,8 +7,24 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 MAVEN_CMD="$ROOT_DIR/apps/api/mvnw"
 ENV_FILE="$ROOT_DIR/.env"
+ENV_EXAMPLE="$ROOT_DIR/.env.example"
+
+check_env_file() {
+  if [ ! -f "$ENV_FILE" ]; then
+    echo "[.env] Arquivo .env não encontrado"
+    if [ -f "$ENV_EXAMPLE" ]; then
+      echo "[.env] Criando .env a partir do .env.example"
+      cp "$ENV_EXAMPLE" "$ENV_FILE"
+      echo "[.env] Arquivo .env criado"
+    else
+      echo "[.env] Erro ao criar o .env, arquivo .env.example não encontrado"
+    fi
+  echo "[.env] Arquivo .env funcionando"
+  fi
+}
 
 load_env() {
+  check_env_file
   if [ -f "$ENV_FILE" ]; then
     echo "Carregando variáveis de ambiente de $ENV_FILE..."
     set -a

--- a/.scripts/run-app.sh
+++ b/.scripts/run-app.sh
@@ -19,7 +19,6 @@ check_env_file() {
     else
       echo "[.env] Erro ao criar o .env, arquivo .env.example não encontrado"
     fi
-  echo "[.env] Arquivo .env funcionando"
   fi
 }
 

--- a/README.md
+++ b/README.md
@@ -200,6 +200,15 @@ O Kanban é usado para organizar as **issues** no processo de desenvolvimento. A
 
 ## Configuração do Projeto
 
+### Configuração de Ambiente
+
+Este projeto automatiza a configuração inicial das variáveis de ambiente. 
+Ao rodar `pnpm dev`, o script verifica a existência do arquivo `.env`. 
+Caso ele não exista, uma cópia será criada automaticamente a partir do `.env.example`.
+
+**Nota:** O script nunca sobrescreverá um arquivo `.env` já existente. 
+Caso precise resetar as configurações, delete o `.env` manualmente, faça as modificações necessárias no .env.example e execute o comando novamente.
+
 ### Variáveis de Ambiente (Opcional)
 
 O projeto utiliza variáveis de ambiente para configurar serviços externos, como envio de e-mails (SMTP), banco de dados e integrações.


### PR DESCRIPTION
## O que mudou?
Foi criado a função check_env_file() no .scripts/run-app.sh no qual é verificado se o .env já existe no projeto ou não. Caso não exista, o .env é criado se baseando no formato do .env.example. O processo de criação do .env é iniciado com o comando de rodar o projeto `pnpm dev`. 

## Tarefas Relacionadas 
Issue: https://github.com/IFPBEsp/APAE/issues/589

## Mudanças Realizadas
- Criação da função check_env_file() no run-app.sh e sua implementação no load_env();
- Atualização no README.md com a explicação desse novo comportamento no projeto e observação para alterações no env.example.

 ## Evidências

https://github.com/user-attachments/assets/c23ce294-a59a-4d9e-8127-e37f57511156

