### PR TITLE
571-ajuste para excluir os pacientes não associados

### DIFF
--- a/apps/apae/src/app/disorders/TranstornosListItem.tsx
+++ b/apps/apae/src/app/disorders/TranstornosListItem.tsx
@@ -33,36 +33,44 @@ export function TranstornoListItem({
         >
           <Edit className="h-4 w-4" />
         </Button>
-        
-        <ConfirmModal
-          title="Tem certeza?"
-          description={<>Essa ação não pode ser desfeita. Isso irá excluir permanentemente o transtorno <strong>{transtorno.name}</strong>.</>}
-          onConfirm={onDelete}
-          trigger={
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className={transtorno.hasPatient ? "cursor-not-allowed" : ""}>
-                      <Button
-                        variant="outline"
-                        size="icon"
-                        disabled={transtorno.hasPatient}
-                        className={transtorno.hasPatient ? "pointer-events-none opacity-50" : "h-8-w-8"}
-                      >
-                        <Trash2 className="h-4 w-4 text-red-500"/>
-                      </Button>
-                    </span>
-                  </TooltipTrigger>
-                  {transtorno.hasPatient && (
-                    <TooltipContent side="top">
-                      <p>Não é possível excluir transtorno pois está associado a um paciente!</p>
-                    </TooltipContent>
-                  )}
-                </Tooltip>
-              </TooltipProvider> 
-          }
-          />
 
+        {transtorno.hasPatient ? (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="cursor-not-allowed">
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    className="h-8 w-8 hover:bg-red-50 hover:border-red-500 cursor-not-allowed"
+                    disabled 
+                  >
+                    <Trash2 className="h-4 w-4 text-red-500" />
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="top" className="bg-slate-800 text-white p-2 rounded shadow-lg">
+                <p>Não é possível excluir este transtorno porque ele está associado a um paciente!</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+
+        ) : (
+            <ConfirmModal
+              title="Tem certeza?"
+              description={<>Essa ação não pode ser desfeita. Isso irá excluir permanentemente o transtorno <strong>{transtorno.name}</strong>.</>}
+              onConfirm={onDelete}
+              trigger={
+                <Button
+                  variant="outline"
+                  size="icon"
+                  className="h-8 w-8 hover:bg-red-50 hover:border-red-500"
+                >
+                  <Trash2 className="h-4 w-4 text-red-500"/>
+                </Button>
+              }
+            />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
O que foi feito?

No PR entregue https://github.com/IFPBEsp/APAE/pull/632, foi realizado a implementação para desabilitar o botão de excluir transtornos caso tivesse pacientes associados. Porém, no PR não foi incluído a parte em que permite excluir pacientes não associados.

Foi alterado "TranstornoListItem.tsx":
<img width="1645" height="896" alt="image" src="https://github.com/user-attachments/assets/5907bf35-d461-408e-b850-6fbc9ae6d4d8" />

Agora, está funcionando corretamente:

<img width="1906" height="741" alt="Captura de tela 2026-04-07 111637" src="https://github.com/user-attachments/assets/8e4f8f4b-db9c-42c7-ba62-59f5b9627d35" />

<img width="1901" height="843" alt="Captura de tela 2026-04-07 111648" src="https://github.com/user-attachments/assets/cbbe8633-0201-40aa-971d-df6a19e4e054" />
