### PR TITLE
Ajustar Tipagem do Front-end - Escopo Geral

### DIFF
--- a/apps/apae/src/app/auth/layout.tsx
+++ b/apps/apae/src/app/auth/layout.tsx
@@ -1,4 +1,5 @@
-import Image from "@/assets/background_image.jpg";
+import Image from "next/image";
+import BackgroundImage from "@/assets/background_image.jpg";
 import Logo from "@/assets/logo.png";
 
 export default function AuthLayout({
@@ -11,7 +12,7 @@ export default function AuthLayout({
       <div
         className="absolute inset-0 bg-cover bg-center bg-no-repeat grayscale-90"
         style={{
-          backgroundImage: `url(${Image.src})`,
+          backgroundImage: `url(${BackgroundImage.src})`,
           backgroundAttachment: "fixed",
         }}
       />
@@ -24,16 +25,17 @@ export default function AuthLayout({
         }}
       />
 
-      <div className="relative z-10 relative flex items-center justify-center p-4">
+      <div className="relative z-10 flex items-center justify-center p-4">
         <div
-          className="absolute top-[-2vh] left-1/2 transform -translate-x-1/2 z-[10]
+          className="absolute top-[-2vh] left-1/2 transform -translate-x-1/2 z-10
                 w-18 sm:w-18 md:w-20 lg:w-22
                 bg-white rounded-t-full flex items-center justify-center overflow-hidden"
         >
           <div className="relative w-full">
-            <img
-              src={Logo.src}
+            <Image
+              src={Logo}
               alt="Logo"
+              priority
               className="w-full h-auto object-contain"
             />
           </div>

--- a/apps/apae/src/app/layout.tsx
+++ b/apps/apae/src/app/layout.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
-import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
-import { AppSidebar } from "@/components/sidebar/sidebar";
 import "./globals.css";
+
 import ToastProvider from "@/components/shared/ToastProvider";
 import { SidebarWrapper } from "@/components/sidebar/SidebarWrapper";
 
@@ -20,7 +19,7 @@ export const metadata: Metadata = {
   title: "APAE-ESP APP",
   description: "Aplicação de gerenciamento da APAE",
   icons: {
-    icon: "/favicon.png"
+    icon: "/favicon.png",
   },
 };
 

--- a/apps/apae/src/components/AnnualRegistryEditModal.tsx
+++ b/apps/apae/src/components/AnnualRegistryEditModal.tsx
@@ -1,512 +1,826 @@
 "use client";
 
-
 import { useEffect, useState, useRef } from "react";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { AnnualRegistryFormSchema, AnnualRegistryFormValues } from "@/schemas/anualRegistrySchema";
+import {
+  AnnualRegistryFormSchema,
+  AnnualRegistryFormValues,
+} from "@/schemas/anualRegistrySchema";
 import { toast } from "react-toastify";
-import { Loader2, Upload, FileText, RefreshCw, ExternalLink } from "lucide-react";
-
+import {
+  Loader2,
+  Upload,
+  FileText,
+  RefreshCw,
+  ExternalLink,
+} from "lucide-react";
 
 import { StringMultiSelect } from "@/components/StringMultiSelect";
 import { GenericDatabaseSelect } from "@/components/GenericDatabaseSelect";
 
-
 interface DocumentDTO {
-    id: string;
-    name: string;
-    category: string;
-    type: string;
-    url: string;
+  id: string;
+  name: string;
+  category: string;
+  type: string;
+  url: string;
 }
-
 
 interface AnnualRegistryEditModalProps {
-    isOpen: boolean;
-    onClose: (str?: string) => void;
-    patientId: string;
-    currentYear: string;
-    initialData: any;
-    mode?: "create" | "edit";
+  isOpen: boolean;
+  onClose: (str?: string) => void;
+  patientId: string;
+  currentYear: string;
+  initialData: any;
+  mode?: "create" | "edit";
 }
 
+interface Vaccine {
+  id?: string | number;
+  name?: string;
+}
+
+interface Disorder {
+  id?: string | number;
+  name?: string;
+}
+
+interface ServiceType {
+  id?: string | number;
+  area?: string;
+}
 
 const MEDICAL_DOC_TYPES = [
-    { value: "MEDICAL_REPORT", label: "Laudo Médico" },
-    { value: "EXAMINATION", label: "Exame" },
-    { value: "REFERRAL", label: "Encaminhamento" },
-    { value: "OTHER", label: "Outro" }
+  { value: "MEDICAL_REPORT", label: "Laudo Médico" },
+  { value: "EXAMINATION", label: "Exame" },
+  { value: "REFERRAL", label: "Encaminhamento" },
+  { value: "OTHER", label: "Outro" },
 ];
 
 const docTypeTranslations: Record<string, string> = {
-    MEDICAL_REPORT: "Laudo Médico",
-    EXAMINATION: "Exame",
-    REFERRAL: "Encaminhamento",
-    OTHER: "Outro",
-    VACCINE_CARD: "Cartão de Vacina"
+  MEDICAL_REPORT: "Laudo Médico",
+  EXAMINATION: "Exame",
+  REFERRAL: "Encaminhamento",
+  OTHER: "Outro",
+  VACCINE_CARD: "Cartão de Vacina",
 };
 
 export default function AnnualRegistryEditModal({
-                                                    isOpen,
-                                                    onClose,
-                                                    patientId,
-                                                    currentYear,
-                                                    initialData,
-                                                    mode = "edit"
-                                                }: AnnualRegistryEditModalProps) {
-
-    const [documents, setDocuments] = useState<DocumentDTO[]>([]);
-    const [isLoadingDocs, setIsLoadingDocs] = useState(false);
-    const [isUploading, setIsUploading] = useState(false);
-    const [docType, setDocType] = useState("MEDICAL_REPORT");
-
-    const [fullPatientData, setFullPatientData] = useState<any>(null);
-    const fileInputRef = useRef<HTMLInputElement>(null);
-
-
-    const currentYearInt = new Date().getFullYear();
-
-
-    const availableYears = Array.from({ length: 32 }, (_, i) => (currentYearInt + 1 - i).toString());
-
-
-    const form = useForm<AnnualRegistryFormValues>({
-        resolver: zodResolver(AnnualRegistryFormSchema),
-        defaultValues: {
-            year: currentYear || currentYearInt.toString(),
-            bpc: "false",
-            familyIncome: "",
-            diseases: "",
-            continuousMedication: "",
-            disorders: [],
-            allergies: "",
-            vaccines: [],
-            serviceTypes: []
-        },
-    });
-
-
-    const { isSubmitting } = form.formState;
-
-
-    useEffect(() => {
-        if (isOpen && patientId) {
-            if (mode === "edit") fetchDocuments();
-            else setDocuments([]);
-            fetchPatientData();
-        }
-    }, [isOpen, patientId, mode]);
-
-
-    useEffect(() => {
-        if (isOpen) {
-            if (mode === "edit" && initialData) {
-                const rawBpc = initialData.bpc;
-                const bpcString = (rawBpc === true || String(rawBpc) === "true") ? "true" : "false";
-
-
-                const vaccineList = Array.isArray(fullPatientData?.vaccineNames)
-                    ? fullPatientData.vaccineNames.map((v: any) => (typeof v === 'string' ? { name: v } : v))
-                    : [];
-
-
-                const sourceServiceAreas = initialData.serviceArea || initialData.serviceAreas || initialData.serviceTypes || [];
-                const serviceTypeList = Array.isArray(sourceServiceAreas) ? sourceServiceAreas.map((s: any) => ({
-                    id: s.id,
-                    area: s.area || s.name,
-                    name: s.name || s.area
-                })) : [];
-
-
-                const disorderList = Array.isArray(initialData.disorders) ? initialData.disorders : [];
-
-
-                form.reset({
-                    year: currentYear,
-                    bpc: bpcString,
-                    familyIncome: initialData.familyIncome ? formatCurrencyForDisplay(initialData.familyIncome) : "",
-                    diseases: initialData.diseases ?? "",
-                    continuousMedication: initialData.continuousMedication ?? "",
-                    allergies: fullPatientData?.allergies ?? "",
-                    disorders: disorderList,
-                    vaccines: vaccineList,
-                    serviceTypes: serviceTypeList
-                });
-
-
-            } else if (mode === "create") {
-                const vaccineList = Array.isArray(fullPatientData?.vaccineNames)
-                    ? fullPatientData.vaccineNames.map((v: any) => (typeof v === 'string' ? { name: v } : v))
-                    : [];
-
-
-                form.reset({
-                    year: currentYearInt.toString(),
-                    bpc: "false",
-                    familyIncome: "",
-                    diseases: "",
-                    continuousMedication: "",
-                    allergies: fullPatientData?.allergies ?? "",
-                    disorders: [],
-                    vaccines: vaccineList,
-                    serviceTypes: []
-                });
-            }
-        }
-    }, [initialData, fullPatientData, isOpen, form, mode, currentYear]);
-
-    const fetchDocuments = async () => {
-        setIsLoadingDocs(true);
-        try {
-            const response = await fetch(`/api/pessoas/${patientId}/documentos?category=MEDICAL`);
-            if (response.ok) {
-                const data = await response.json().catch(() => []);
-                setDocuments(Array.isArray(data) ? data : []);
-            }
-        } catch (error) { console.error("Erro fetch docs:", error); }
-        finally { setIsLoadingDocs(false); }
-    };
-
-
-    const fetchPatientData = async () => {
-        try {
-            const response = await fetch(`/api/pessoas/${patientId}`);
-            if (response.ok) setFullPatientData(await response.json());
-        } catch (error) { console.error(error); }
-    };
-
-
-    const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
-        const file = e.target.files?.[0];
-        if (!file) return;
-        setIsUploading(true);
-        const formData = new FormData();
-        formData.append("file", file);
-        formData.append("category", "MEDICAL");
-        formData.append("type", docType);
-        try {
-            const res = await fetch(`/api/pessoas/${patientId}/documentos`, {
-                method: "POST",
-                body: formData,
-            });
-            if (!res.ok) throw new Error("Falha no upload");
-            toast.success("Documento anexado!");
-            fetchDocuments();
-            if (fileInputRef.current) fileInputRef.current.value = "";
-        } catch (error) { toast.error("Erro ao enviar documento."); }
-        finally { setIsUploading(false); }
-    };
-
-
-    const cleanCurrency = (value: string) => (!value ? "0.00" : value.replace(/[^\d,]/g, '').replace(',', '.'));
-    const formatCurrencyForDisplay = (value: number | string) => (!value ? "" : Number(value).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' }));
-
-    const handleMoneyChange = (e: React.ChangeEvent<HTMLInputElement>, onChange: (value: string) => void) => {
-        let value = e.target.value.replace(/\D/g, "");
-        if (value === "") { onChange(""); return; }
-        onChange((parseFloat(value) / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" }));
-    };
-
-
-    const cleanPatientData = (data: any) => {
-        if (!data) return {};
-        const { documents, annualRegistry, createdAt, updatedAt, deleted, isDeleted, age, ...rest } = data;
-        return rest;
-    };
-
-
-    const onSubmit = async (data: AnnualRegistryFormValues) => {
-        try {
-            const registryId = initialData?.id;
-
-            const finalDiseases = (data.diseases && data.diseases.trim() !== "") ? data.diseases : "Nenhuma";
-            const finalMedication = (data.continuousMedication && data.continuousMedication.trim() !== "") ? data.continuousMedication : "Nenhum";
-            const finalAllergies = (data.allergies && data.allergies.trim() !== "") ? data.allergies : "Nenhuma";
-
-            const income = parseFloat(cleanCurrency(data.familyIncome));
-            const bpcToSend = data.bpc === "true";
-
-
-            const formattedDisorders = (data.disorders || []).map((d: any) => ({
-                name: d.name || d.label || d.value,
-                id: d.id
-            }));
-
-
-            const formattedServiceAreas = (data.serviceTypes || []).map((s: any) => ({
-                id: s.id,
-                area: s.area || s.name || s.label || s.value
-            }));
-
-
-            const regPayload: any = {
-                bpc: bpcToSend,
-                familyIncome: income,
-                diseases: finalDiseases,
-                continuousMedication: finalMedication,
-                disorders: formattedDisorders,
-                serviceArea: formattedServiceAreas,
-                serviceAreas: formattedServiceAreas
-            };
-
-
-            let regRes;
-
-
-            if (mode === "create") {
-                regPayload.year = parseInt(data.year);
-
-
-                regRes = await fetch(`/api/pessoas/${patientId}/registro-anual`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify(regPayload),
-                });
-            } else {
-                if (!registryId) throw new Error("ID do registro não encontrado.");
-
-                regRes = await fetch(`/api/pessoas/${patientId}/registro-anual/${registryId}`, {
-                    method: 'PUT',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify(regPayload),
-                });
-            }
-
-
-            if (!regRes.ok) {
-                const errorText = await regRes.text();
-                console.error("Erro Backend:", errorText);
-                if (regRes.status === 409) {
-                    throw new Error(`Já existe um registro para o ano de ${data.year}.`);
-                }
-                throw new Error("Erro ao salvar registro anual.");
-            }
-
-
-            if (fullPatientData) {
-                const vaccineList = (data.vaccines || []).map((v: any) => ({ name: v.name || v.label || v.value, id: v.id }));
-                const baseData = cleanPatientData(fullPatientData);
-                const safeNationality = baseData.nationality || baseData.birthplace || "Brasileira";
-
-
-                const patientPayload = {
-                    ...baseData,
-                    nationality: safeNationality,
-                    allergies: finalAllergies,
-                    vaccineNames: vaccineList,
-                    address: fullPatientData.address ? { ...fullPatientData.address } : null,
-                    guardian: fullPatientData.guardian ? { ...fullPatientData.guardian } : null,
-                    parents: fullPatientData.parents?.map((p: any) => ({
-                        id: p.id, name: p.name, rg: p.rg, cpf: p.cpf, profession: p.profession, isAlive: p.isAlive, kinship: p.kinship
-                    })) ?? []
-                };
-
-
-                await fetch(`/api/pessoas/${patientId}`, {
-                    method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(patientPayload)
-                });
-            }
-
-
-            const savedYear = mode === "create" ? data.year : undefined;
-            onClose(savedYear);
-
-            toast.success(mode === "create" ? "Registro criado com sucesso!" : "Alterações salvas!");
-
-
-        } catch (error: any) {
-            console.error(error);
-            toast.error(error.message || "Erro ao salvar.");
-        }
-    };
-
-
-    const isCreateMode = mode === "create";
-
-
-    return (
-        <Dialog open={isOpen} onOpenChange={() => onClose()}>
-            <DialogContent className="!max-w-[1200px] w-[95vw] h-[85vh] flex flex-col p-0 overflow-hidden bg-slate-50 rounded-xl shadow-xl">
-                <DialogHeader className="px-6 py-4 bg-[#0D4F97] text-white shrink-0">
-                    <DialogTitle className="text-xl font-bold font-baloo">
-                        {isCreateMode ? "Novo Registro Anual" : "Edição de Saúde & Social"}
-                    </DialogTitle>
-                    <p className="text-blue-200 text-xs mt-0.5 opacity-90">
-                        {isCreateMode ? "Preencha os dados para iniciar um novo ano." : `Referência: ${currentYear}`}
-                    </p>
-                </DialogHeader>
-
-                <div className="flex-1 overflow-y-auto p-5 pb-24">
-                    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 h-full">
-                        <div className="bg-white p-5 rounded-xl shadow-sm border border-slate-200 h-fit">
-                            <h3 className="text-[#0D4F97] font-bold text-base mb-4 pb-2 border-b border-slate-100 flex items-center gap-2"><span className="bg-blue-50 p-1.5 rounded-lg text-[#0D4F97]"><FileText className="h-4 w-4" /></span>Dados Clínicos e Sociais</h3>
-                            <Form {...form}>
-                                <form id="health-form" onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-
-                                    {isCreateMode && (
-                                        <FormField control={form.control} name="year" render={({ field }) => (
-                                            <FormItem>
-                                                <FormLabel className="text-slate-700 font-bold text-xs">Ano de Referência</FormLabel>
-                                                <Select onValueChange={field.onChange} defaultValue={field.value}>
-                                                    <FormControl><SelectTrigger className="bg-slate-50 border-slate-200 h-10 text-sm"><SelectValue placeholder="Selecione o ano" /></SelectTrigger></FormControl>
-                                                    <SelectContent className="max-h-60">
-                                                        {availableYears.map(year => (
-                                                            <SelectItem key={year} value={year}>{year}</SelectItem>
-                                                        ))}
-                                                    </SelectContent>
-                                                </Select>
-                                                <FormMessage />
-                                            </FormItem>
-                                        )} />
-                                    )}
-
-
-                                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                        <FormField control={form.control} name="bpc" render={({ field }) => (
-                                            <FormItem><FormLabel className="text-slate-700 font-bold text-xs">Recebe BPC?</FormLabel>
-                                                <Select
-                                                    onValueChange={field.onChange}
-                                                    value={field.value}
-                                                    defaultValue={field.value}
-                                                >
-                                                    <FormControl><SelectTrigger className="bg-slate-50 border-slate-200 h-10 text-sm"><SelectValue placeholder="Selecione" /></SelectTrigger></FormControl>
-                                                    <SelectContent><SelectItem value="true">Sim</SelectItem><SelectItem value="false">Não</SelectItem></SelectContent>
-                                                </Select><FormMessage />
-                                            </FormItem>)} />
-                                        <FormField control={form.control} name="familyIncome" render={({ field }) => (
-                                            <FormItem><FormLabel className="text-slate-700 font-bold text-xs">Renda Familiar</FormLabel><FormControl><Input className="bg-slate-50 border-slate-200 h-10 text-sm" placeholder="R$ 0,00" value={field.value} onChange={(e) => handleMoneyChange(e, field.onChange)} /></FormControl><FormMessage /></FormItem>)} />
-                                    </div>
-                                    <div className="space-y-3">
-                                        <FormField control={form.control} name="diseases" render={({ field }) => (
-                                            <FormItem><FormLabel className="text-slate-700 font-bold text-xs">Doenças</FormLabel>
-                                                <FormControl><StringMultiSelect value={field.value || ""} onChange={field.onChange} placeholder="Digite doenças (ex: Diabetes)..." /></FormControl><FormMessage /></FormItem>)} />
-
-                                        <FormField control={form.control} name="allergies" render={({ field }) => (
-                                            <FormItem><FormLabel className="text-slate-700 font-bold text-xs">Alergias</FormLabel>
-                                                <FormControl><StringMultiSelect value={field.value || ""} onChange={field.onChange} placeholder="Digite alergias (ex: Dipirona)..." /></FormControl><FormMessage /></FormItem>)} />
-
-                                        <FormField control={form.control} name="continuousMedication" render={({ field }) => (
-                                            <FormItem><FormLabel className="text-slate-700 font-bold text-xs">Medicamentos</FormLabel>
-                                                <FormControl><StringMultiSelect value={field.value || ""} onChange={field.onChange} placeholder="Digite medicamentos..." /></FormControl><FormMessage /></FormItem>)} />
-
-                                        <FormField control={form.control} name="vaccines" render={({ field }) => (
-                                            <FormItem>
-                                                <FormLabel className="text-slate-700 font-bold text-xs">Vacinas</FormLabel>
-                                                <FormControl>
-                                                    <GenericDatabaseSelect
-                                                        value={field.value || []}
-                                                        onChange={field.onChange}
-                                                        endpoint="/api/vacinas"
-                                                        labelSingular="Vacina"
-                                                        placeholder="Selecione ou crie vacinas..."
-                                                    />
-                                                </FormControl><FormMessage /></FormItem>)}
-                                        />
-                                    </div>
-                                    <div className="pt-1 space-y-3">
-                                        <FormField control={form.control} name="disorders" render={({ field }) => (
-                                            <FormItem>
-                                                <FormLabel className="text-slate-700 font-bold text-xs mb-1.5 block">Transtornos</FormLabel>
-                                                <FormControl>
-                                                    <GenericDatabaseSelect
-                                                        value={field.value || []}
-                                                        onChange={field.onChange}
-                                                        endpoint="/api/transtornos"
-                                                        labelSingular="Transtorno"
-                                                        placeholder="Selecione ou crie transtornos..."
-                                                    />
-                                                </FormControl><FormMessage /></FormItem>)}
-                                        />
-
-
-                                        <FormField control={form.control} name="serviceTypes" render={({ field }) => (
-                                            <FormItem>
-                                                <FormLabel className="text-slate-700 font-bold text-xs mb-1.5 block">Tipos de Atendimento</FormLabel>
-                                                <FormControl>
-                                                    <GenericDatabaseSelect
-                                                        value={field.value || []}
-                                                        onChange={field.onChange}
-                                                        endpoint="/api/tipo-atendimento"
-                                                        labelSingular="Tipo de Atendimento"
-                                                        placeholder="Selecione ou crie tipos..."
-                                                        labelKey="area"
-                                                        menuPlacement="top"
-                                                    />
-                                                </FormControl><FormMessage /></FormItem>)}
-                                        />
-                                    </div>
-                                </form>
-                            </Form>
-                        </div>
-                        <div className="flex flex-col h-full bg-white p-5 rounded-xl shadow-sm border border-slate-200">
-                            <h3 className="text-[#0D4F97] font-bold text-base mb-4 pb-2 border-b border-slate-100 flex items-center justify-between">
-                                <div className="flex items-center gap-2"><span className="bg-green-50 p-1.5 rounded-lg text-green-700"><FileText className="h-4 w-4" /></span>Documentação Digital</div>
-                                <Button variant="ghost" size="sm" className="h-8 w-8 p-0 hover:bg-slate-100 rounded-full" onClick={fetchDocuments} disabled={isLoadingDocs}><RefreshCw className={`h-4 w-4 ${isLoadingDocs ? 'animate-spin' : ''}`} /></Button>
-                            </h3>
-                            <div className="flex-1 flex flex-col">
-                                {isCreateMode ? (
-                                    <div className="flex flex-col items-center justify-center h-full text-center p-8 opacity-60">
-                                        <FileText className="h-12 w-12 text-slate-300 mb-3" />
-                                        <p className="text-slate-500 font-medium text-sm">Documentos poderão ser anexados após a criação do registro.</p>
-                                    </div>
-                                ) : (
-                                    <>
-                                        <div className="bg-slate-50 p-5 rounded-xl border-2 border-dashed border-slate-300 mb-6 hover:border-[#0D4F97]/40 transition-all duration-300 group">
-                                            <label className="text-xs font-bold text-slate-500 uppercase mb-3 block text-center tracking-widest group-hover:text-[#0D4F97] transition-colors">Adicionar Novo Documento</label>
-                                            <div className="flex flex-col gap-3 max-w-sm mx-auto w-full">
-                                                <Select value={docType} onValueChange={setDocType}>
-                                                    <SelectTrigger className="w-full bg-white shadow-sm border-slate-200 h-10 text-sm"><SelectValue /></SelectTrigger>
-                                                    <SelectContent>{MEDICAL_DOC_TYPES.map(t => <SelectItem key={t.value} value={t.value}>{t.label}</SelectItem>)}</SelectContent>
-                                                </Select>
-                                                <input type="file" ref={fileInputRef} onChange={handleFileUpload} className="hidden" accept=".pdf,.jpg,.png,.jpeg" disabled={isUploading} />
-                                                <Button variant="outline" className="w-full bg-white text-[#0D4F97] border-[#0D4F97]/20 hover:bg-[#0D4F97] hover:text-white shadow-sm h-10 transition-all text-sm" onClick={() => fileInputRef.current?.click()} disabled={isUploading}>{isUploading ? <Loader2 className="mr-2 h-4 w-4 animate-spin"/> : <Upload className="mr-2 h-4 w-4"/>} Selecionar Arquivo</Button>
-                                            </div>
-                                        </div>
-                                        <div className="flex-1 overflow-y-auto max-h-[400px] pr-2 custom-scrollbar">
-                                            <h4 className="text-[10px] font-bold text-slate-400 uppercase mb-3 tracking-widest">Arquivos Anexados ({documents.length})</h4>
-                                            <div className="space-y-2">
-                                                {documents.length === 0 ? (
-                                                    <div className="flex flex-col items-center justify-center h-32 text-slate-400 border-2 border-slate-100 rounded-xl bg-slate-50/50"><FileText className="h-8 w-8 mb-2 opacity-20" /><p className="text-xs font-medium opacity-60">Nenhum documento encontrado.</p></div>
-                                                ) : (
-                                                    documents.map((doc) => (
-                                                        <div key={doc.id} className="group flex items-center justify-between p-3 bg-white border border-slate-100 rounded-xl shadow-sm hover:shadow-md hover:border-[#0D4F97]/20 transition-all duration-200">
-                                                            <div className="flex items-center gap-3 overflow-hidden">
-                                                                <div className="bg-blue-50 p-2 rounded-lg group-hover:bg-[#0D4F97] group-hover:text-white transition-colors duration-300"><FileText className="h-4 w-4" /></div>
-                                                                <div className="flex flex-col min-w-0">
-                                                                <span className="text-sm font-semibold truncate text-slate-700 group-hover:text-[#0D4F97] transition-colors" 
-                                                                title={doc.name}>{doc.name}</span>
-                                                                <span className="text-[10px] text-slate-400 font-bold uppercase tracking-wide mt-0.5">{docTypeTranslations[doc.type] || doc.type}</span></div>
-                                                            </div>
-                                                            {doc.url && (<a href={doc.url} target="_blank" rel="noreferrer" className="p-2 text-slate-400 hover:text-[#0D4F97] hover:bg-blue-50 rounded-full transition-all" title="Abrir em nova aba"><ExternalLink className="h-4 w-4" /></a>)}
-                                                        </div>
-                                                    ))
-                                                )}
-                                            </div>
-                                        </div>
-                                    </>
-                                )}
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <DialogFooter className="px-6 py-4 bg-white border-t border-slate-100 shrink-0 flex justify-end gap-3 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.05)] z-10">
-                    <Button variant="ghost" onClick={() => onClose()} type="button" className="text-slate-500 hover:text-slate-800 hover:bg-slate-100 h-10 px-5 rounded-lg font-medium transition-colors text-sm">Cancelar</Button>
-                    <Button
-                        form="health-form"
-                        type="submit"
-                        disabled={isSubmitting}
-                        className="text-white bg-[#0D4F97] hover:bg-[#0b427d] shadow-lg shadow-blue-900/10 h-10 px-6 rounded-lg font-bold tracking-wide transition-all transform active:scale-95 text-sm disabled:opacity-70 disabled:cursor-not-allowed"
-                    >
-                        {isSubmitting ? <><Loader2 className="mr-2 h-4 w-4 animate-spin" /> {isCreateMode ? "Criar Registro" : "Salvar Alterações"}</> : (isCreateMode ? "Criar Registro" : "Salvar Alterações")}
-                    </Button>
-                </DialogFooter>
-            </DialogContent>
-        </Dialog>
+  isOpen,
+  onClose,
+  patientId,
+  currentYear,
+  initialData,
+  mode = "edit",
+}: AnnualRegistryEditModalProps) {
+  const [documents, setDocuments] = useState<DocumentDTO[]>([]);
+  const [isLoadingDocs, setIsLoadingDocs] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
+  const [docType, setDocType] = useState("MEDICAL_REPORT");
+
+  const [fullPatientData, setFullPatientData] = useState<any>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const currentYearInt = new Date().getFullYear();
+
+  const availableYears = Array.from({ length: 32 }, (_, i) =>
+    (currentYearInt + 1 - i).toString(),
+  );
+
+  const form = useForm<AnnualRegistryFormValues>({
+    resolver: zodResolver(AnnualRegistryFormSchema),
+    defaultValues: {
+      year: currentYear || currentYearInt.toString(),
+      bpc: "false",
+      familyIncome: "",
+      diseases: "",
+      continuousMedication: "",
+      disorders: [],
+      allergies: "",
+      vaccines: [],
+      serviceTypes: [],
+    },
+  });
+
+  const { isSubmitting } = form.formState;
+
+  useEffect(() => {
+    if (isOpen && patientId) {
+      if (mode === "edit") fetchDocuments();
+      else setDocuments([]);
+      fetchPatientData();
+    }
+  }, [isOpen, patientId, mode]);
+
+  useEffect(() => {
+    if (isOpen) {
+      if (mode === "edit" && initialData) {
+        const rawBpc = initialData.bpc;
+        const bpcString =
+          rawBpc === true || String(rawBpc) === "true" ? "true" : "false";
+
+        const vaccineList = Array.isArray(fullPatientData?.vaccineNames)
+          ? fullPatientData.vaccineNames.map((v: any) =>
+              typeof v === "string" ? { name: v } : v,
+            )
+          : [];
+
+        const sourceServiceAreas =
+          initialData.serviceArea ||
+          initialData.serviceAreas ||
+          initialData.serviceTypes ||
+          [];
+        const serviceTypeList = Array.isArray(sourceServiceAreas)
+          ? sourceServiceAreas.map((s: any) => ({
+              id: s.id,
+              area: s.area || s.name,
+              name: s.name || s.area,
+            }))
+          : [];
+
+        const disorderList = Array.isArray(initialData.disorders)
+          ? initialData.disorders
+          : [];
+
+        form.reset({
+          year: currentYear,
+          bpc: bpcString,
+          familyIncome: initialData.familyIncome
+            ? formatCurrencyForDisplay(initialData.familyIncome)
+            : "",
+          diseases: initialData.diseases ?? "",
+          continuousMedication: initialData.continuousMedication ?? "",
+          allergies: fullPatientData?.allergies ?? "",
+          disorders: disorderList,
+          vaccines: vaccineList,
+          serviceTypes: serviceTypeList,
+        });
+      } else if (mode === "create") {
+        const vaccineList = Array.isArray(fullPatientData?.vaccineNames)
+          ? fullPatientData.vaccineNames.map((v: any) =>
+              typeof v === "string" ? { name: v } : v,
+            )
+          : [];
+
+        form.reset({
+          year: currentYearInt.toString(),
+          bpc: "false",
+          familyIncome: "",
+          diseases: "",
+          continuousMedication: "",
+          allergies: fullPatientData?.allergies ?? "",
+          disorders: [],
+          vaccines: vaccineList,
+          serviceTypes: [],
+        });
+      }
+    }
+  }, [initialData, fullPatientData, isOpen, form, mode, currentYear]);
+
+  const fetchDocuments = async () => {
+    setIsLoadingDocs(true);
+    try {
+      const response = await fetch(
+        `/api/pessoas/${patientId}/documentos?category=MEDICAL`,
+      );
+      if (response.ok) {
+        const data = await response.json().catch(() => []);
+        setDocuments(Array.isArray(data) ? data : []);
+      }
+    } catch (error) {
+      console.error("Erro fetch docs:", error);
+    } finally {
+      setIsLoadingDocs(false);
+    }
+  };
+
+  const fetchPatientData = async () => {
+    try {
+      const response = await fetch(`/api/pessoas/${patientId}`);
+      if (response.ok) setFullPatientData(await response.json());
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setIsUploading(true);
+    const formData = new FormData();
+    formData.append("file", file);
+    formData.append("category", "MEDICAL");
+    formData.append("type", docType);
+    try {
+      const res = await fetch(`/api/pessoas/${patientId}/documentos`, {
+        method: "POST",
+        body: formData,
+      });
+      if (!res.ok) throw new Error("Falha no upload");
+      toast.success("Documento anexado!");
+      fetchDocuments();
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    } catch (error) {
+      toast.error("Erro ao enviar documento.");
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const cleanCurrency = (value: string) =>
+    !value ? "0.00" : value.replace(/[^\d,]/g, "").replace(",", ".");
+  const formatCurrencyForDisplay = (value: number | string) =>
+    !value
+      ? ""
+      : Number(value).toLocaleString("pt-BR", {
+          style: "currency",
+          currency: "BRL",
+        });
+
+  const handleMoneyChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+    onChange: (value: string) => void,
+  ) => {
+    let value = e.target.value.replace(/\D/g, "");
+    if (value === "") {
+      onChange("");
+      return;
+    }
+    onChange(
+      (parseFloat(value) / 100).toLocaleString("pt-BR", {
+        style: "currency",
+        currency: "BRL",
+      }),
     );
+  };
+
+  const cleanPatientData = (data: any) => {
+    if (!data) return {};
+    const {
+      documents,
+      annualRegistry,
+      createdAt,
+      updatedAt,
+      deleted,
+      isDeleted,
+      age,
+      ...rest
+    } = data;
+    return rest;
+  };
+
+  const onSubmit = async (data: AnnualRegistryFormValues) => {
+    try {
+      const registryId = initialData?.id;
+
+      const finalDiseases =
+        data.diseases && data.diseases.trim() !== ""
+          ? data.diseases
+          : "Nenhuma";
+      const finalMedication =
+        data.continuousMedication && data.continuousMedication.trim() !== ""
+          ? data.continuousMedication
+          : "Nenhum";
+      const finalAllergies =
+        data.allergies && data.allergies.trim() !== ""
+          ? data.allergies
+          : "Nenhuma";
+
+      const income = parseFloat(cleanCurrency(data.familyIncome));
+      const bpcToSend = data.bpc === "true";
+
+      const formattedDisorders = (data.disorders || []).map((d: any) => ({
+        name: d.name || d.label || d.value,
+        id: d.id,
+      }));
+
+      const formattedServiceAreas = (data.serviceTypes || []).map((s: any) => ({
+        id: s.id,
+        area: s.area || s.name || s.label || s.value,
+      }));
+
+      const regPayload: any = {
+        bpc: bpcToSend,
+        familyIncome: income,
+        diseases: finalDiseases,
+        continuousMedication: finalMedication,
+        disorders: formattedDisorders,
+        serviceArea: formattedServiceAreas,
+        serviceAreas: formattedServiceAreas,
+      };
+
+      let regRes;
+
+      if (mode === "create") {
+        regPayload.year = parseInt(data.year);
+
+        regRes = await fetch(`/api/pessoas/${patientId}/registro-anual`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(regPayload),
+        });
+      } else {
+        if (!registryId) throw new Error("ID do registro não encontrado.");
+
+        regRes = await fetch(
+          `/api/pessoas/${patientId}/registro-anual/${registryId}`,
+          {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(regPayload),
+          },
+        );
+      }
+
+      if (!regRes.ok) {
+        const errorText = await regRes.text();
+        console.error("Erro Backend:", errorText);
+        if (regRes.status === 409) {
+          throw new Error(`Já existe um registro para o ano de ${data.year}.`);
+        }
+        throw new Error("Erro ao salvar registro anual.");
+      }
+
+      if (fullPatientData) {
+        const vaccineList = (data.vaccines || []).map((v: any) => ({
+          name: v.name || v.label || v.value,
+          id: v.id,
+        }));
+        const baseData = cleanPatientData(fullPatientData);
+        const safeNationality =
+          baseData.nationality || baseData.birthplace || "Brasileira";
+
+        const patientPayload = {
+          ...baseData,
+          nationality: safeNationality,
+          allergies: finalAllergies,
+          vaccineNames: vaccineList,
+          address: fullPatientData.address
+            ? { ...fullPatientData.address }
+            : null,
+          guardian: fullPatientData.guardian
+            ? { ...fullPatientData.guardian }
+            : null,
+          parents:
+            fullPatientData.parents?.map((p: any) => ({
+              id: p.id,
+              name: p.name,
+              rg: p.rg,
+              cpf: p.cpf,
+              profession: p.profession,
+              isAlive: p.isAlive,
+              kinship: p.kinship,
+            })) ?? [],
+        };
+
+        await fetch(`/api/pessoas/${patientId}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(patientPayload),
+        });
+      }
+
+      const savedYear = mode === "create" ? data.year : undefined;
+      onClose(savedYear);
+
+      toast.success(
+        mode === "create"
+          ? "Registro criado com sucesso!"
+          : "Alterações salvas!",
+      );
+    } catch (error: any) {
+      console.error(error);
+      toast.error(error.message || "Erro ao salvar.");
+    }
+  };
+
+  const isCreateMode = mode === "create";
+
+  return (
+    <Dialog open={isOpen} onOpenChange={() => onClose()}>
+      <DialogContent className="!max-w-[1200px] w-[95vw] h-[85vh] flex flex-col p-0 overflow-hidden bg-slate-50 rounded-xl shadow-xl">
+        <DialogHeader className="px-6 py-4 bg-[#0D4F97] text-white shrink-0">
+          <DialogTitle className="text-xl font-bold font-baloo">
+            {isCreateMode ? "Novo Registro Anual" : "Edição de Saúde & Social"}
+          </DialogTitle>
+          <p className="text-blue-200 text-xs mt-0.5 opacity-90">
+            {isCreateMode
+              ? "Preencha os dados para iniciar um novo ano."
+              : `Referência: ${currentYear}`}
+          </p>
+        </DialogHeader>
+
+        <div className="flex-1 overflow-y-auto p-5 pb-24">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 h-full">
+            <div className="bg-white p-5 rounded-xl shadow-sm border border-slate-200 h-fit">
+              <h3 className="text-[#0D4F97] font-bold text-base mb-4 pb-2 border-b border-slate-100 flex items-center gap-2">
+                <span className="bg-blue-50 p-1.5 rounded-lg text-[#0D4F97]">
+                  <FileText className="h-4 w-4" />
+                </span>
+                Dados Clínicos e Sociais
+              </h3>
+              <Form {...form}>
+                <form
+                  id="health-form"
+                  onSubmit={form.handleSubmit(onSubmit)}
+                  className="space-y-4"
+                >
+                  {isCreateMode && (
+                    <FormField
+                      control={form.control}
+                      name="year"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel className="text-slate-700 font-bold text-xs">
+                            Ano de Referência
+                          </FormLabel>
+                          <Select
+                            onValueChange={field.onChange}
+                            defaultValue={field.value}
+                          >
+                            <FormControl>
+                              <SelectTrigger className="bg-slate-50 border-slate-200 h-10 text-sm">
+                                <SelectValue placeholder="Selecione o ano" />
+                              </SelectTrigger>
+                            </FormControl>
+                            <SelectContent className="max-h-60">
+                              {availableYears.map((year) => (
+                                <SelectItem key={year} value={year}>
+                                  {year}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  )}
+
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <FormField
+                      control={form.control}
+                      name="bpc"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel className="text-slate-700 font-bold text-xs">
+                            Recebe BPC?
+                          </FormLabel>
+                          <Select
+                            onValueChange={field.onChange}
+                            value={field.value}
+                            defaultValue={field.value}
+                          >
+                            <FormControl>
+                              <SelectTrigger className="bg-slate-50 border-slate-200 h-10 text-sm">
+                                <SelectValue placeholder="Selecione" />
+                              </SelectTrigger>
+                            </FormControl>
+                            <SelectContent>
+                              <SelectItem value="true">Sim</SelectItem>
+                              <SelectItem value="false">Não</SelectItem>
+                            </SelectContent>
+                          </Select>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name="familyIncome"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel className="text-slate-700 font-bold text-xs">
+                            Renda Familiar
+                          </FormLabel>
+                          <FormControl>
+                            <Input
+                              className="bg-slate-50 border-slate-200 h-10 text-sm"
+                              placeholder="R$ 0,00"
+                              value={field.value}
+                              onChange={(e) =>
+                                handleMoneyChange(e, field.onChange)
+                              }
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  </div>
+                  <div className="space-y-3">
+                    <FormField
+                      control={form.control}
+                      name="diseases"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel className="text-slate-700 font-bold text-xs">
+                            Doenças
+                          </FormLabel>
+                          <FormControl>
+                            <StringMultiSelect
+                              value={field.value || ""}
+                              onChange={field.onChange}
+                              placeholder="Digite doenças (ex: Diabetes)..."
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <FormField
+                      control={form.control}
+                      name="allergies"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel className="text-slate-700 font-bold text-xs">
+                            Alergias
+                          </FormLabel>
+                          <FormControl>
+                            <StringMultiSelect
+                              value={field.value || ""}
+                              onChange={field.onChange}
+                              placeholder="Digite alergias (ex: Dipirona)..."
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <FormField
+                      control={form.control}
+                      name="continuousMedication"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel className="text-slate-700 font-bold text-xs">
+                            Medicamentos
+                          </FormLabel>
+                          <FormControl>
+                            <StringMultiSelect
+                              value={field.value || ""}
+                              onChange={field.onChange}
+                              placeholder="Digite medicamentos..."
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <FormField
+                      control={form.control}
+                      name="vaccines"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel className="...">Vacinas</FormLabel>
+                          <FormControl>
+                            <GenericDatabaseSelect<Vaccine>
+                              value={field.value}
+                              onChange={field.onChange}
+                              endpoint="/api/vacinas"
+                              labelSingular="Vacina"
+                              labelKey="name"
+                              placeholder="Selecione ou crie vacinas..."
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  </div>
+
+                  <div className="pt-1 space-y-3">
+                    <FormField
+                      control={form.control}
+                      name="disorders"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel className="text-slate-700 font-bold text-xs mb-1.5 block">
+                            Transtornos
+                          </FormLabel>
+                          <FormControl>
+                            <GenericDatabaseSelect<Disorder>
+                              value={field.value}
+                              onChange={field.onChange}
+                              endpoint="/api/transtornos"
+                              labelSingular="Transtorno"
+                              labelKey="name"
+                              placeholder="Selecione ou crie transtornos..."
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <FormField
+                      control={form.control}
+                      name="serviceTypes"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel className="text-slate-700 font-bold text-xs mb-1.5 block">
+                            Tipos de Atendimento
+                          </FormLabel>
+                          <FormControl>
+                            <GenericDatabaseSelect<ServiceType>
+                              value={field.value}
+                              onChange={field.onChange}
+                              endpoint="/api/tipo-atendimento"
+                              labelSingular="Tipo de Atendimento"
+                              labelKey="area"
+                              placeholder="Selecione ou crie tipos..."
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  </div>
+                </form>
+              </Form>
+            </div>
+            <div className="flex flex-col h-full bg-white p-5 rounded-xl shadow-sm border border-slate-200">
+              <h3 className="text-[#0D4F97] font-bold text-base mb-4 pb-2 border-b border-slate-100 flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <span className="bg-green-50 p-1.5 rounded-lg text-green-700">
+                    <FileText className="h-4 w-4" />
+                  </span>
+                  Documentação Digital
+                </div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 w-8 p-0 hover:bg-slate-100 rounded-full"
+                  onClick={fetchDocuments}
+                  disabled={isLoadingDocs}
+                >
+                  <RefreshCw
+                    className={`h-4 w-4 ${isLoadingDocs ? "animate-spin" : ""}`}
+                  />
+                </Button>
+              </h3>
+              <div className="flex-1 flex flex-col">
+                {isCreateMode ? (
+                  <div className="flex flex-col items-center justify-center h-full text-center p-8 opacity-60">
+                    <FileText className="h-12 w-12 text-slate-300 mb-3" />
+                    <p className="text-slate-500 font-medium text-sm">
+                      Documentos poderão ser anexados após a criação do
+                      registro.
+                    </p>
+                  </div>
+                ) : (
+                  <>
+                    <div className="bg-slate-50 p-5 rounded-xl border-2 border-dashed border-slate-300 mb-6 hover:border-[#0D4F97]/40 transition-all duration-300 group">
+                      <label className="text-xs font-bold text-slate-500 uppercase mb-3 block text-center tracking-widest group-hover:text-[#0D4F97] transition-colors">
+                        Adicionar Novo Documento
+                      </label>
+                      <div className="flex flex-col gap-3 max-w-sm mx-auto w-full">
+                        <Select value={docType} onValueChange={setDocType}>
+                          <SelectTrigger className="w-full bg-white shadow-sm border-slate-200 h-10 text-sm">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {MEDICAL_DOC_TYPES.map((t) => (
+                              <SelectItem key={t.value} value={t.value}>
+                                {t.label}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <input
+                          type="file"
+                          ref={fileInputRef}
+                          onChange={handleFileUpload}
+                          className="hidden"
+                          accept=".pdf,.jpg,.png,.jpeg"
+                          disabled={isUploading}
+                        />
+                        <Button
+                          variant="outline"
+                          className="w-full bg-white text-[#0D4F97] border-[#0D4F97]/20 hover:bg-[#0D4F97] hover:text-white shadow-sm h-10 transition-all text-sm"
+                          onClick={() => fileInputRef.current?.click()}
+                          disabled={isUploading}
+                        >
+                          {isUploading ? (
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          ) : (
+                            <Upload className="mr-2 h-4 w-4" />
+                          )}{" "}
+                          Selecionar Arquivo
+                        </Button>
+                      </div>
+                    </div>
+                    <div className="flex-1 overflow-y-auto max-h-[400px] pr-2 custom-scrollbar">
+                      <h4 className="text-[10px] font-bold text-slate-400 uppercase mb-3 tracking-widest">
+                        Arquivos Anexados ({documents.length})
+                      </h4>
+                      <div className="space-y-2">
+                        {documents.length === 0 ? (
+                          <div className="flex flex-col items-center justify-center h-32 text-slate-400 border-2 border-slate-100 rounded-xl bg-slate-50/50">
+                            <FileText className="h-8 w-8 mb-2 opacity-20" />
+                            <p className="text-xs font-medium opacity-60">
+                              Nenhum documento encontrado.
+                            </p>
+                          </div>
+                        ) : (
+                          documents.map((doc) => (
+                            <div
+                              key={doc.id}
+                              className="group flex items-center justify-between p-3 bg-white border border-slate-100 rounded-xl shadow-sm hover:shadow-md hover:border-[#0D4F97]/20 transition-all duration-200"
+                            >
+                              <div className="flex items-center gap-3 overflow-hidden">
+                                <div className="bg-blue-50 p-2 rounded-lg group-hover:bg-[#0D4F97] group-hover:text-white transition-colors duration-300">
+                                  <FileText className="h-4 w-4" />
+                                </div>
+                                <div className="flex flex-col min-w-0">
+                                  <span
+                                    className="text-sm font-semibold truncate text-slate-700 group-hover:text-[#0D4F97] transition-colors"
+                                    title={doc.name}
+                                  >
+                                    {doc.name}
+                                  </span>
+                                  <span className="text-[10px] text-slate-400 font-bold uppercase tracking-wide mt-0.5">
+                                    {docTypeTranslations[doc.type] || doc.type}
+                                  </span>
+                                </div>
+                              </div>
+                              {doc.url && (
+                                <a
+                                  href={doc.url}
+                                  target="_blank"
+                                  rel="noreferrer"
+                                  className="p-2 text-slate-400 hover:text-[#0D4F97] hover:bg-blue-50 rounded-full transition-all"
+                                  title="Abrir em nova aba"
+                                >
+                                  <ExternalLink className="h-4 w-4" />
+                                </a>
+                              )}
+                            </div>
+                          ))
+                        )}
+                      </div>
+                    </div>
+                  </>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+        <DialogFooter className="px-6 py-4 bg-white border-t border-slate-100 shrink-0 flex justify-end gap-3 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.05)] z-10">
+          <Button
+            variant="ghost"
+            onClick={() => onClose()}
+            type="button"
+            className="text-slate-500 hover:text-slate-800 hover:bg-slate-100 h-10 px-5 rounded-lg font-medium transition-colors text-sm"
+          >
+            Cancelar
+          </Button>
+          <Button
+            form="health-form"
+            type="submit"
+            disabled={isSubmitting}
+            className="text-white bg-[#0D4F97] hover:bg-[#0b427d] shadow-lg shadow-blue-900/10 h-10 px-6 rounded-lg font-bold tracking-wide transition-all transform active:scale-95 text-sm disabled:opacity-70 disabled:cursor-not-allowed"
+          >
+            {isSubmitting ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />{" "}
+                {isCreateMode ? "Criar Registro" : "Salvar Alterações"}
+              </>
+            ) : isCreateMode ? (
+              "Criar Registro"
+            ) : (
+              "Salvar Alterações"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
 }

--- a/apps/apae/src/components/GenericDatabaseSelect.tsx
+++ b/apps/apae/src/components/GenericDatabaseSelect.tsx
@@ -8,31 +8,30 @@ interface Option {
   label: string;
   value: string;
   id?: string | number;
-  [key: string]: any;
 }
 
-interface GenericDatabaseSelectProps {
-  value: any[]; 
-  onChange: (value: any[]) => void;
-  endpoint: string; 
+interface GenericDatabaseSelectProps<T> {
+  value: T[];
+  onChange: (value: T[]) => void;
+  endpoint: string;
   placeholder?: string;
-  labelSingular: string; 
-  labelKey?: string; 
+  labelSingular: string;
+  labelKey: keyof T;
   menuPlacement?: "auto" | "bottom" | "top";
 }
 
-const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+const capitalize = (s: string) =>
+  s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
 
-export const GenericDatabaseSelect = ({ 
-    value, 
-    onChange, 
-    endpoint, 
-    placeholder, 
-    labelSingular,
-    labelKey = "name",
-    menuPlacement = "auto"
-}: GenericDatabaseSelectProps) => {
-  
+export const GenericDatabaseSelect = <T extends { id?: string | number }>({
+  value,
+  onChange,
+  endpoint,
+  placeholder,
+  labelSingular,
+  labelKey,
+  menuPlacement = "auto",
+}: GenericDatabaseSelectProps<T>) => {
   const [options, setOptions] = useState<Option[]>([]);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -40,88 +39,108 @@ export const GenericDatabaseSelect = ({
     const fetchData = async () => {
       try {
         const res = await fetch(endpoint);
+
         if (res.ok) {
-            const data = await res.json();
-            const safeData = Array.isArray(data) ? data :[];
-            setOptions(safeData.map((d: any) => ({ 
-                label: d[labelKey] || d.name || "Sem nome", 
-                value: d[labelKey] || d.name || "Sem nome", 
-                id: d.id
-            })));
+          const data = (await res.json()) as T[];
+          const safeData = Array.isArray(data) ? data : [];
+
+          setOptions(
+            safeData.map((d) => ({
+              label: String(d[labelKey] ?? "Sem nome"),
+              value: String(d[labelKey] ?? "Sem nome"),
+              id: d.id,
+            })),
+          );
         }
-      } catch (error) { console.error(error); }
+      } catch (error) {
+        console.error(error);
+      }
     };
+
     fetchData();
   }, [endpoint, labelKey]);
 
   const getCurrentValue = (): Option[] => {
-    if (!value || !Array.isArray(value)) return[];
-    return value.map((v) => {
-        const text = v[labelKey] || v.name || v.label || v.value;
+    if (!value || !Array.isArray(value)) return [];
+
+    return value
+      .map((v) => {
+        const text = String(v[labelKey] ?? "");
+
         return { label: text, value: text, id: v.id };
-    }).filter(v => v.label); 
+      })
+      .filter((v) => v.label);
   };
 
   const handleChange = (newValue: MultiValue<Option>) => {
-    const formatted = newValue.map(v => ({ 
-        [labelKey]: v.value, 
-        name: v.value,       
-        id: v.id
-    }));
+    const formatted = newValue.map(
+      (v) =>
+        ({
+          [labelKey]: v.value,
+          id: v.id,
+        }) as unknown as T,
+    );
     onChange(formatted);
   };
 
   const handleCreate = async (inputValue: string) => {
     const normalizedName = capitalize(inputValue.trim());
-    const existingOption = options.find(opt => opt.label.toLowerCase() === normalizedName.toLowerCase());
-    
+    const existingOption = options.find(
+      (opt) => opt.label.toLowerCase() === normalizedName.toLowerCase(),
+    );
+
+    const currentSelected = Array.isArray(value) ? value : [];
+
     if (existingOption) {
-        const currentSelected = Array.isArray(value) ? value :[];
-        if (!currentSelected.some(s => s.id === existingOption.id || s[labelKey] === existingOption.value)) {
-            onChange([...currentSelected, {
-                [labelKey]: existingOption.value,
-                name: existingOption.value,
-                id: existingOption.id
-            }]);
-        }
-        return;
+      const isAlreadySelected = currentSelected.some(
+        (s) =>
+          s.id === existingOption.id ||
+          String(s[labelKey] ?? "") === existingOption.value,
+      );
+
+      if (!isAlreadySelected) {
+        onChange([
+          ...currentSelected,
+          {
+            [labelKey]: existingOption.value,
+            id: existingOption.id,
+          } as unknown as T,
+        ]);
+      }
+
+      return;
     }
 
     setIsLoading(true);
     try {
-        const payload = { [labelKey]: normalizedName };
-        
-        const res = await fetch(endpoint, { 
-          method: "POST", 
-          headers: { "Content-Type": "application/json" }, // CORREÇÃO 1: Faltava o header
-          body: JSON.stringify(payload) 
-        });
-        
-        let newOption: Option = { label: normalizedName, value: normalizedName };
-        
-        if (res.ok || res.status === 201 || res.status === 409) {
-            const created = await res.json().catch(() => ({}));
-            if (created && created.id) newOption.id = created.id;
-        }
+      const res = await fetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ [labelKey]: normalizedName }),
+      });
 
-        // CORREÇÃO 2: ID temporário caso a API não devolva o ID imediatamente
-        if (!newOption.id) newOption.id = `temp-${Date.now()}`;
+      const newOption: Option = {
+        label: normalizedName,
+        value: normalizedName,
+      };
 
-        // 1. Atualiza as opções do menu
-        setOptions((prev) => [...prev, newOption]);
-        
-        // CORREÇÃO 3: 2. Injeta direto no formulário com o onChange!
-        const currentSelected = Array.isArray(value) ? value : [];
-        onChange([...currentSelected, { 
-            [labelKey]: newOption.value, 
-            name: newOption.value,
-            id: newOption.id
-        }]);
+      if (res.ok || res.status === 201 || res.status === 409) {
+        const created = (await res.json().catch(() => ({}))) as T;
+        if (created && created.id) newOption.id = created.id;
+      }
 
-    } catch (error) { 
-        console.error(error); 
-    } finally { 
-        setIsLoading(false); 
+      if (!newOption.id) newOption.id = `temp-${Date.now()}`;
+
+      setOptions((prev) => [...prev, newOption]);
+
+      onChange([
+        ...currentSelected,
+        { [labelKey]: newOption.value, id: newOption.id } as unknown as T,
+      ]);
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -132,22 +151,33 @@ export const GenericDatabaseSelect = ({
       borderRadius: "0.375rem",
       fontSize: "0.875rem",
       minHeight: "2.5rem",
-      boxShadow: "none",
       backgroundColor: "white",
+      boxShadow: "none",
       "&:hover": { borderColor: "#cbd5e1" },
-      ...(state.isFocused && { borderColor: "black", borderWidth: "1px", outline: "1px solid black" })
+      ...(state.isFocused && {
+        borderColor: "black",
+        borderWidth: "1px",
+        outline: "1px solid black",
+      }),
     }),
-    multiValue: (base) => ({ ...base, backgroundColor: "#eff6ff", borderRadius: "0.25rem" }),
-    multiValueLabel: (base) => ({ ...base, color: "#0D4F97", fontWeight: 600, fontSize: "0.75rem" }),
-    multiValueRemove: (base) => ({ ...base, color: "#0D4F97", ":hover": { backgroundColor: "#dbeafe", color: "#1e3a8a" } }),
+    multiValue: (base) => ({
+      ...base,
+      backgroundColor: "#eff6ff",
+      borderRadius: "0.25rem",
+    }),
+    multiValueLabel: (base) => ({
+      ...base,
+      color: "#0D4F97",
+      fontWeight: 600,
+      fontSize: "0.75rem",
+    }),
+    multiValueRemove: (base) => ({
+      ...base,
+      color: "#0D4F97",
+      ":hover": { backgroundColor: "#dbeafe", color: "#1e3a8a" },
+    }),
     menu: (base) => ({ ...base, zIndex: 9999 }),
-    menuPortal: (base) => ({ ...base, zIndex: 9999 }), // CORREÇÃO 4: Garante que o menu fique na frente do modal Shadcn
-    menuList: (base) => ({
-        ...base,
-        paddingRight: "4px",
-        "::-webkit-scrollbar": { width: "6px", height: "6px" },
-        "::-webkit-scrollbar-thumb": { background: "#cbd5e1", borderRadius: "3px" }
-    })
+    menuPortal: (base) => ({ ...base, zIndex: 9999 }),
   };
 
   return (
@@ -161,13 +191,15 @@ export const GenericDatabaseSelect = ({
       value={getCurrentValue()}
       styles={customStyles}
       placeholder={placeholder}
-      formatCreateLabel={(inputValue) => `Criar ${labelSingular} "${capitalize(inputValue)}"`}
-      noOptionsMessage={() => `Nenhum(a) ${labelSingular.toLowerCase()} encontrado(a)`}
+      formatCreateLabel={(inputValue) =>
+        `Criar ${labelSingular} "${capitalize(inputValue)}"`
+      }
+      noOptionsMessage={() =>
+        `Nenhum(a) ${labelSingular.toLowerCase()} encontrado(a)`
+      }
       createOptionPosition="first"
-      blurInputOnSelect={false}
-      maxMenuHeight={250}
       menuPlacement={menuPlacement}
-      menuPortalTarget={typeof document !== "undefined" ? document.body : null} // CORREÇÃO 5: Tira o menu de dentro do clipping do modal
+      menuPortalTarget={typeof document !== "undefined" ? document.body : null}
     />
   );
 };

--- a/apps/apae/src/components/StringMultiSelect.tsx
+++ b/apps/apae/src/components/StringMultiSelect.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import CreatableSelect from "react-select/creatable";
 import { MultiValue, StylesConfig } from "react-select";
 

--- a/apps/apae/src/components/creatable-multi-select.tsx
+++ b/apps/apae/src/components/creatable-multi-select.tsx
@@ -321,7 +321,6 @@ export const CreatableMultiSelect = React.forwardRef<
       animationConfig,
       maxCount = 3,
       modalPopover = false,
-      asChild = false,
       className,
       hideSelectAll = false,
       searchable = true,
@@ -874,7 +873,7 @@ export const CreatableMultiSelect = React.forwardRef<
                                 "text-xs px-1.5 py-0.5",
                               screenSize === "mobile" &&
                                 "max-w-[120px] truncate",
-                              singleLine && "flex-shrink-0 whitespace-nowrap",
+                              singleLine && "shrink-0 whitespace-nowrap",
                               "[&>svg]:pointer-events-auto",
                             )}
                             style={{
@@ -945,7 +944,7 @@ export const CreatableMultiSelect = React.forwardRef<
                           multiSelectVariants({ variant }),
                           responsiveSettings.compactMode &&
                             "text-xs px-1.5 py-0.5",
-                          singleLine && "flex-shrink-0 whitespace-nowrap",
+                          singleLine && "shrink-0 whitespace-nowrap",
                           "[&>svg]:pointer-events-auto",
                         )}
                         style={{

--- a/apps/apae/src/components/fileCard.tsx
+++ b/apps/apae/src/components/fileCard.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import * as React from "react";
+import Image from "next/image";
+import { useState } from "react";
+
 import {
   Dialog,
   DialogContent,
@@ -18,7 +20,8 @@ interface Props {
 }
 
 export default function FileCard({ file }: Props) {
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = useState(false);
+  const descriptionId = `dialog-description-${file.fileName.replace(/\s+/g, "-")}`;
 
   return (
     <>
@@ -27,29 +30,42 @@ export default function FileCard({ file }: Props) {
         onClick={() => setOpen(true)}
       >
         <p className="truncate">{file.fileName}</p>
-        <img
-          src={file.link}
-          alt={file.fileName}
-          className="w-full h-32 object-contain mt-2"
-        />
+        <div className="relative w-full h-32 mt-2">
+          <Image
+            src={file.link}
+            alt={file.fileName}
+            fill
+            priority
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+            className="object-contain"
+          />
+        </div>
       </div>
 
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="sm:max-w-[800px]">
+        <DialogContent
+          className="sm:max-w-[800px]"
+          aria-describedby={descriptionId}
+        >
           <DialogHeader>
             <DialogTitle>{file.fileName}</DialogTitle>
           </DialogHeader>
-          <div className="flex justify-center">
-            <img
+          <div
+            id={descriptionId}
+            className="relative w-full h-[60vh] flex justify-center"
+          >
+            <Image
               src={file.link}
               alt={file.fileName}
-              className="max-w-full max-h-[80vh] object-contain"
+              fill
+              sizes="(max-width: 800px) 100vw, 800px"
+              className="object-contain"
             />
           </div>
           <DialogFooter>
             <Button
               variant="secondary"
-              onClick={() => window.open(file.link, file.fileName)}
+              onClick={() => window.open(file.link, "_blank")}
               className="cursor-pointer hover:bg-gray-300 hover:text-black transition-colors"
             >
               Visualizar Arquivo

--- a/apps/apae/src/components/shared/DataTable.tsx
+++ b/apps/apae/src/components/shared/DataTable.tsx
@@ -1,3 +1,5 @@
+import { ReactNode } from "react";
+
 import {
   Table,
   TableBody,
@@ -5,20 +7,20 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from "@/components/ui/table"
+} from "@/components/ui/table";
 
-interface Column {
-  header: string
-  accessor: string
+interface Column<T> {
+  header: string;
+  accessor: keyof T;
 }
 
-interface DataTableProps {
-  columns: Column[]
-  data: any[]
-  actions?: (row: any) => React.ReactNode
+interface DataTableProps<T> {
+  columns: Column<T>[];
+  data: T[];
+  actions?: (row: T) => ReactNode;
 }
 
-export function DataTable({ columns, data, actions }: DataTableProps) {
+export function DataTable<T>({ columns, data, actions }: DataTableProps<T>) {
   return (
     <Table>
       <TableHeader>
@@ -33,12 +35,14 @@ export function DataTable({ columns, data, actions }: DataTableProps) {
         {data.map((row, i) => (
           <TableRow key={i}>
             {columns.map((col, j) => (
-              <TableCell key={j}>{row[col.accessor]}</TableCell>
+              <TableCell key={j}>
+                {row[col.accessor] as React.ReactNode}
+              </TableCell>
             ))}
             {actions && <TableCell>{actions(row)}</TableCell>}
           </TableRow>
         ))}
       </TableBody>
     </Table>
-  )
+  );
 }

--- a/apps/apae/src/components/shared/filters/fileFilter.tsx
+++ b/apps/apae/src/components/shared/filters/fileFilter.tsx
@@ -14,7 +14,6 @@ type FileFilterProps = {
   readonly type: string;
   readonly onYearChange: (year: string) => void;
   readonly onTypeChange: (type: string) => void;
-  readonly categoryTypes: string[];
 };
 
 const years = [2023, 2024, 2025];
@@ -29,7 +28,6 @@ export default function FileFilter({
   type,
   onYearChange,
   onTypeChange,
-  categoryTypes,
 }: FileFilterProps) {
   console.log(type);
   return (

--- a/apps/apae/src/components/sidebar/Header.tsx
+++ b/apps/apae/src/components/sidebar/Header.tsx
@@ -1,19 +1,26 @@
 "use client";
 
 import React from "react";
+import Image from "next/image";
 import { User } from "lucide-react";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import Logo from "../../assets/logo.png";
 
 export default function Header() {
   return (
-    <header className="flex h-16 shrink-0 items-center justify-between bg-[#0D4F97] px-4 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12 rounded-lg relative my-4 mx-10 shadow-lg">
+    <header className="flex h-16 shrink-0 items-center justify-between bg-[#0D4F97] px-4 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12 rounded-lg relative my-4 mx-10 shadow-lg">
       <div className="flex items-center">
         <SidebarTrigger className="text-white hover:bg-white/10" />
       </div>
 
       <div className="flex-1 flex items-center justify-center">
-        <img src={Logo.src} alt="logo apae" className="h-10 w-8 mr-3" />
+        <Image
+          src={Logo}
+          alt="logo apae"
+          width={32}
+          height={40}
+          className="mr-3 h-10 w-8 object-contain"
+        />
         <span className="text-white font-medium text-lg hidden md:block">
           Apae Esperança
         </span>

--- a/apps/apae/src/components/sidebar/sidebar.tsx
+++ b/apps/apae/src/components/sidebar/sidebar.tsx
@@ -1,4 +1,18 @@
 "use client";
+
+import {
+  BriefcaseMedical,
+  LogOut,
+  ShieldUser,
+  SquareActivity,
+  Stethoscope,
+  Syringe,
+  UserRoundPlus,
+} from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+
 import {
   Sidebar,
   SidebarContent,
@@ -9,48 +23,38 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  useSidebar,
 } from "@/components/ui/sidebar";
+import { removeSessionCookie } from "@/lib/cookies";
+import { cn } from "@/lib/utils";
 import {
+  AlertIcon,
+  ArrowLeftIcon,
   ChecklistIcon,
   ChevronDownIcon,
   ClockIcon,
-  AlertIcon,
   IdBadgeIcon,
-  TasklistIcon,
-  ArrowLeftIcon,
-  PersonIcon,
   PeopleIcon,
+  PersonIcon,
+  TasklistIcon,
 } from "@primer/octicons-react";
-import Image from "next/image";
-import Link from "next/link";
+import logo from "../../assets/logo.png";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "../ui/collapsible";
 import styles from "./sidebar.module.css";
-import { useSidebar } from "@/components/ui/sidebar";
-import { usePathname, useRouter } from "next/navigation";
-import { cn } from "@/lib/utils";
-import logo from "../../assets/logo.png";
-import {
-  SquareActivity,
-  BriefcaseMedical,
-  Syringe,
-  Stethoscope,
-  LogOut,
-  ShieldUser,
-  UserRoundPlus,
-} from "lucide-react";
-import { removeSessionCookie } from "@/lib/cookies";
 
 export function AppSidebar() {
-  const { open, setOpen, isMobile, setOpenMobile } = useSidebar();
+  const { setOpen, isMobile, setOpenMobile } = useSidebar();
+
   const pathname = usePathname();
   const router = useRouter();
 
   const handleLogout = () => {
     removeSessionCookie();
+
     router.refresh();
   };
 
@@ -103,8 +107,8 @@ export function AppSidebar() {
                       className={`${styles.menuButton} font-base gap-2 ${cn(
                         "h-10 transition-colors",
                         pathname == "/"
-                          ? "bg-[#FFFFFF] !text-[#000000]"
-                          : "text-[#0D4F97] hover:bg-[#0D4F97] hover:!text-white",
+                          ? "bg-[#FFFFFF] text-[#000000]!"
+                          : "text-[#0D4F97] hover:bg-[#0D4F97] hover:text-white!",
                       )}`}
                     >
                       <ChecklistIcon size={16} />
@@ -118,8 +122,8 @@ export function AppSidebar() {
                       className={`${styles.menuButton} font-base gap-2 ${cn(
                         "h-10 transition-colors",
                         pathname == "/all-appointments"
-                          ? "bg-[#FFFFFF] !text-[#000000]"
-                          : "text-[#0D4F97] hover:bg-[#0D4F97] hover:!text-white",
+                          ? "bg-[#FFFFFF] text-[#000000]!"
+                          : "text-[#0D4F97] hover:bg-[#0D4F97] hover:text-white!",
                       )}`}
                     >
                       <TasklistIcon size={16} />
@@ -133,8 +137,8 @@ export function AppSidebar() {
                       className={`${styles.menuButton} font-base gap-2 ${cn(
                         "h-10 transition-colors",
                         pathname == "/absence"
-                          ? "bg-[#FFFFFF] !text-[#000000]"
-                          : "text-[#0D4F97] hover:bg-[#0D4F97] hover:!text-white",
+                          ? "bg-[#FFFFFF] text-[#000000]!"
+                          : "text-[#0D4F97] hover:bg-[#0D4F97] hover:text-white!",
                       )}`}
                     >
                       <AlertIcon size={16} />
@@ -169,8 +173,8 @@ export function AppSidebar() {
                       className={`${styles.menuButton} font-base gap-2 ${cn(
                         "h-10 transition-colors",
                         pathname == "/visualization-professional"
-                          ? "bg-[#FFFFFF] !text-[#000000]"
-                          : "text-[#0D4F97] hover:bg-[#0D4F97] hover:!text-white",
+                          ? "bg-[#FFFFFF] text-[#000000]!"
+                          : "text-[#0D4F97] hover:bg-[#0D4F97] hover:text-white!",
                       )}`}
                     >
                       <Stethoscope size={20} />
@@ -184,8 +188,8 @@ export function AppSidebar() {
                       className={`${styles.menuButton} font-base gap-2 ${cn(
                         "h-10 transition-colors",
                         pathname == "/tipo-atendimento"
-                          ? "bg-[#FFFFFF] !text-[#000000]"
-                          : "text-[#0D4F97] hover:bg-[#0D4F97] hover:!text-white",
+                          ? "bg-[#FFFFFF] text-[#000000]!"
+                          : "text-[#0D4F97] hover:bg-[#0D4F97] hover:text-white!",
                       )}`}
                     >
                       <BriefcaseMedical size={16} />
@@ -220,8 +224,8 @@ export function AppSidebar() {
                       className={`${styles.menuButton} font-base gap-2 ${cn(
                         "h-10 transition-colors",
                         pathname == "/visualization-patients"
-                          ? "bg-[#FFFFFF] !text-[#000000]"
-                          : "text-[#0D4F97] hover:bg-[#0D4F97] hover:!text-white",
+                          ? "bg-[#FFFFFF] text-[#000000]!"
+                          : "text-[#0D4F97] hover:bg-[#0D4F97] hover:text-white!",
                       )}`}
                     >
                       <PeopleIcon size={16} />
@@ -235,8 +239,8 @@ export function AppSidebar() {
                       className={`${styles.menuButton} font-base gap-2 ${cn(
                         "h-10 transition-colors",
                         pathname == "/disorders"
-                          ? "bg-[#FFFFFF] !text-[#000000]"
-                          : "text-[#0D4F97] hover:bg-[#0D4F97] hover:!text-white",
+                          ? "bg-[#FFFFFF] text-[#000000]!"
+                          : "text-[#0D4F97] hover:bg-[#0D4F97] hover:text-white!",
                       )}`}
                     >
                       <SquareActivity size={16} />
@@ -250,8 +254,8 @@ export function AppSidebar() {
                       className={`${styles.menuButton} font-base gap-2 ${cn(
                         "h-10 transition-colors",
                         pathname == "/vaccines"
-                          ? "bg-[#FFFFFF] !text-[#000000]"
-                          : "text-[#0D4F97] hover:bg-[#0D4F97] hover:!text-white",
+                          ? "bg-[#FFFFFF] text-[#000000]!"
+                          : "text-[#0D4F97] hover:bg-[#0D4F97] hover:text-white!",
                       )}`}
                     >
                       <Syringe size={16} />
@@ -263,7 +267,7 @@ export function AppSidebar() {
             </CollapsibleContent>
           </SidebarGroup>
         </Collapsible>
-        
+
         <Collapsible defaultOpen={false} className="group/collapsible">
           <SidebarGroup>
             <SidebarGroupLabel asChild>
@@ -286,8 +290,8 @@ export function AppSidebar() {
                       className={`${styles.menuButton} font-base gap-2 ${cn(
                         "h-10 transition-colors",
                         pathname == ""
-                          ? "bg-[#FFFFFF] !text-[#000000]"
-                          : "text-[#0D4F97] hover:bg-[#0D4F97] hover:!text-white"
+                          ? "bg-[#FFFFFF] text-[#000000]!"
+                          : "text-[#0D4F97] hover:bg-[#0D4F97] hover:text-white!",
                       )}`}
                     >
                       <UserRoundPlus size={16} />
@@ -308,7 +312,7 @@ export function AppSidebar() {
           flex w-full items-center rounded-3xl bg-transparent text-[#0D4F97] transition-all hover:bg-white/40 justify-center gap-3 px-4 py-3 cursor-pointer`}
           title="Sair"
         >
-          <LogOut className="h-5 w-5 flex-shrink-0" strokeWidth={1.75} />
+          <LogOut className="h-5 w-5 shrink-0" strokeWidth={1.75} />
           {<span className="font-medium">Sair</span>}
         </button>
       </SidebarFooter>


### PR DESCRIPTION
# O que esse PR forneceu?

- **Tipagem Estática com Generics**: substituição do tipo `any` por Generics (`<T>`) nos componentes `DataTable` e `GenericDatabaseSelect`, garantindo *type-safety* e melhor suporte do IntelliSense.

- **Otimização de Imagens (Next.js)**: substituição de tags nativas `<img>` pelo componente `Image` do `next/image` nos layouts de autenticação, cabeçalho e cartões de arquivo. Foram aplicadas as propriedades `priority`, `fill` e `sizes` para melhorar o *Largest Contentful Paint* (LCP) e reduzir o consumo de banda.

- **Limpeza de Código (Cleanup)**: remoção de imports e variáveis declaradas mas não utilizadas em componentes como `Sidebar`, `FileFilter`, `StringMultiSelect` e `CreatableMultiSelect`.

- **Correções de Linting**: ajustes de `let` para `const` quando não há reatribuição e resolução de avisos de acessibilidade (`aria-describedby`) em componentes de diálogo.

- **Melhoria na Performance de Carregamento**: uso do componente `Image` do Next.js trouxe redimensionamento automático e *lazy loading* nativo, impactando positivamente na pontuação do *Core Web Vitals*.

- **Padronização de Layout**: correção de avisos de importação no `layout.tsx` principal, removendo componentes de `Sidebar` que estavam importados mas não renderizados.

# Coleta de evidências

Este PR não contém anexos de mídia, focando estritamente em correções técnicas de tipagem, linting e performance.