### PR TITLE
622 definir validação de 11 dígitos para o campo nis

### DIFF
--- a/apps/apae/src/app/person/[id]/page.tsx
+++ b/apps/apae/src/app/person/[id]/page.tsx
@@ -37,9 +37,9 @@ const InfoRow: React.FC<InfoRowProps> = ({ label, value }) => {
   }
 
   return (
-    <div className="mb-2">
+    <div className="mb-2 overflow-hidden"> 
       <span className="text-sm font-semibold text-gray-500">{label}</span>
-      <p className="text-base text-black">{displayValue}</p>
+      <p className="text-base text-black break-all">{displayValue}</p>
     </div>
   );
 };

--- a/apps/apae/src/app/person/register/personal/page.tsx
+++ b/apps/apae/src/app/person/register/personal/page.tsx
@@ -151,7 +151,10 @@ export default function MembersRegisterPersonalPage() {
               <FormItem>
                 <FormLabel>NIS *</FormLabel>
                 <FormControl>
-                  <Input placeholder="Digite o NIS" {...field} />
+                  <Input placeholder="Apenas 11 números" {...field}maxLength={11}onChange={(e) => {
+                    const value = e.target.value.replace(/\D/g, "");
+                    field.onChange(value);
+            }} />
                 </FormControl>
                 <FormMessage />
               </FormItem>

--- a/apps/apae/src/app/person/register/responsible/page.tsx
+++ b/apps/apae/src/app/person/register/responsible/page.tsx
@@ -21,6 +21,7 @@ import React, { useState, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { handleBackendValidationErrors } from "@/utils/form-errors";
 import { usePathname } from "next/navigation"; 
+import { formatPhone } from "@/lib/formats";
 
 import z from "zod";
 import { DoubleColumn, FormButton, MembersRegisterForm } from "../form";
@@ -124,8 +125,10 @@ export default function MembersRegisterGuardianPage() {
                 <FormLabel>Contato de Emergência *</FormLabel>
                 <FormControl>
                   <Input
-                    placeholder="Número de telefone, email e etc."
-                    {...field}
+                    placeholder="(00) 00000-0000"{...field}maxLength={15} onChange={(e) => {
+                      const formatted = formatPhone(e.target.value); 
+                      field.onChange(formatted);
+                  }}
                   />
                 </FormControl>
                 <FormMessage />

--- a/apps/apae/src/schemas/edit-member-schemas.ts
+++ b/apps/apae/src/schemas/edit-member-schemas.ts
@@ -22,7 +22,11 @@ export const EditPersonal = z.object({
     }),
   }),
   cns: z.string().optional().or(z.literal("")),
-  nis: z.string().optional().or(z.literal("")),
+  nis: z
+    .string()
+    .min(1, "NIS é obrigatório")
+    .length(11, "O NIS deve ter exatamente 11 dígitos")
+    .regex(/^\d+$/, "O NIS deve conter apenas números"),
   birth: z.object({
     certificate: z.string().min(1, "Obrigatório"),
     date: z.coerce.date() as any,

--- a/apps/apae/src/schemas/member-schemas.ts
+++ b/apps/apae/src/schemas/member-schemas.ts
@@ -18,9 +18,13 @@ const CNS = z
   .min(18, "CNS deve ter pelo menos 18 dígitos")
   .regex(/^\d{3} \d{4} \d{4} \d{4}$/, "Formato de CNS inválido");
 
-const NIS = z.string().min(1, "NIS é obrigatório");
+const NIS = z
+  .string()
+  .min(1, "NIS é obrigatório")
+  .length(11, "O NIS deve ter exatamente 11 dígitos") 
+  .regex(/^\d+$/, "O NIS deve conter apenas números");
 
-export const Personal = z
+  export const Personal = z
   .object({
     name: z
       .string()


### PR DESCRIPTION
Descrição
Garante que o campo NIS aceite exatamente 11 dígitos numéricos, evitando inconsistências no banco de dados e quebras no layout da tela de detalhes do paciente.

Alterações
- Frontend: Atualizados os schemas do Zod (`Personal` e `EditPersonal`) para exigir `.length(11)` no campo NIS.
- Frontend: Adicionada trava de `maxLength={11}` e filtro de apenas números no input do NIS.
- **UX:** Implementada máscara de telefone e limite de caracteres no contato do responsável para evitar overflow.
- **Layout:** Adicionada a classe CSS `break-all` no componente `InfoRow` para garantir que dados extensos não quebrem a estrutura dos cards de detalhes.

 Evidências
https://github.com/user-attachments/assets/f34d27e5-1de1-4a2c-a26e-1485fcba5466

