### PR TITLE
BUILD - Ajustar tipagem de APIs e Utils- Escopo Geral

### DIFF
--- a/apps/apae/src/app/api/tipo-atendimento/[id]/route.ts
+++ b/apps/apae/src/app/api/tipo-atendimento/[id]/route.ts
@@ -1,6 +1,7 @@
 import { createBaseApi } from "@/lib/axios";
 import { updateserviceTypeSchema } from "@/schemas/service-type-schemas";
 import { NextResponse } from "next/server";
+import { AxiosError } from "axios";
 
 interface IParams {
   params: Promise<{ id: string }>;
@@ -12,8 +13,15 @@ export async function GET(request: Request, { params }: IParams) {
     const api = await createBaseApi();
     const { data } = await api.get(`/service-areas/${id}`);
     return NextResponse.json(data);
-  } catch (error: any) {
-    return new NextResponse(JSON.stringify(error.response?.data), { status: 500 });
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      return new NextResponse(
+        JSON.stringify(error.response?.data || { message: error.message }),
+        { status: error.response?.status || 500 }
+      );
+    }
+
+    return new NextResponse(JSON.stringify({ message: "Erro ao buscar dados" }), { status: 500 });
   }
 }
 
@@ -27,7 +35,14 @@ export async function PUT(request: Request, { params }: IParams) {
     const api = await createBaseApi();
     const { data } = await api.put(`/service-areas/${id}`, validation.data);
     return NextResponse.json(data);
-  } catch (error: any) {
-    return new NextResponse(JSON.stringify(error.response?.data), { status: 500 });
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      return new NextResponse(
+        JSON.stringify(error.response?.data || { message: error.message }),
+        { status: error.response?.status || 500 } 
+      );
+    }
+
+    return new NextResponse(JSON.stringify({ message: "Erro ao atualizar dados." }), { status: 500 });
   }
 }

--- a/apps/apae/src/app/api/tipo-atendimento/route.ts
+++ b/apps/apae/src/app/api/tipo-atendimento/route.ts
@@ -1,6 +1,7 @@
 import { createBaseApi } from "@/lib/axios";
 import { createserviceTypeSchema } from "@/schemas/service-type-schemas";
 import { NextResponse } from "next/server";
+import { AxiosError } from "axios";
 
 export async function POST(request: Request) {
   try {
@@ -22,11 +23,16 @@ export async function POST(request: Request) {
     const { data } = await api.post("/service-areas", validation.data);
 
     return NextResponse.json(data);
-  } catch (error: any) {
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      return new NextResponse(
+        JSON.stringify(error.response?.data || { message: error.message }),
+        { status: error.response?.status || 500 }
+      );
+    }
+
     return new NextResponse(
-      JSON.stringify(error.response?.data || { message: error.message }),
-      { status: error.response?.status || 500 }
-    );
+      JSON.stringify({ message: "Ocorreu um erro inesperado." }), { status: 500 });
   }
 }
 
@@ -35,10 +41,14 @@ export async function GET() {
     const api = await createBaseApi();
     const { data } = await api.get("/service-areas");
     return NextResponse.json(data);
-  } catch (error: any) {
-    return new NextResponse(
-      JSON.stringify(error.response?.data || { message: error.message }),
-      { status: error.response?.status || 500 }
-    );
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      return new NextResponse(
+        JSON.stringify(error.response?.data || { message: error.message }),
+        { status: error.response?.status || 500 }
+      );
+    }
+
+    return new NextResponse(JSON.stringify({ message: "Erro ao buscar dados." }), { status: 500 });
   }
 }

--- a/apps/apae/src/app/api/transtornos/[id]/route.ts
+++ b/apps/apae/src/app/api/transtornos/[id]/route.ts
@@ -1,6 +1,7 @@
 import { createBaseApi } from "@/lib/axios";
 import { updateTranstornoSchema } from "@/schemas/transtornosSchema";
 import { NextResponse } from "next/server";
+import { AxiosError } from "axios";
 
 interface IParams {
   params: Promise<{ id: string }>;
@@ -12,8 +13,11 @@ export async function GET(request: Request, { params }: IParams) {
     const api = await createBaseApi();
     const { data } = await api.get(`/disorders/${id}`);
     return NextResponse.json(data);
-  } catch (error: any) {
-    return new NextResponse(JSON.stringify(error.response?.data), { status: 500 });
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      return new NextResponse(JSON.stringify(error.response?.data || { message: error.message }), { status: error.response?.status || 500 });
+    }
+    return new NextResponse(JSON.stringify({ message: "Erro ao buscar dados." }), { status: 500 });
   }
 }
 
@@ -27,8 +31,11 @@ export async function PUT(request: Request, { params }: IParams) {
     const api = await createBaseApi();
     const { data } = await api.put(`/disorders/${id}`, validation.data);
     return NextResponse.json(data);
-  } catch (error: any) {
-    return new NextResponse(JSON.stringify(error.response?.data), { status: 500 });
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      return new NextResponse(JSON.stringify(error.response?.data || { message: error.message }), { status: error.response?.status || 500 });
+    }
+    return new NextResponse(JSON.stringify({ message: "Erro ao atualizar dados." }), { status: 500 });
   }
 }
 
@@ -38,7 +45,10 @@ export async function DELETE(request: Request, { params }: IParams) {
     const api = await createBaseApi();
     const { data } = await api.delete(`/disorders/${id}`);
     return NextResponse.json(data);
-  } catch (error: any) {
-    return new NextResponse(JSON.stringify(error.response?.data), { status: 500 });
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      return new NextResponse(JSON.stringify(error.response?.data || { message: error.message }), { status: error.response?.status || 500 });
+    }
+    return new NextResponse(JSON.stringify({ message: "Erro ao excluir dados." }), { status: 500 });
   }
 }

--- a/apps/apae/src/app/api/transtornos/route.ts
+++ b/apps/apae/src/app/api/transtornos/route.ts
@@ -24,20 +24,22 @@ export async function POST(request: Request) {
 
     return NextResponse.json(data, { status: 201 });
 
-  } catch (error: any) {
-    const err = error as AxiosError;
-    
-    if (err.response?.status === 409) {
-        return NextResponse.json(
-            { message: "Transtorno já existente, prosseguindo." }, 
-            { status: 200 }
+  } catch (error) {    
+    if (error instanceof AxiosError) {
+      if (error.response?.status === 409) {
+        return new NextResponse(
+          JSON.stringify({ message: "Transtorno já existente, prosseguindo." }), 
+          { status: 200 }
         );
-    }
+      }
 
-    return new NextResponse(
-      JSON.stringify(err.response?.data || { message: err.message }),
-      { status: err.response?.status || 500 }
-    );
+      return new NextResponse(
+        JSON.stringify(error.response?.data || { message: error.message }),
+        { status: error.response?.status || 500 } 
+      );
+    }
+    
+    return new NextResponse(JSON.stringify({ message: "Erro inesperado ao criar dados" }), { status: 500 });
   }
 }
 
@@ -46,10 +48,11 @@ export async function GET() {
     const api = await createBaseApi();
     const { data } = await api.get("/disorders");
     return NextResponse.json(data);
-  } catch (error: any) {
-    return new NextResponse(
-      JSON.stringify(error.response?.data || { message: error.message }),
-      { status: error.response?.status || 500 }
-    );
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      return new NextResponse(JSON.stringify(error.response?.data || { message: error.message }), { status: error.response?.status || 500 });
+    }
+
+    return new NextResponse(JSON.stringify({ message: "Erro ao buscar transtornos." }), { status: 500 });
   }
 }

--- a/apps/apae/src/app/api/vacinas/[id]/route.ts
+++ b/apps/apae/src/app/api/vacinas/[id]/route.ts
@@ -1,5 +1,6 @@
 import { createBaseApi } from "@/lib/axios";
 import { NextResponse } from "next/server";
+import { AxiosError } from "axios";
 
 interface Params {
     params: Promise<{ id: string }>;
@@ -11,8 +12,11 @@ export async function GET(request: Request, { params }: Params) {
         const api = await createBaseApi();
         const { data } = await api.get(`/vaccines/${id}`);
         return NextResponse.json(data);
-    } catch (error: any) {
-        return new NextResponse(JSON.stringify(error.response?.data), { status: 500 });
+    } catch (error) {
+        if (error instanceof AxiosError) {
+            return new NextResponse(JSON.stringify(error.response?.data || { message: error.message }), { status: error.response?.status || 500 });
+        }
+        return new NextResponse(JSON.stringify({ message: "Erro ao buscar dados." }), { status: 500 });
     }
 }
 
@@ -23,8 +27,11 @@ export async function PUT(request: Request, { params }: Params) {
         const api = await createBaseApi();
         const { data } = await api.put(`/vaccines/${id}`, body);
         return NextResponse.json(data);
-    } catch (error: any) {
-        return new NextResponse(JSON.stringify(error.response?.data), { status: 500 });
+    } catch (error) {
+        if (error instanceof AxiosError) {
+            return new NextResponse(JSON.stringify(error.response?.data || { message: error.message }), { status: error.response?.status || 500 });
+        }
+        return new NextResponse(JSON.stringify({ message: "Erro ao atualizar dados." }), { status: 500 });
     }
 }
 
@@ -34,7 +41,10 @@ export async function DELETE(request: Request, { params }: Params) {
         const api = await createBaseApi();
         const { data } = await api.delete(`/vaccines/${id}`);
         return NextResponse.json(data);
-    } catch (error: any) {
-        return new NextResponse(JSON.stringify(error.response?.data), { status: 500 });
+    } catch (error) {
+        if (error instanceof AxiosError) {
+            return new NextResponse(JSON.stringify(error.response?.data || { message: error.message }), { status: error.response?.status || 500 });
+        }
+        return new NextResponse(JSON.stringify({ message: "Erro ao excluir dados." }), { status: 500 });
     }
 }

--- a/apps/apae/src/app/api/vacinas/route.ts
+++ b/apps/apae/src/app/api/vacinas/route.ts
@@ -9,15 +9,17 @@ export async function POST(request: Request) {
         const { data } = await api.post("/vaccines", body);
         
         return NextResponse.json(data, { status: 201 });
-    } catch (error: any) {
-        const err = error as AxiosError;
-        if (err.response?.status === 409) {
-             return NextResponse.json({ message: "Vacina já existe" }, { status: 200 });
+    } catch (error) {
+        if(error instanceof AxiosError) {
+            if (error.response?.status === 409) {
+             return new NextResponse(JSON.stringify({ message: "Vacina já existe" }), { status: 200 });
+            }
+            return new NextResponse(
+                JSON.stringify(error.response?.data || { message: error.message }), { status: error.response?.status || 500 }
+            );
         }
-        return new NextResponse(
-            JSON.stringify(err.response?.data || { message: err.message }),
-            { status: err.response?.status || 500 },
-        );
+        
+        return new NextResponse(JSON.stringify({ message: "Erro inesperado ao criar vacina" }), { status: 500 });
     }
 }
 
@@ -26,8 +28,10 @@ export async function GET() {
         const api = await createBaseApi();
         const { data } = await api.get("/vaccines");
         return NextResponse.json(data);
-    } catch (error: any) {
-        console.error("Erro ao buscar vacinas:", error.message);
-        return NextResponse.json([], { status: 200 });
+    } catch (error) {
+        const message = error instanceof Error ? error.message : "Erro desconhecido";
+        console.error("Erro ao buscar vacinas:", message);
+        return NextResponse.json({ message: "Erro ao buscar a lista de vacinas." }, { status: 500 }
+        );
     }
 }

--- a/apps/apae/src/utils/form-errors.ts
+++ b/apps/apae/src/utils/form-errors.ts
@@ -1,4 +1,4 @@
-import { UseFormSetError } from "react-hook-form";
+import { UseFormSetError, FieldValues, Path } from "react-hook-form";
 
 /**
  * Interface que espelha o ValidationErrorResponse do Java.
@@ -19,9 +19,9 @@ interface ApiErrorResponse {
  * * @param errorData Objeto de erro retornado pela API contendo a lista de campos.
  * @param setError Função setError proveniente do useForm do React Hook Form.
  */
-export function handleBackendValidationErrors(
+export function handleBackendValidationErrors<T extends FieldValues>(
   errorData: ApiErrorResponse,
-  setError: UseFormSetError<any>,
+  setError: UseFormSetError<T>,
 ) {
   if (errorData.fields && Array.isArray(errorData.fields)) {
     errorData.fields.forEach((err) => {
@@ -38,7 +38,7 @@ export function handleBackendValidationErrors(
       if (fieldName === "contact") fieldName = "phone";
       if (fieldName === "familyIncome") fieldName = "householdIncome";
 
-      setError(fieldName as any, {
+      setError(fieldName as Path<T>, {
         type: "server",
         message: err.message,
       });


### PR DESCRIPTION
## O que mudou?
A principal mudança consistiu na substituição do tipo genérico any pela verificação de instância AxiosError, permitindo que o TypeScript valide a existência de propriedades como response e status antes do acesso, eliminando falhas de "runtime" e erros de tipagem estática.

**Issue:** #637 

## Tarefas Relacionadas
* **Refatoração de Tipagem :** Substituição de `any` por `instanceof AxiosError` em todas as rotas de API para garantir segurança de tipos e tratamento de erros dinâmico;
* **Tipagem Genérica em Utils:** Refatoração da função handleBackendValidationErrors utilizando Generics do TypeScript (<T extends FieldValues>) para garantir suporte a qualquer formulário do sistema.

##  Mudanças realizadas

####  Camada de API e Utils (Segurança de Tipos)
* **`src/app/api/.../route.ts`**: Refatoração dos métodos `GET`, `POST`, `PUT` e `DELETE`. Removido o uso de `any` no catch e implementada a verificação `instanceof AxiosError`.
* **`src/utils/form-errors.ts`**: Implementação de Generics (`<T extends FieldValues>`) na função `handleBackendValidationErrors`, eliminando erros de lint e garantindo autocomplete nos campos de formulário.

## Evidências
Este PR não contém anexos de mídia, focando exclusivamente na correção de tipagem e estabilidade do build.
