### PR TITLE
fix: correção da filtragem por área da saúde na aba 'todos os agendam…

### DIFF
--- a/apps/apae/src/app/all-appointments/page.tsx
+++ b/apps/apae/src/app/all-appointments/page.tsx
@@ -110,7 +110,11 @@ useEffect(() => {
         .toLowerCase()
         .includes(search);
 
-    return matchesDate && matchesSearch;
+    const matchesArea = selectedArea
+      ? appointment.professional.healthSector === selectedArea
+        : true;
+
+    return matchesDate && matchesSearch && matchesArea;
   });
 
   const clearFilter = () => {

--- a/apps/apae/src/app/all-appointments/page.tsx
+++ b/apps/apae/src/app/all-appointments/page.tsx
@@ -194,7 +194,7 @@ useEffect(() => {
             />
           </div>
 
-          <Select onValueChange={setSelectedArea}>
+          <Select value={selectedArea} onValueChange={setSelectedArea}>
             <SelectTrigger className="data-[placeholder]:text-[#0D4F97] border-[#0D4F97] hover:bg-accent">
               <SelectValue placeholder="Área da Saúde" />
             </SelectTrigger>


### PR DESCRIPTION
Problema:
Na tela "Todos os Agendamentos", o filtro por profissional não está funcionando corretamente. Ao selecionar um tipo de profissional, os agendamentos não são filtrados como esperado.

Causa:
O estado `selectedArea` era atualizado corretamente pelo componente `Select`, porém nunca era utilizado na lógica de filtragem de `filteredAppointments`. A condição `matchesArea` simplesmente não existia, e o `return` do `.filter()` ignorava completamente o valor selecionado.

Solução:
- Adicionada a constante `matchesArea` que verifica se a área do profissional corresponde à área selecionada
- Incluída `matchesArea` no `return` do filtro junto com `matchesDate` e `matchesSearch`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Appointment filtering now includes health area selection. When a specific health area is selected, only matching appointments are displayed. When no area is selected, all appointments are shown regardless of health sector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->