### PR TITLE
626 lint e limpeza de código

### DIFF
--- a/apps/apae/package.json
+++ b/apps/apae/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "lint:fix": "next lint --fix"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.1",

--- a/apps/apae/src/app/api/consultation-histories/route.ts
+++ b/apps/apae/src/app/api/consultation-histories/route.ts
@@ -38,7 +38,7 @@ export async function GET(req: Request) {
 
     const api = await createBaseApi();
 
-    let url = "/consultation-histories";
+    const url = "/consultation-histories";
     const params: Record<string, string> = {};
 
     if (agendamentoId) params.agendamentoId = agendamentoId;

--- a/apps/apae/src/app/api/pessoas/[id]/registro-anual/route.ts
+++ b/apps/apae/src/app/api/pessoas/[id]/registro-anual/route.ts
@@ -30,7 +30,7 @@ export async function POST(
             if (extracted) {
                 finalToken = extracted;
             }
-        } catch (e) {
+        } catch {
         }
     }
 

--- a/apps/apae/src/app/api/pessoas/[id]/registro-anual/years-list/route.ts
+++ b/apps/apae/src/app/api/pessoas/[id]/registro-anual/years-list/route.ts
@@ -17,7 +17,7 @@ export async function GET(
     if (token && token.trim().startsWith("{")) {
         try {
             token = JSON.parse(token).accessToken || token;
-        } catch(e) {}
+        } catch {}
     }
     
     if (token) token = token.replace(/^"|"$/g, '').replace(/^Bearer\s+/i, '').trim();
@@ -38,7 +38,7 @@ export async function GET(
     const data = await res.json();
     return NextResponse.json(data, { status: 200 });
 
-  } catch (error) {
+  } catch {
     return NextResponse.json([], { status: 500 });
   }
 }

--- a/apps/apae/src/app/person/[id]/documents/[type]/page.tsx
+++ b/apps/apae/src/app/person/[id]/documents/[type]/page.tsx
@@ -50,10 +50,10 @@ export default function DocumentTypePage() {
 
   const category = params?.type as keyof typeof documentCategory;
 
-  const [yearFilter, setYearFilter] = React.useState<string>(
+  const [yearFilter] = React.useState<string>(
     new Date().getFullYear().toString()
   );
-  const [typeFilter, setTypeFilter] = React.useState<string>("");
+  const [typeFilter] = React.useState<string>("");
   const [files, setFiles] = React.useState<FileItem[]>([]);
 
   React.useEffect(() => {

--- a/apps/apae/src/app/person/register/profile/page.tsx
+++ b/apps/apae/src/app/person/register/profile/page.tsx
@@ -154,7 +154,7 @@ export default function MembersRegisterProfilePage() {
             toast.error(res.data?.message || "Erro inesperado no servidor.");
             setSubmitted(false);
           }
-        } catch (error) {
+        } catch {
           toast.error("Falha na conexão com o servidor.");
           setSubmitted(false);
         } finally {

--- a/apps/apae/src/app/person/register/responsible/page.tsx
+++ b/apps/apae/src/app/person/register/responsible/page.tsx
@@ -23,7 +23,6 @@ import { handleBackendValidationErrors } from "@/utils/form-errors";
 import { usePathname } from "next/navigation"; 
 import { formatPhone } from "@/lib/formats";
 
-import z from "zod";
 import { DoubleColumn, FormButton, MembersRegisterForm } from "../form";
 
 export default function MembersRegisterGuardianPage() {

--- a/apps/apae/src/app/update-profissional/[id]/page.tsx
+++ b/apps/apae/src/app/update-profissional/[id]/page.tsx
@@ -155,7 +155,7 @@ export default function AtualizarProfissional(): JSX.Element {
   useEffect(() => {
     if (!profissional?.id) return;
     refreshDocuments(profissional.id);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+     
   }, [profissional?.id]);
 
   const groupedDocs = useMemo(() => {

--- a/apps/apae/src/app/vaccines/layout-client.tsx
+++ b/apps/apae/src/app/vaccines/layout-client.tsx
@@ -12,8 +12,8 @@ export function VaccinesLayoutClient({
     const { feedback } = useVaccinesContext();
 
     useEffect(() => {
-        feedback.error && toast.error(feedback.message);
-        feedback.success && toast.success(feedback.message);
+    if (feedback.error) toast.error(feedback.message);
+    if (feedback.success) toast.success(feedback.message);
     }, [feedback]);
 
     return children;

--- a/apps/apae/src/app/vaccines/page.tsx
+++ b/apps/apae/src/app/vaccines/page.tsx
@@ -81,7 +81,7 @@ function VaccinesList({ searchName }: { searchName: string }) {
     if (filteredVaccines.length === 0) {
         return (
             <p className="text-center text-gray-500 p-10">
-                Nenhuma vacina encontrada para "{searchName}".
+                    Nenhuma vacina encontrada para &quot;{searchName}&quot;.
             </p>
         );
     }

--- a/apps/apae/src/app/visualization-patients/page.tsx
+++ b/apps/apae/src/app/visualization-patients/page.tsx
@@ -24,9 +24,8 @@ export default function PatientsAndStudentsScreen() {
   const debouncedSearchName = useDebounce(searchName, 500);
   const [page, setPage] = useState(0);
   const [size] = useState(10);
-  const [totalPages, setTotalPages] = useState(0);
-  const [totalElements, setTotalElements] = useState(0);
-
+  const [, setTotalPages] = useState(0);
+  const [, setTotalElements] = useState(0);
   const {
     transtornoOptions,
     anoOptions,

--- a/apps/apae/src/components/AnnualRegistryEditModal.tsx
+++ b/apps/apae/src/components/AnnualRegistryEditModal.tsx
@@ -199,7 +199,7 @@ export default function AnnualRegistryEditModal({
             toast.success("Documento anexado!");
             fetchDocuments();
             if (fileInputRef.current) fileInputRef.current.value = "";
-        } catch (error) { toast.error("Erro ao enviar documento."); }
+        } catch { toast.error("Erro ao enviar documento."); }
         finally { setIsUploading(false); }
     };
 
@@ -208,16 +208,17 @@ export default function AnnualRegistryEditModal({
     const formatCurrencyForDisplay = (value: number | string) => (!value ? "" : Number(value).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' }));
 
     const handleMoneyChange = (e: React.ChangeEvent<HTMLInputElement>, onChange: (value: string) => void) => {
-        let value = e.target.value.replace(/\D/g, "");
+        const value = e.target.value.replace(/\D/g, "");
         if (value === "") { onChange(""); return; }
         onChange((parseFloat(value) / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" }));
     };
 
 
     const cleanPatientData = (data: any) => {
-        if (!data) return {};
-        const { documents, annualRegistry, createdAt, updatedAt, deleted, isDeleted, age, ...rest } = data;
-        return rest;
+    if (!data) return {};
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { documents, annualRegistry, createdAt, updatedAt, deleted, isDeleted, age, ...rest } = data;
+    return rest;
     };
 
 

--- a/apps/apae/src/components/GenericDatabaseSelect.tsx
+++ b/apps/apae/src/components/GenericDatabaseSelect.tsx
@@ -97,7 +97,7 @@ export const GenericDatabaseSelect = ({
           body: JSON.stringify(payload) 
         });
         
-        let newOption: Option = { label: normalizedName, value: normalizedName };
+        const newOption: Option = { label: normalizedName, value: normalizedName };
         
         if (res.ok || res.status === 201 || res.status === 409) {
             const created = await res.json().catch(() => ({}));

--- a/apps/apae/src/hooks/use-members-register-context.tsx
+++ b/apps/apae/src/hooks/use-members-register-context.tsx
@@ -356,7 +356,7 @@ export function MembersRegisterProvider({
         let resData = {};
         const text = await responsePessoa.text();
         if (text) {
-          try { resData = JSON.parse(text); } catch(e) {}
+          try { resData = JSON.parse(text); } catch {}
         }
         return { status: responsePessoa.status, data: resData };
 


### PR DESCRIPTION
Descrição:
- Trocado let por const em 3 arquivos
- Removidos parâmetros não usados de blocos catch
- Corrigidas aspas não escapadas no JSX (vaccines/page.tsx)
- Removidas variáveis não usadas (setYearFilter, setTypeFilter, totalPages, totalElements, etc.)
- Corrigidas expressões soltas no vaccines/layout-client.tsx
- Adicionado script lint:fix no package.json

O que não foi tocado e por quê:

Erros de any - escopo das issues #627 e #628
useEffect com dependências faltando - escopo da issue #629
rules-of-hooks - escopo da issue #629

Observação:
O build ainda falha pelos erros das issues #627, #628 e #629 que já existiam antes desta branch. Nenhum erro novo foi introduzido.