### PR TITLE
582 fix corrigir registro de faltas bug

### DIFF
--- a/apps/apae/src/app/page.tsx
+++ b/apps/apae/src/app/page.tsx
@@ -215,6 +215,15 @@ export default function DashboardPage() {
                         generatedAppointmentId={item.id}
                         absenceDate={format(selectedDate, 'yyyy-MM-dd')}
                         disabled={item.hasAbsence}
+                        onSuccess={() => {
+                          setTodayAppointments(prev =>
+                            prev.map(a =>
+                              a.id === item.id
+                                ? { ...a, hasAbsence: true }
+                                : a
+                            )
+                          )
+                        }}
                       />
                     </TableCell>
                   </TableRow>

--- a/apps/apae/src/components/buttons/RegistrarFaltaButton.tsx
+++ b/apps/apae/src/components/buttons/RegistrarFaltaButton.tsx
@@ -17,10 +17,6 @@ import { Textarea } from "@/components/ui/textarea";
 import { toast } from "react-toastify"
 import { useState } from "react";
 
-import { useRouter } from "next/navigation"
-
-
-
 interface RegistrarFaltaButtonProps {
   generatedAppointmentId: string;
   absenceDate: string;

--- a/apps/apae/src/components/buttons/RegistrarFaltaButton.tsx
+++ b/apps/apae/src/components/buttons/RegistrarFaltaButton.tsx
@@ -74,6 +74,7 @@ export function RegistrarFaltaButton({
           : error.message || "Erro ao registrar a falta. Tente novamente.";
 
           toast.error(message);
+          setOpen(false);
     } finally {
       setIsLoading(false);
     }

--- a/apps/apae/src/components/buttons/RegistrarFaltaButton.tsx
+++ b/apps/apae/src/components/buttons/RegistrarFaltaButton.tsx
@@ -14,18 +14,25 @@ import {
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { toast } from "react-toastify"
 import { useState } from "react";
+
+import { useRouter } from "next/navigation"
+
+
 
 interface RegistrarFaltaButtonProps {
   generatedAppointmentId: string;
   absenceDate: string;
   disabled?: boolean;
+  onSuccess?: () => void;
 }
 
 export function RegistrarFaltaButton({
   generatedAppointmentId,
   absenceDate,
   disabled,
+  onSuccess,
 }: RegistrarFaltaButtonProps) {
   const [motivo, setMotivo] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -60,7 +67,8 @@ export function RegistrarFaltaButton({
 
       setMotivo("");
       setOpen(false);
-      window.location.reload();
+      onSuccess?.();
+      toast.success("Salvo com sucesso!");
     } catch (error: any) {
       console.error("Erro ao registrar falta:", error);
 
@@ -68,6 +76,8 @@ export function RegistrarFaltaButton({
         error.message?.includes("Já existe uma falta")
           ? "Esta consulta já possui uma falta registrada."
           : error.message || "Erro ao registrar a falta. Tente novamente.";
+
+          toast.error(message);
     } finally {
       setIsLoading(false);
     }

--- a/apps/apae/src/components/buttons/RegistrarFaltaButton.tsx
+++ b/apps/apae/src/components/buttons/RegistrarFaltaButton.tsx
@@ -29,7 +29,7 @@ export function RegistrarFaltaButton({
 }: RegistrarFaltaButtonProps) {
   const [motivo, setMotivo] = useState("");
   const [isLoading, setIsLoading] = useState(false);
-  const [open, setOpen] = useState(false); 
+  const [open, setOpen] = useState(false);
 
   const handleConfirm = async () => {
     if (!motivo.trim()) {
@@ -45,9 +45,22 @@ export function RegistrarFaltaButton({
         justification: motivo.trim(),
       };
 
-      await AbsenceService.registerAbsence(dto);
+      const response = await fetch("/api/absence", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(dto),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message);
+      }
+
       setMotivo("");
       setOpen(false);
+      window.location.reload();
     } catch (error: any) {
       console.error("Erro ao registrar falta:", error);
 

--- a/apps/api/src/main/java/br/org/apae/api/appointment/application/internal/AppointmentApplicationServiceImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/appointment/application/internal/AppointmentApplicationServiceImpl.java
@@ -336,14 +336,20 @@ public class AppointmentApplicationServiceImpl implements AppointmentApplication
 
   @Override
   public Page<TodayAppointmentsResponseDTO> listAppointmentForToday(LocalDate date, Pageable pageable) {
-    return this.generatedRepo.listAppointmentsForToday(date, pageable).map(appointment -> {
+
+    LocalDate target = (date != null) ? date : LocalDate.now();
+
+    LocalDateTime start = target.atStartOfDay();
+    LocalDateTime end = target.atTime(23, 59, 59);
+
+    return this.generatedRepo.listAppointmentsForToday(start , end, pageable).map(appointment -> {
         try {
         Patient patient = patientRepo.findById(appointment.getPatientId())
                 .orElseThrow(() -> new RuntimeException("Paciente não encontrado"));
-            
+
         Guardian guardian = guardianRepo.findByPatientId(patient.getId())
                 .orElseThrow(() -> new RuntimeException("Responsável não encontrado"));
-                
+
             List<Parent> pais = parentRepo.findAllByPatientId(patient.getId());
 
             AddressResponseDTO adto = new AddressResponseDTO(patient.getAddress());

--- a/apps/api/src/main/java/br/org/apae/api/appointment/domain/repository/GeneratedAppointmentRepository.java
+++ b/apps/api/src/main/java/br/org/apae/api/appointment/domain/repository/GeneratedAppointmentRepository.java
@@ -24,7 +24,14 @@ public interface GeneratedAppointmentRepository extends JpaRepository<GeneratedA
     Page<GeneratedAppointment> findByPatientIdAndScheduledDateTimeBetween(
             UUID patientId, LocalDateTime start, LocalDateTime end, Pageable pageable);
 
-    @Query("SELECT g FROM GeneratedAppointment g " +
-       "WHERE FUNCTION('DATE', COALESCE(g.overriddenDateTime, g.scheduledDateTime)) = :date")
-    Page<GeneratedAppointment> listAppointmentsForToday(@Param("date") java.time.LocalDate date, Pageable pageable);
+    @Query("""
+        SELECT g FROM GeneratedAppointment g
+        WHERE COALESCE(g.overriddenDateTime, g.scheduledDateTime)
+        BETWEEN :start AND :end
+    """)
+    Page<GeneratedAppointment> listAppointmentsForToday(
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end,
+            Pageable pageable
+    );
 }

--- a/apps/api/src/main/java/br/org/apae/api/professional/application/internal/HealthProfessionalApplicationServiceImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/professional/application/internal/HealthProfessionalApplicationServiceImpl.java
@@ -199,10 +199,19 @@ public class HealthProfessionalApplicationServiceImpl implements HealthProfessio
     public List<LocalTime> getAvailableTimes(UUID professionalId, LocalDate date) {
         List<LocalTime> occupied = repository.findOccupiedHours(professionalId, date);
 
-        List<LocalTime> allSlots = generateSlots(
+        List<LocalTime> morningSlots = generateSlots(
                 LocalTime.of(8, 0),
                 LocalTime.of(12, 0)
         );
+
+        List<LocalTime> afternoonSlots = generateSlots(
+                LocalTime.of(14, 0),
+                LocalTime.of(17, 0)
+        );
+
+        List<LocalTime> allSlots = new ArrayList<>();
+        allSlots.addAll(morningSlots);
+        allSlots.addAll(afternoonSlots);
 
         return allSlots.stream()
                 .filter(slot -> !occupied.contains(slot))


### PR DESCRIPTION
# O que esse PR forneceu?

- **Registro de falta:** o sistema agora consegue registrar as faltas normalmente, retornando para o front end uma mensagem de sucesso ou falha de forma simples e limpa.
- **Horários de agendamento de profissionais a tarde:** foi identificado que apenas os horários pela manhã estavam sendo retornados, agora, horários a tarde também são retornados.

# Coleta de evidências

<img width="474" height="725" alt="image" src="https://github.com/user-attachments/assets/6ffa6b35-d711-4208-85df-0867c7f69aab" />

[simplescreenrecorder-2026-04-01_13.20.19.webm](https://github.com/user-attachments/assets/457cd1c1-51ea-48e8-9bd1-687fc9984dab)

[simplescreenrecorder-2026-04-01_13.30.17.webm](https://github.com/user-attachments/assets/5247b800-8cc0-4305-bda5-516fca5d6081)

> A função de atualização de faltas em tela foi desativada propositalmente para que o segundo vídeo possa demonstrar o caso em que ocorra um problema ao registrar uma falta
