### PR TITLE
565 melhorar ux do formulário de cadastroedição de pacientes

### DIFF
--- a/apps/apae/src/app/person/[id]/edit/layout.tsx
+++ b/apps/apae/src/app/person/[id]/edit/layout.tsx
@@ -6,6 +6,8 @@ import { DisordersProvider } from "@/hooks/use-disorders";
 import { useParams, useRouter, usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 import { Loader2 } from "lucide-react";
+import Image from "@/assets/background_image.jpg";
+import { SidebarSteps } from "@/components/shared/SidebarSteps";
 
 function EditPatientDataLoader({ children }: { children: React.ReactNode }) {
   const { setters, state } = useMembersRegisterContext();
@@ -118,7 +120,33 @@ export default function EditPatientLayout({ children }: { children: React.ReactN
       {/* @ts-ignore */}
       <DisordersProvider>
         <MembersRegisterProvider>
-          <EditPatientDataLoader>{children}</EditPatientDataLoader>
+          <EditPatientDataLoader>
+            {/* 🚀 NOVA ESTRUTURA VISUAL (Duas Colunas) */}
+            <div className="h-[90vh] md:h-screen rounded-xl md:rounded-none md:mx-0 mx-4 my-4 md:my-0 relative grid grid-cols-1 md:grid-cols-[1fr_2fr] antialiased overflow-hidden shadow-2xl">
+              
+              {/* Fundo e degradê da coluna esquerda */}
+              <div className="hidden md:block absolute inset-0 bg-cover bg-center bg-no-repeat grayscale-90 w-1/3" style={{ backgroundImage: `url(${Image.src})`, backgroundAttachment: "fixed" }} />
+              <div className="hidden md:block absolute inset-0 w-1/3" style={{ background: "linear-gradient(180deg, rgba(13, 79, 151, 0.9) 0%, rgba(13, 79, 151, 0.95) 100%)" }} />
+
+              {/* O MENU LATERAL */}
+              <div className="hidden md:flex relative z-10 w-full h-full bg-[#0D4F97]/90 backdrop-blur-sm">
+                <SidebarSteps />
+              </div>
+
+              {/* O FORMULÁRIO (Coluna direita) */}
+              <div className="relative flex flex-col w-full h-full p-4 md:p-12 bg-slate-50 overflow-y-auto">
+                <div className="max-w-3xl mx-auto w-full">
+                  <h1 className="text-2xl md:text-3xl font-bold text-[#0D4F97] mb-6 border-b pb-4">
+                    Edição de Paciente
+                  </h1>
+                  <div className="bg-white p-6 md:p-8 rounded-xl shadow-sm border border-slate-200">
+                    {children}
+                  </div>
+                </div>
+              </div>
+
+            </div>
+          </EditPatientDataLoader>
         </MembersRegisterProvider>
       </DisordersProvider>
     </VaccinesProvider>

--- a/apps/apae/src/app/person/register/additional/page.tsx
+++ b/apps/apae/src/app/person/register/additional/page.tsx
@@ -215,6 +215,18 @@ export default function MembersRegisterAdditionalsPage() {
     }
   }, [additionals, form, isEditing, isInitialized]);
 
+  useEffect(() => {
+    const hasData = 
+      additionals.diseases !== "" || 
+      additionals.vaccines.length > 0 || 
+      additionals.disability.report instanceof File || 
+      additionals.care.referral instanceof File;
+
+    if (hasData) {
+      form.reset(additionals);
+    }
+  }, [additionals, form]);
+
   const onSubmit = async (values: any) => {
     setIsLoading(true);
     try {

--- a/apps/apae/src/app/person/register/address/page.tsx
+++ b/apps/apae/src/app/person/register/address/page.tsx
@@ -71,6 +71,12 @@ export default function MembersRegisterAddressPage() {
     }
   };
 
+  useEffect(() => {
+    if (address.cep !== "") { 
+       form.reset(address);
+    }
+  }, [address, form]);
+
   return (
     <Form {...form}>
       <MembersRegisterForm

--- a/apps/apae/src/app/person/register/kinships/page.tsx
+++ b/apps/apae/src/app/person/register/kinships/page.tsx
@@ -16,7 +16,7 @@ import {
 import { formatCPF, formatRG } from "@/lib/formats";
 import { Kinships } from "@/schemas/member-schemas";
 import { zodResolver } from "@hookform/resolvers/zod";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
 import { handleBackendValidationErrors } from "@/utils/form-errors";
 
@@ -44,6 +44,11 @@ export default function MembersRegisterKinshipsPage() {
       kinships,
     },
   });
+  useEffect(() => {
+    if (kinships.length > 0) {
+      form.reset({ kinships }); 
+    }
+  }, [kinships, form]);
 
   const { fields, append, remove } = useFieldArray({
     control: form.control,

--- a/apps/apae/src/app/person/register/layout.tsx
+++ b/apps/apae/src/app/person/register/layout.tsx
@@ -1,14 +1,60 @@
+"use client";
+
 import Image from "@/assets/background_image.jpg";
 import { MembersRegisterProvider } from "@/hooks/use-members-register-context";
 import { PageOrchestrator } from "./orchestrator";
 import { Nunito } from "next/font/google";
 import { VaccinesProvider } from "@/hooks/use-vaccines";
+import { useMembersRegisterContext, MembersRegisterStep } from "@/hooks/use-members-register-context";
+import { CheckCircle2, Circle } from "lucide-react";
 import { DisordersProvider } from "@/hooks/use-disorders";
 
 const nunito = Nunito({
   subsets: ["latin"],
   weight: ["400", "600", "700", "900"],
 });
+
+function SidebarSteps() {
+  const { state: { step } } = useMembersRegisterContext();
+
+  const stepsList = [
+    { id: MembersRegisterStep.PERSONAL, label: "Dados Pessoais" },
+    { id: MembersRegisterStep.KINSHIPS, label: "Parentesco" },
+    { id: MembersRegisterStep.ADDRESS, label: "Endereço" },
+    { id: MembersRegisterStep.ADDITIONALS, label: "Saúde & Social" },
+    { id: MembersRegisterStep.GUARDIAN, label: "Responsável" },
+    { id: MembersRegisterStep.PROFILE, label: "Perfil & Documentos" },
+  ];
+
+  const currentStepIndex = stepsList.findIndex((s) => s.id === step);
+
+  return (
+    <div className={`relative flex flex-col w-full h-full justify-center text-left text-white px-12 ${nunito.className}`}>
+      <h1 className="text-4xl font-bold mb-4">BEM-VINDO</h1>
+      <p className="text-lg font-semibold mb-12 text-blue-100">Progresso do cadastro:</p>
+
+      <div className="flex flex-col gap-6">
+        {stepsList.map((s, index) => {
+          const isCompleted = index < currentStepIndex;
+          const isCurrent = index === currentStepIndex;
+
+          return (
+            <div key={s.id} className={`flex items-center gap-4 transition-all ${isCurrent ? "opacity-100 scale-105" : "opacity-60"}`}>
+              {isCompleted ? (
+                <CheckCircle2 className="w-8 h-8 text-green-400" />
+              ) : isCurrent ? (
+                <div className="w-8 h-8 rounded-full bg-white flex items-center justify-center text-[#0D4F97] font-bold shadow-lg">{index + 1}</div>
+              ) : (
+                <Circle className="w-8 h-8 text-blue-300" />
+              )}
+              <span className={`text-lg font-bold ${isCurrent ? "text-white" : "text-blue-200"}`}>{s.label}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
 
 export default function MembersRegisterLayout({
   children,
@@ -36,14 +82,8 @@ export default function MembersRegisterLayout({
                     "linear-gradient(180deg, rgba(13, 79, 151, 0.7) 54.32%, rgba(255, 255, 255, 0.6) 110.28%)",
                 }}
               />
-              <div
-                className={`relative flex flex-col w-full h-full justify-center text-center text-white font-bold ${nunito.className}`}
-              >
-                <h1 className="text-4xl">BEM-VINDO</h1>
-                <p className="text-3xl px-28 py-12">
-                  Informe seus dados ao lado para poder fazer parte da nossa
-                  associação.
-                </p>
+               <div className="hidden md:flex relative z-10 w-full h-full bg-[#0D4F97]/90 backdrop-blur-sm">
+                <SidebarSteps />
               </div>
               <div className="relative flex flex-col w-full h-full p-8 bg-muted overflow-y-auto">
                 <h1 className="text-2xl font-bold text-blue-900 mb-4">

--- a/apps/apae/src/app/person/register/orchestrator.tsx
+++ b/apps/apae/src/app/person/register/orchestrator.tsx
@@ -4,7 +4,7 @@ import {
   MembersRegisterStep,
   useMembersRegisterContext,
 } from "@/hooks/use-members-register-context";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation"; 
 import { useEffect } from "react";
 
 export function PageOrchestrator({
@@ -13,32 +13,28 @@ export function PageOrchestrator({
   readonly children: React.ReactNode;
 }) {
   const router = useRouter();
+  const pathname = usePathname(); 
   const {
     state: { step },
   } = useMembersRegisterContext();
 
   useEffect(() => {
-    switch (step) {
-      case MembersRegisterStep.PERSONAL:
-        router.push("/person/register/personal");
-        break;
-      case MembersRegisterStep.KINSHIPS:
-        router.push("/person/register/kinships");
-        break;
-      case MembersRegisterStep.ADDRESS:
-        router.push("/person/register/address");
-        break;
-      case MembersRegisterStep.ADDITIONALS:
-        router.push("/person/register/additional");
-        break;
-      case MembersRegisterStep.GUARDIAN:
-        router.push("/person/register/responsible");
-        break;
-      case MembersRegisterStep.PROFILE:
-        router.push("/person/register/profile");
-        break;
+    const stepPaths: Record<string, string> = {
+      [MembersRegisterStep.PERSONAL]: "personal",
+      [MembersRegisterStep.KINSHIPS]: "kinships",
+      [MembersRegisterStep.ADDRESS]: "address",
+      [MembersRegisterStep.ADDITIONALS]: "additional",
+      [MembersRegisterStep.GUARDIAN]: "responsible",
+      [MembersRegisterStep.PROFILE]: "profile",
+    };
+
+    const targetSlug = stepPaths[step];
+    const targetPath = `/person/register/${targetSlug}`;
+
+    if (pathname === "/person/register" || (targetSlug && !pathname.includes(targetSlug))) {
+      router.push(targetPath);
     }
-  }, [step, router]);
+  }, [step, router, pathname]);
 
   return children;
 }

--- a/apps/apae/src/app/person/register/personal/page.tsx
+++ b/apps/apae/src/app/person/register/personal/page.tsx
@@ -58,6 +58,12 @@ export default function MembersRegisterPersonalPage() {
     }
   }, [personal, form, isInitialized]);
 
+  useEffect(() => {
+    if (personal.name !== "") {
+      form.reset(personal);
+    }
+  }, [personal, form]);
+
   const onSubmit = async (values: any) => {
     setIsLoading(true);
     try {

--- a/apps/apae/src/app/person/register/profile/page.tsx
+++ b/apps/apae/src/app/person/register/profile/page.tsx
@@ -58,6 +58,11 @@ export default function MembersRegisterProfilePage() {
   }, [profile, form, isEditing, isInitialized]);
 
   useEffect(() => {
+    if (profile.role || profile.photo instanceof File) {
+      form.reset(profile);
+    }
+  }, [profile, form]);
+  useEffect(() => {
     if (submitted && profile) {
       (async () => {
         setIsLoading(true);

--- a/apps/apae/src/app/person/register/responsible/page.tsx
+++ b/apps/apae/src/app/person/register/responsible/page.tsx
@@ -53,6 +53,12 @@ export default function MembersRegisterGuardianPage() {
     }
   }, [isEditing, guardian, form, isInitialized]);
 
+  useEffect(() => {
+    if (guardian.name !== "") {
+      form.reset(guardian);
+    }
+  }, [guardian, form]);
+
   const onSubmit = async (values: any) => {
     setIsLoading(true);
     try {

--- a/apps/apae/src/components/FileRestoreAlert.tsx
+++ b/apps/apae/src/components/FileRestoreAlert.tsx
@@ -1,0 +1,16 @@
+import { AlertCircle } from "lucide-react";
+
+export function FileRestoreAlert() {
+  return (
+    <div className="flex gap-3 p-4 mb-6 border-l-4 rounded-r-md bg-amber-50 border-amber-400 animate-in fade-in slide-in-from-top-2">
+      <AlertCircle className="flex-shrink-0 w-5 h-5 text-amber-600 mt-0.5" />
+      <div>
+        <h4 className="text-sm font-bold text-amber-900">Rascunho recuperado</h4>
+        <p className="mt-1 text-xs leading-relaxed text-amber-800">
+          Seus dados de texto foram restaurados, mas por segurança, 
+          <strong> arquivos e laudos precisam ser selecionados novamente.</strong>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/apae/src/components/shared/SidebarSteps.tsx
+++ b/apps/apae/src/components/shared/SidebarSteps.tsx
@@ -1,0 +1,64 @@
+"use client";
+import { useMembersRegisterContext, MembersRegisterStep } from "@/hooks/use-members-register-context";
+import { CheckCircle2, Circle } from "lucide-react";
+import { Nunito } from "next/font/google";
+import { usePathname } from "next/navigation";
+import { useState, useEffect } from "react";
+
+const nunito = Nunito({ subsets: ["latin"], weight: ["400", "600", "700", "900"] });
+
+export function SidebarSteps() {
+  const { state: { step } } = useMembersRegisterContext();
+  const pathname = usePathname();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
+
+  const isEditing = pathname.includes("/edit");
+  const stepsList = [
+    { id: MembersRegisterStep.PERSONAL, label: "Dados Pessoais" },
+    { id: MembersRegisterStep.KINSHIPS, label: "Parentesco" },
+    { id: MembersRegisterStep.ADDRESS, label: "Endereço" },
+    ...(!isEditing ? [{ id: MembersRegisterStep.ADDITIONALS, label: "Saúde & Social" }] : []),
+    { id: MembersRegisterStep.GUARDIAN, label: "Responsável" },
+    { id: MembersRegisterStep.PROFILE, label: "Perfil & Documentos" },
+  ];
+  const currentStepIndex = stepsList.findIndex((s) => s.id === step);
+
+  return (
+    <div className={`relative flex flex-col w-full h-full justify-center text-left text-white px-8 md:px-16 ${nunito.className}`}>
+      <h1 className="text-3xl md:text-4xl font-bold mb-4">{isEditing ? "EDIÇÃO" : "BEM-VINDO"}</h1>
+      <p className="text-base md:text-lg font-semibold mb-10 text-blue-100">
+        {isEditing ? "Acompanhe o progresso da edição:" : "Acompanhe o progresso do seu cadastro:"}
+      </p>
+      <div className="flex flex-col gap-6">
+        {stepsList.map((s, index) => {
+          const isCompleted = index < currentStepIndex;
+          const isCurrent = index === currentStepIndex;
+          return (
+            <div key={s.id} className={`flex items-center gap-4 transition-all duration-300 ${isCurrent ? "opacity-100 scale-105" : "opacity-60"}`}>
+              <div className="flex-shrink-0">
+                {isCompleted ? (
+                  <CheckCircle2 className="w-8 h-8 text-green-400" />
+                ) : isCurrent ? (
+                  <div className="w-8 h-8 rounded-full bg-white flex items-center justify-center text-[#0D4F97] font-bold shadow-lg">
+                    {index + 1}
+                  </div>
+                ) : (
+                  <Circle className="w-8 h-8 text-blue-300" />
+                )}
+              </div>
+              <span className={`text-base md:text-lg font-bold ${isCurrent ? "text-white" : "text-blue-200"}`}>
+                {s.label}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/apae/src/components/shared/SidebarSteps.tsx
+++ b/apps/apae/src/components/shared/SidebarSteps.tsx
@@ -1,24 +1,17 @@
 "use client";
+
 import { useMembersRegisterContext, MembersRegisterStep } from "@/hooks/use-members-register-context";
 import { CheckCircle2, Circle } from "lucide-react";
 import { Nunito } from "next/font/google";
 import { usePathname } from "next/navigation";
-import { useState, useEffect } from "react";
 
 const nunito = Nunito({ subsets: ["latin"], weight: ["400", "600", "700", "900"] });
 
 export function SidebarSteps() {
   const { state: { step } } = useMembersRegisterContext();
   const pathname = usePathname();
-  const [mounted, setMounted] = useState(false);
+  const isEditing = pathname.includes("/edit"); 
 
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  if (!mounted) return null;
-
-  const isEditing = pathname.includes("/edit");
   const stepsList = [
     { id: MembersRegisterStep.PERSONAL, label: "Dados Pessoais" },
     { id: MembersRegisterStep.KINSHIPS, label: "Parentesco" },
@@ -27,6 +20,7 @@ export function SidebarSteps() {
     { id: MembersRegisterStep.GUARDIAN, label: "Responsável" },
     { id: MembersRegisterStep.PROFILE, label: "Perfil & Documentos" },
   ];
+
   const currentStepIndex = stepsList.findIndex((s) => s.id === step);
 
   return (
@@ -35,12 +29,15 @@ export function SidebarSteps() {
       <p className="text-base md:text-lg font-semibold mb-10 text-blue-100">
         {isEditing ? "Acompanhe o progresso da edição:" : "Acompanhe o progresso do seu cadastro:"}
       </p>
+
       <div className="flex flex-col gap-6">
         {stepsList.map((s, index) => {
           const isCompleted = index < currentStepIndex;
           const isCurrent = index === currentStepIndex;
+
           return (
             <div key={s.id} className={`flex items-center gap-4 transition-all duration-300 ${isCurrent ? "opacity-100 scale-105" : "opacity-60"}`}>
+              {/* O Ícone da Bolinha */}
               <div className="flex-shrink-0">
                 {isCompleted ? (
                   <CheckCircle2 className="w-8 h-8 text-green-400" />
@@ -52,6 +49,7 @@ export function SidebarSteps() {
                   <Circle className="w-8 h-8 text-blue-300" />
                 )}
               </div>
+              {/* O Texto do Passo */}
               <span className={`text-base md:text-lg font-bold ${isCurrent ? "text-white" : "text-blue-200"}`}>
                 {s.label}
               </span>

--- a/apps/apae/src/hooks/use-members-register-context.tsx
+++ b/apps/apae/src/hooks/use-members-register-context.tsx
@@ -3,6 +3,7 @@
 import { createContext, useCallback, useContext, useReducer, useEffect, useMemo } from "react";
 import { useParams } from "next/navigation";
 
+// --- INTERFACES ---
 interface PersonalData {
   name: string;
   cpf: string;
@@ -88,6 +89,28 @@ interface MembersRegisterContextData {
   register: (id?: string) => Promise<{ status: number; data: any }>;
 }
 
+// --- UTILS: FILE CONVERSION (Foras do componente) ---
+const fileToBase64 = (file: File): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = (error) => reject(error);
+  });
+};
+
+const base64ToFile = (base64: string, filename: string, mimeType: string): File => {
+  const arr = base64.split(",");
+  const bstr = atob(arr[1]);
+  let n = bstr.length;
+  const u8arr = new Uint8Array(n);
+  while (n--) {
+    u8arr[n] = bstr.charCodeAt(n);
+  }
+  return new File([u8arr], filename, { type: mimeType });
+};
+
+// --- REDUCER ---
 type MembersRegisterAction =
   | { type: "SET_PERSONAL_DATA"; payload: Partial<PersonalData> }
   | { type: "SET_KINSHIPS_DATA"; payload: KinshipData[] }
@@ -114,31 +137,13 @@ function membersRegisterReducer(state: MembersRegisterState, action: MembersRegi
 }
 
 const initialState: MembersRegisterState = {
-  personal: { name: "", cpf: "", phone: "", rg: { number: "", issuing: { body: "", date: new Date() } }, cns: "", nis: "", birth: { certificate: "", date: new Date(), place: "" } },
+  personal: { name: "", cpf: "", phone: "", rg: { number: "", issuing: { body: "", date: undefined as any } }, cns: "", nis: "", birth: { certificate: "", date: undefined as any, place: "" } },
   address: { cep: "", state: "", city: "", district: "", street: "" },
   additionals: { id: undefined, diseases: "", medications: "", vaccines: [], allergies: "", disability: { types: [], report: undefined }, care: { types: [], referral: undefined }, bpc: false, householdIncome: "" },
   guardian: { address: { cep: "", state: "", city: "", district: "", street: "" }, contact: "", kinship: "", name: "" },
   kinships: [],
   step: MembersRegisterStep.PERSONAL,
   profile: { role: "patient", photo: undefined },
-};
-const fileToBase64 = (file: File): Promise<string> => {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.readAsDataURL(file);
-    reader.onload = () => resolve(reader.result as string);
-    reader.onerror = (error) => reject(error);
-  });
-};
-const base64ToFile = (base64: string, filename: string, mimeType: string): File => {
-  const arr = base64.split(",");
-  const bstr = atob(arr[1]);
-  let n = bstr.length;
-  const u8arr = new Uint8Array(n);
-  while (n--) {
-    u8arr[n] = bstr.charCodeAt(n);
-  }
-  return new File([u8arr], filename, { type: mimeType });
 };
 
 const MembersRegisterContext = createContext<MembersRegisterContextData | undefined>(undefined);
@@ -147,78 +152,14 @@ export function MembersRegisterProvider({ children }: { children: React.ReactNod
   const [state, dispatch] = useReducer(membersRegisterReducer, initialState);
   const params = useParams();
   
+  // 1. CHAVE DE CACHE
   const STORAGE_KEY = useMemo(() => {
     const patientId = params?.id as string;
     return patientId ? `apae_edit_cache_${patientId}` : "apae_register_cache";
   }, [params?.id]);
 
-  const setters = {
-    setPersonalData: useCallback((data: Partial<PersonalData>) => dispatch({ type: "SET_PERSONAL_DATA", payload: data }), []),
-    setKinshipsData: useCallback((data: KinshipData[]) => dispatch({ type: "SET_KINSHIPS_DATA", payload: data }), []),
-    setAddressData: useCallback((data: Partial<AddressData>) => dispatch({ type: "SET_ADDRESS_DATA", payload: data }), []),
-    setAdditionalsData: useCallback((data: Partial<AdditionalsData>) => dispatch({ type: "SET_ADDITIONALS_DATA", payload: data }), []),
-    setGuardianData: useCallback((data: Partial<GuardianData>) => dispatch({ type: "SET_GUARDIAN_DATA", payload: data }), []),
-    setProfileData: useCallback((data: Partial<ProfileData>) => dispatch({ type: "SET_PROFILE_DATA", payload: data }), []),
-    setStep: useCallback((step: MembersRegisterStep) => dispatch({ type: "SET_STEP", payload: step }), []),
-    loadAllData: useCallback((apiData: MembersRegisterState) => {
-      if (typeof window !== "undefined") {
-        const saved = localStorage.getItem(STORAGE_KEY);
-        if (saved) {
-          try {
-            const parsed = JSON.parse(saved);
-
-            if (parsed.additionals?.disability?.report?.base64) {
-              parsed.additionals.disability.report = base64ToFile(
-                parsed.additionals.disability.report.base64,
-                parsed.additionals.disability.report.name,
-                parsed.additionals.disability.report.type
-              );
-            }
-            if (parsed.additionals?.care?.referral?.base64) {
-              parsed.additionals.care.referral = base64ToFile(
-                parsed.additionals.care.referral.base64,
-                parsed.additionals.care.referral.name,
-                parsed.additionals.care.referral.type
-              );
-            }
-            if (parsed.profile?.photo?.base64) {
-              parsed.profile.photo = base64ToFile(
-                parsed.profile.photo.base64,
-                parsed.profile.photo.name,
-                parsed.profile.photo.type
-              );
-            }
-
-            dispatch({ 
-              type: "LOAD_ALL_DATA", 
-              payload: { ...apiData, ...parsed } 
-            });
-            return; 
-          } catch (e) {
-            console.error("Erro ao carregar rascunho na edição", e);
-          }
-        }
-      }
-      dispatch({ type: "LOAD_ALL_DATA", payload: apiData });
-    }, [STORAGE_KEY]),
-  };
-
-  useEffect(() => {
-  if (typeof window !== "undefined") {
-    const saved = localStorage.getItem(STORAGE_KEY);
-    if (saved) {
-      try {
-        const parsed = JSON.parse(saved);
-        if (!params?.id && state.personal.name === "") {
-           const draftWithFiles = reconstructFiles(parsed);
-           dispatch({ type: "LOAD_ALL_DATA", payload: { ...state, ...draftWithFiles } });
-        }
-      } catch (e) { console.error("Erro no rascunho", e); }
-    }
-  }
-}, [STORAGE_KEY, params?.id]);  
-
-  const reconstructFiles = (obj: any) => {
+  // 2. FUNÇÃO DE RECONSTRUÇÃO (Declarada antes de ser usada)
+  const reconstructFiles = useCallback((obj: any) => {
     if (obj.additionals?.disability?.report?.base64) {
       obj.additionals.disability.report = base64ToFile(
         obj.additionals.disability.report.base64,
@@ -240,16 +181,62 @@ export function MembersRegisterProvider({ children }: { children: React.ReactNod
         obj.profile.photo.type
       );
     }
+    if (obj.personal?.rg?.issuing?.date) {
+      obj.personal.rg.issuing.date = new Date(obj.personal.rg.issuing.date);
+    }
+    if (obj.personal?.birth?.date) {
+      obj.personal.birth.date = new Date(obj.personal.birth.date);
+    }
     return obj;
+  }, []);
+
+  // 3. SETTERS
+  const setters = {
+    setPersonalData: useCallback((data: Partial<PersonalData>) => dispatch({ type: "SET_PERSONAL_DATA", payload: data }), []),
+    setKinshipsData: useCallback((data: KinshipData[]) => dispatch({ type: "SET_KINSHIPS_DATA", payload: data }), []),
+    setAddressData: useCallback((data: Partial<AddressData>) => dispatch({ type: "SET_ADDRESS_DATA", payload: data }), []),
+    setAdditionalsData: useCallback((data: Partial<AdditionalsData>) => dispatch({ type: "SET_ADDITIONALS_DATA", payload: data }), []),
+    setGuardianData: useCallback((data: Partial<GuardianData>) => dispatch({ type: "SET_GUARDIAN_DATA", payload: data }), []),
+    setProfileData: useCallback((data: Partial<ProfileData>) => dispatch({ type: "SET_PROFILE_DATA", payload: data }), []),
+    setStep: useCallback((step: MembersRegisterStep) => dispatch({ type: "SET_STEP", payload: step }), []),
+    loadAllData: useCallback((apiData: MembersRegisterState) => {
+      if (typeof window !== "undefined") {
+        const saved = localStorage.getItem(STORAGE_KEY);
+        if (saved) {
+          try {
+            const parsed = JSON.parse(saved);
+            const draftWithFiles = reconstructFiles(parsed);
+            dispatch({ type: "LOAD_ALL_DATA", payload: { ...apiData, ...draftWithFiles } });
+            return; 
+          } catch (e) { console.error(e); }
+        }
+      }
+      dispatch({ type: "LOAD_ALL_DATA", payload: apiData });
+    }, [STORAGE_KEY, reconstructFiles]),
   };
 
+  // 4. EFEITO DE RECUPERAÇÃO (Hydration)
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (saved) {
+        try {
+          const parsed = JSON.parse(saved);
+          if (state.personal.name === "") {
+             const draftWithFiles = reconstructFiles(parsed);
+             dispatch({ type: "LOAD_ALL_DATA", payload: { ...state, ...draftWithFiles } });
+          }
+        } catch (e) { console.error("Erro no rascunho", e); }
+      }
+    }
+  }, [STORAGE_KEY, reconstructFiles]);   
+
+  // 5. EFEITO DE SALVAMENTO AUTOMÁTICO
   useEffect(() => {
     if (typeof window === "undefined") return;
 
     const saveDraft = async () => {
-      if (params?.id && state.personal.name === "") {
-        return;
-      }
+      if (params?.id && state.personal.name === "") return;
 
       try {
         const draft = JSON.parse(JSON.stringify(state, (key, value) => value));
@@ -261,7 +248,6 @@ export function MembersRegisterProvider({ children }: { children: React.ReactNod
             type: state.additionals.disability.report.type
           };
         }
-        
         if (state.additionals.care.referral instanceof File) {
           draft.additionals.care.referral = {
             base64: await fileToBase64(state.additionals.care.referral),
@@ -269,7 +255,6 @@ export function MembersRegisterProvider({ children }: { children: React.ReactNod
             type: state.additionals.care.referral.type
           };
         }
-        
         if (state.profile.photo instanceof File) {
           draft.profile.photo = {
             base64: await fileToBase64(state.profile.photo),
@@ -289,6 +274,7 @@ export function MembersRegisterProvider({ children }: { children: React.ReactNod
     saveDraft();
   }, [state, STORAGE_KEY, params?.id]);
   
+  // 6. FUNÇÃO REGISTER
   const register = useCallback(
     async (id?: string) => {
       const { personal, address, additionals, guardian, kinships, profile } = state;
@@ -318,7 +304,6 @@ export function MembersRegisterProvider({ children }: { children: React.ReactNod
       if (id) {
         const res = await fetch(`/api/pessoas/${id}`, { method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify(patient) });
         if (res.ok) { localStorage.removeItem(STORAGE_KEY); }
-
         if (profile.photo instanceof File && res.ok) {
           const photoFormData = new FormData(); photoFormData.append("photo", profile.photo);
           await fetch(`/api/pessoas/${id}/photo`, { method: "PUT", body: photoFormData });

--- a/apps/apae/src/hooks/use-members-register-context.tsx
+++ b/apps/apae/src/hooks/use-members-register-context.tsx
@@ -1,25 +1,16 @@
 "use client";
 
-import { createContext, useCallback, useContext, useReducer } from "react";
+import { createContext, useCallback, useContext, useReducer, useEffect, useMemo } from "react";
+import { useParams } from "next/navigation";
 
 interface PersonalData {
   name: string;
   cpf: string;
   phone: string;
-  rg: {
-    number: string;
-    issuing: {
-      body: string;
-      date: Date;
-    };
-  };
+  rg: { number: string; issuing: { body: string; date: Date } };
   cns: string;
   nis: string;
-  birth: {
-    certificate: string;
-    date: Date;
-    place: string;
-  };
+  birth: { certificate: string; date: Date; place: string };
 }
 
 interface KinshipData {
@@ -45,14 +36,8 @@ interface AdditionalsData {
   medications: string;
   vaccines: string[];
   allergies: string;
-  disability: {
-    types: string[];
-    report: File | undefined;
-  };
-  care: {
-    types: string[];
-    referral: File | undefined;
-  };
+  disability: { types: string[]; report: File | string | undefined };
+  care: { types: string[]; referral: File | string | undefined };
   bpc: boolean;
   householdIncome: string;
 }
@@ -113,177 +98,202 @@ type MembersRegisterAction =
   | { type: "SET_STEP"; payload: MembersRegisterStep }
   | { type: "LOAD_ALL_DATA"; payload: MembersRegisterState };
 
-function membersRegisterReducer(
-  state: MembersRegisterState,
-  action: MembersRegisterAction,
-): MembersRegisterState {
+function membersRegisterReducer(state: MembersRegisterState, action: MembersRegisterAction): MembersRegisterState {
   switch (action.type) {
     case "SET_PERSONAL_DATA":
-      return {
-        ...state,
-        personal: {
-          ...state.personal,
-          ...action.payload,
-          rg: {
-            ...state.personal.rg,
-            ...action.payload.rg,
-            issuing: {
-              ...state.personal.rg.issuing,
-              ...action.payload.rg?.issuing,
-            },
-          },
-          birth: {
-            ...state.personal.birth,
-            ...action.payload.birth,
-          },
-        },
-      };
-    case "SET_KINSHIPS_DATA":
-      return { ...state, kinships: action.payload };
-    case "SET_ADDRESS_DATA":
-      return { ...state, address: { ...state.address, ...action.payload } };
-    case "SET_ADDITIONALS_DATA":
-      return {
-        ...state,
-        additionals: {
-          ...state.additionals,
-          ...action.payload,
-          disability: {
-            ...state.additionals.disability,
-            ...action.payload.disability,
-          },
-          care: {
-            ...state.additionals.care,
-            ...action.payload.care,
-          },
-        },
-      };
-    case "SET_GUARDIAN_DATA":
-      return {
-        ...state,
-        guardian: {
-          ...state.guardian,
-          ...action.payload,
-          address: {
-            ...state.guardian.address,
-            ...action.payload.address,
-          },
-        },
-      };
-    case "SET_PROFILE_DATA":
-      return { ...state, profile: { ...state.profile, ...action.payload } };
-    case "SET_STEP":
-      return { ...state, step: action.payload };
-    case "LOAD_ALL_DATA":
-      return { ...action.payload };
-    default:
-      return state;
+      return { ...state, personal: { ...state.personal, ...action.payload, rg: { ...state.personal.rg, ...action.payload.rg, issuing: { ...state.personal.rg.issuing, ...action.payload.rg?.issuing } }, birth: { ...state.personal.birth, ...action.payload.birth } } };
+    case "SET_KINSHIPS_DATA": return { ...state, kinships: action.payload };
+    case "SET_ADDRESS_DATA": return { ...state, address: { ...state.address, ...action.payload } };
+    case "SET_ADDITIONALS_DATA": return { ...state, additionals: { ...state.additionals, ...action.payload, disability: { ...state.additionals.disability, ...action.payload.disability }, care: { ...state.additionals.care, ...action.payload.care } } };
+    case "SET_GUARDIAN_DATA": return { ...state, guardian: { ...state.guardian, ...action.payload, address: { ...state.guardian.address, ...action.payload.address } } };
+    case "SET_PROFILE_DATA": return { ...state, profile: { ...state.profile, ...action.payload } };
+    case "SET_STEP": return { ...state, step: action.payload };
+    case "LOAD_ALL_DATA": return { ...action.payload };
+    default: return state;
   }
 }
 
 const initialState: MembersRegisterState = {
-  personal: {
-    name: "",
-    cpf: "",
-    phone: "",
-    rg: { number: "", issuing: { body: "", date: new Date() } },
-    cns: "",
-    nis: "",
-    birth: { certificate: "", date: new Date(), place: "" },
-  },
+  personal: { name: "", cpf: "", phone: "", rg: { number: "", issuing: { body: "", date: new Date() } }, cns: "", nis: "", birth: { certificate: "", date: new Date(), place: "" } },
   address: { cep: "", state: "", city: "", district: "", street: "" },
-  additionals: {
-    id: undefined,
-    diseases: "",
-    medications: "",
-    vaccines: [],
-    allergies: "",
-    disability: { types: [], report: undefined },
-    care: { types: [], referral: undefined },
-    bpc: false,
-    householdIncome: "",
-  },
-  guardian: {
-    address: { cep: "", state: "", city: "", district: "", street: "" },
-    contact: "",
-    kinship: "",
-    name: "",
-  },
+  additionals: { id: undefined, diseases: "", medications: "", vaccines: [], allergies: "", disability: { types: [], report: undefined }, care: { types: [], referral: undefined }, bpc: false, householdIncome: "" },
+  guardian: { address: { cep: "", state: "", city: "", district: "", street: "" }, contact: "", kinship: "", name: "" },
   kinships: [],
   step: MembersRegisterStep.PERSONAL,
   profile: { role: "patient", photo: undefined },
 };
+const fileToBase64 = (file: File): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = (error) => reject(error);
+  });
+};
+const base64ToFile = (base64: string, filename: string, mimeType: string): File => {
+  const arr = base64.split(",");
+  const bstr = atob(arr[1]);
+  let n = bstr.length;
+  const u8arr = new Uint8Array(n);
+  while (n--) {
+    u8arr[n] = bstr.charCodeAt(n);
+  }
+  return new File([u8arr], filename, { type: mimeType });
+};
 
-const MembersRegisterContext = createContext<
-  MembersRegisterContextData | undefined
->(undefined);
+const MembersRegisterContext = createContext<MembersRegisterContextData | undefined>(undefined);
 
-export function MembersRegisterProvider({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export function MembersRegisterProvider({ children }: { children: React.ReactNode }) {
   const [state, dispatch] = useReducer(membersRegisterReducer, initialState);
+  const params = useParams();
+  
+  const STORAGE_KEY = useMemo(() => {
+    const patientId = params?.id as string;
+    return patientId ? `apae_edit_cache_${patientId}` : "apae_register_cache";
+  }, [params?.id]);
 
   const setters = {
-    setPersonalData: useCallback(
-      (data: Partial<PersonalData>) =>
-        dispatch({ type: "SET_PERSONAL_DATA", payload: data }),
-      [],
-    ),
-    setKinshipsData: useCallback(
-      (data: KinshipData[]) =>
-        dispatch({ type: "SET_KINSHIPS_DATA", payload: data }),
-      [],
-    ),
-    setAddressData: useCallback(
-      (data: Partial<AddressData>) =>
-        dispatch({ type: "SET_ADDRESS_DATA", payload: data }),
-      [],
-    ),
-    setAdditionalsData: useCallback(
-      (data: Partial<AdditionalsData>) =>
-        dispatch({ type: "SET_ADDITIONALS_DATA", payload: data }),
-      [],
-    ),
-    setGuardianData: useCallback(
-      (data: Partial<GuardianData>) =>
-        dispatch({ type: "SET_GUARDIAN_DATA", payload: data }),
-      [],
-    ),
-    setProfileData: useCallback(
-      (data: Partial<ProfileData>) =>
-        dispatch({ type: "SET_PROFILE_DATA", payload: data }),
-      [],
-    ),
-    setStep: useCallback(
-      (step: MembersRegisterStep) =>
-        dispatch({ type: "SET_STEP", payload: step }),
-      [],
-    ),
-    loadAllData: useCallback(
-      (data: MembersRegisterState) =>
-        dispatch({ type: "LOAD_ALL_DATA", payload: data }),
-      [],
-    ),
+    setPersonalData: useCallback((data: Partial<PersonalData>) => dispatch({ type: "SET_PERSONAL_DATA", payload: data }), []),
+    setKinshipsData: useCallback((data: KinshipData[]) => dispatch({ type: "SET_KINSHIPS_DATA", payload: data }), []),
+    setAddressData: useCallback((data: Partial<AddressData>) => dispatch({ type: "SET_ADDRESS_DATA", payload: data }), []),
+    setAdditionalsData: useCallback((data: Partial<AdditionalsData>) => dispatch({ type: "SET_ADDITIONALS_DATA", payload: data }), []),
+    setGuardianData: useCallback((data: Partial<GuardianData>) => dispatch({ type: "SET_GUARDIAN_DATA", payload: data }), []),
+    setProfileData: useCallback((data: Partial<ProfileData>) => dispatch({ type: "SET_PROFILE_DATA", payload: data }), []),
+    setStep: useCallback((step: MembersRegisterStep) => dispatch({ type: "SET_STEP", payload: step }), []),
+    loadAllData: useCallback((apiData: MembersRegisterState) => {
+      if (typeof window !== "undefined") {
+        const saved = localStorage.getItem(STORAGE_KEY);
+        if (saved) {
+          try {
+            const parsed = JSON.parse(saved);
+
+            if (parsed.additionals?.disability?.report?.base64) {
+              parsed.additionals.disability.report = base64ToFile(
+                parsed.additionals.disability.report.base64,
+                parsed.additionals.disability.report.name,
+                parsed.additionals.disability.report.type
+              );
+            }
+            if (parsed.additionals?.care?.referral?.base64) {
+              parsed.additionals.care.referral = base64ToFile(
+                parsed.additionals.care.referral.base64,
+                parsed.additionals.care.referral.name,
+                parsed.additionals.care.referral.type
+              );
+            }
+            if (parsed.profile?.photo?.base64) {
+              parsed.profile.photo = base64ToFile(
+                parsed.profile.photo.base64,
+                parsed.profile.photo.name,
+                parsed.profile.photo.type
+              );
+            }
+
+            dispatch({ 
+              type: "LOAD_ALL_DATA", 
+              payload: { ...apiData, ...parsed } 
+            });
+            return; 
+          } catch (e) {
+            console.error("Erro ao carregar rascunho na edição", e);
+          }
+        }
+      }
+      dispatch({ type: "LOAD_ALL_DATA", payload: apiData });
+    }, [STORAGE_KEY]),
   };
 
+  useEffect(() => {
+  if (typeof window !== "undefined") {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved);
+        if (!params?.id && state.personal.name === "") {
+           const draftWithFiles = reconstructFiles(parsed);
+           dispatch({ type: "LOAD_ALL_DATA", payload: { ...state, ...draftWithFiles } });
+        }
+      } catch (e) { console.error("Erro no rascunho", e); }
+    }
+  }
+}, [STORAGE_KEY, params?.id]);  
+
+  const reconstructFiles = (obj: any) => {
+    if (obj.additionals?.disability?.report?.base64) {
+      obj.additionals.disability.report = base64ToFile(
+        obj.additionals.disability.report.base64,
+        obj.additionals.disability.report.name,
+        obj.additionals.disability.report.type
+      );
+    }
+    if (obj.additionals?.care?.referral?.base64) {
+      obj.additionals.care.referral = base64ToFile(
+        obj.additionals.care.referral.base64,
+        obj.additionals.care.referral.name,
+        obj.additionals.care.referral.type
+      );
+    }
+    if (obj.profile?.photo?.base64) {
+      obj.profile.photo = base64ToFile(
+        obj.profile.photo.base64,
+        obj.profile.photo.name,
+        obj.profile.photo.type
+      );
+    }
+    return obj;
+  };
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const saveDraft = async () => {
+      if (params?.id && state.personal.name === "") {
+        return;
+      }
+
+      try {
+        const draft = JSON.parse(JSON.stringify(state, (key, value) => value));
+
+        if (state.additionals.disability.report instanceof File) {
+          draft.additionals.disability.report = {
+            base64: await fileToBase64(state.additionals.disability.report),
+            name: state.additionals.disability.report.name,
+            type: state.additionals.disability.report.type
+          };
+        }
+        
+        if (state.additionals.care.referral instanceof File) {
+          draft.additionals.care.referral = {
+            base64: await fileToBase64(state.additionals.care.referral),
+            name: state.additionals.care.referral.name,
+            type: state.additionals.care.referral.type
+          };
+        }
+        
+        if (state.profile.photo instanceof File) {
+          draft.profile.photo = {
+            base64: await fileToBase64(state.profile.photo),
+            name: state.profile.photo.name,
+            type: state.profile.photo.type
+          };
+        }
+
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(draft));
+      } catch (error: any) {
+        if (error.name === 'QuotaExceededError') {
+          console.warn("Aviso: Limite do LocalStorage excedido.");
+        }
+      }
+    };
+
+    saveDraft();
+  }, [state, STORAGE_KEY, params?.id]);
+  
   const register = useCallback(
     async (id?: string) => {
-      const { personal, address, additionals, guardian, kinships, profile } =
-        state;
-
-      const formatDate = (date: any) => {
-        if (!date) return null;
-        const d = new Date(date);
-        return isNaN(d.getTime()) ? null : d.toISOString().split("T")[0];
-      };
-
-      const parseIncome = (val: string) => {
-        const clean = String(val).replace(/[^\d]/g, ""); 
-        const num = parseFloat(clean) * 0.01; 
-        return isNaN(num) ? 0.0 : num;
-      };
+      const { personal, address, additionals, guardian, kinships, profile } = state;
+      const formatDate = (date: any) => (date && !isNaN(new Date(date).getTime())) ? new Date(date).toISOString().split("T")[0] : null;
+      const parseIncome = (val: string) => { const clean = String(val).replace(/[^\d]/g, ""); return isNaN(parseFloat(clean)) ? 0 : parseFloat(clean) * 0.01; };
 
       const patient: any = {
         fullName: personal.name || "Não informado",
@@ -291,97 +301,45 @@ export function MembersRegisterProvider({
         birthDate: formatDate(personal.birth.date),
         contact: personal.phone || "Não informado",
         birthCertificateNumber: personal.birth.certificate || "0",
-        registryOffice: "Cartorio",
-        fls: "0",
-        book: "0",
+        registryOffice: "Cartorio", fls: "0", book: "0",
         rg: personal.rg.number || "0",
         issueDate: formatDate(personal.rg.issuing.date),
         issuingAgency: personal.rg.issuing.body || "SSP/SP",
-        cpf: personal.cpf,
-        cns: personal.cns || "000 0000 0000 0000",
-        nis: personal.nis || "0",
+        cpf: personal.cpf, cns: personal.cns || "000 0000 0000 0000", nis: personal.nis || "0",
         registrationDate: formatDate(new Date()),
         allergies: additionals.allergies || "Nenhuma",
         isStudent: profile.role === "student",
-        address: {
-          city: address.city || "Não informado",
-          cep: address.cep || "00000-000",
-          state: address.state || "Não informado",
-          neighborhood: address.district || "Não informado",
-          street: address.street.split(",")[0].trim() || "Não informado",
-          number: address.street.split(",")[1]?.trim() || "S/N",
-          complement: "",
-        },
-        guardian: {
-          name: guardian.name || "Não informado",
-          contact: guardian.contact || "Não informado",
-          kinship: guardian.kinship || "Não informado",
-          address: {
-            city: guardian.address.city || "Não informado",
-            cep: guardian.address.cep || "00000-000",
-            state: guardian.address.state || "Não informado",
-            neighborhood: guardian.address.district || "Não informado",
-            street: guardian.address.street.split(",")[0].trim() || "Não informado",
-            number: guardian.address.street.split(",")[1]?.trim() || "S/N",
-            complement: "",
-          },
-        },
-        parents: kinships.map((k) => ({
-          name: k.name || "Não informado",
-          rg: k.rg || "0",
-          cpf: k.cpf || "000.000.000-00",
-          profession: k.occupation || "Não informado",
-          isAlive: k.alive,
-          kinship: k.type || "Pai/Mãe",
-        })),
+        address: { city: address.city || "Não informado", cep: address.cep || "00000-000", state: address.state || "Não informado", neighborhood: address.district || "Não informado", street: address.street.split(",")[0].trim() || "Não informado", number: address.street.split(",")[1]?.trim() || "S/N", complement: "" },
+        guardian: { name: guardian.name || "Não informado", contact: guardian.contact || "Não informado", kinship: guardian.kinship || "Não informado", address: { city: guardian.address.city || "Não informado", cep: guardian.address.cep || "00000-000", state: guardian.address.state || "Não informado", neighborhood: guardian.address.district || "Não informado", street: guardian.address.street.split(",")[0].trim() || "Não informado", number: guardian.address.street.split(",")[1]?.trim() || "S/N", complement: "" } },
+        parents: kinships.map((k) => ({ name: k.name || "Não informado", rg: k.rg || "0", cpf: k.cpf || "000.000.000-00", profession: k.occupation || "Não informado", isAlive: k.alive, kinship: k.type || "Pai/Mãe" })),
         vaccineNames: additionals.vaccines.map((v) => ({ name: v })),
       };
 
       if (id) {
-        const responsePessoa = await fetch(`/api/pessoas/${id}`, {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(patient),
-        });
+        const res = await fetch(`/api/pessoas/${id}`, { method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify(patient) });
+        if (res.ok) { localStorage.removeItem(STORAGE_KEY); }
 
-        if (profile.photo instanceof File && responsePessoa.ok) {
-          const photoFormData = new FormData();
-          photoFormData.append("photo", profile.photo);
-          await fetch(`/api/pessoas/${id}/photo`, {
-            method: "PUT",
-            body: photoFormData,
-          });
+        if (profile.photo instanceof File && res.ok) {
+          const photoFormData = new FormData(); photoFormData.append("photo", profile.photo);
+          await fetch(`/api/pessoas/${id}/photo`, { method: "PUT", body: photoFormData });
         }
-
-        let resData = {};
-        const text = await responsePessoa.text();
-        if (text) {
-          try { resData = JSON.parse(text); } catch(e) {}
-        }
-        return { status: responsePessoa.status, data: resData };
-
+        const data = await res.json().catch(() => ({}));
+        return { status: res.status, data };
       } else {
-        patient.annualRegistry = {
-          bpc: additionals.bpc,
-          diseases: additionals.diseases,
-          serviceArea: additionals.care.types.map((area: string) => ({ area })),
-          familyIncome: parseIncome(additionals.householdIncome),
-          year: new Date().getFullYear(),
-          disorders: additionals.disability.types.map((name: string) => ({ name })),
-        };
-
+        patient.annualRegistry = { bpc: additionals.bpc, diseases: additionals.diseases, serviceArea: additionals.care.types.map((area: string) => ({ area })), familyIncome: parseIncome(additionals.householdIncome), year: new Date().getFullYear(), disorders: additionals.disability.types.map((name: string) => ({ name })) };
         const formData = new FormData();
         formData.append("patient", new Blob([JSON.stringify(patient)], { type: "application/json" }));
         if (profile.photo instanceof File) formData.append("photo", profile.photo);
         if (additionals.disability.report instanceof File) formData.append("reports", additionals.disability.report);
         if (additionals.care.referral instanceof File) formData.append("referrals", additionals.care.referral);
 
-        const response = await fetch("/api/pessoas", { method: "POST", body: formData });
-        const data = await response.json().catch(() => ({}));
-        return { status: response.status, data };
+        const res = await fetch("/api/pessoas", { method: "POST", body: formData });
+        if (res.ok) { localStorage.removeItem(STORAGE_KEY); }
+        const data = await res.json().catch(() => ({}));
+        return { status: res.status, data };
       }
     },
-    [state],
+    [state, STORAGE_KEY]
   );
 
   return (

--- a/apps/apae/src/schemas/member-schemas.ts
+++ b/apps/apae/src/schemas/member-schemas.ts
@@ -1,5 +1,7 @@
 import z, { ZodCoercedDate } from "zod";
 
+const MAX_FILE_SIZE = 2 * 1024 * 1024; 
+
 const CPF = z
   .string()
   .min(1, "CPF é obrigatório")


### PR DESCRIPTION
Título
feat: persistência do formulário de pacientes (F5 e rascunho)
Descrição
Implementada a persistência de dados no formulário de cadastro e edição para evitar a perda de informações em caso de atualização de página (F5) ou fechamento acidental.
Principais mudanças:
Salvamento Automático: 
O progresso agora é salvo no navegador (LocalStorage) enquanto o usuário digita.
Suporte a Arquivos: Fotos e laudos agora são preservados no rascunho (convertidos para Base64).
Melhoria na Edição: O sistema prioriza as alterações feitas pelo usuário sobre os dados antigos vindos do banco.
Segurança: Adicionado limite de 2MB para arquivos para não travar o navegador.
Limpeza: O rascunho é deletado automaticamente assim que o paciente é salvo com sucesso

Tecnologias Utilizadas:
Next.js 14 (App Router)
React Context API & useReducer
Zod (Validação de schemas)
LocalStorage API

Como testar:
Vá para a tela de Cadastro de Paciente.
Preencha alguns campos e anexe uma foto.
Atualize a página (F5). Verifique se os dados e o nome do arquivo continuam lá.
Vá para a tela de Edição de Paciente.
Altere o nome do paciente e dê F5. Verifique se o nome alterado persiste (em vez de voltar ao original do banco obs: os dados sao salvos depois de confimado em "Proximo").
Finalize o cadastro/edição e verifique se o rascunho foi limpo do localStorage (Aba Application do DevTools).


https://github.com/user-attachments/assets/f4058843-e580-4e3b-9afe-ea256cba96a7




