### PR TITLE
671 feat adicionar cards de agendamentos ativos e inativos

### DIFF
--- a/apps/apae/src/app/page.tsx
+++ b/apps/apae/src/app/page.tsx
@@ -21,7 +21,9 @@ import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import {
   CalendarDays,
-  Users
+  Users,
+  UserRoundCheck,
+  UserRoundX
 } from 'lucide-react';
 import { useEffect, useState, useRef } from 'react';
 
@@ -52,6 +54,8 @@ export default function DashboardPage() {
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
   const [todayAppointments, setTodayAppointments] = useState<TodayAppointment[]>([]);
   const [allAppointments, setAllAppointments] = useState<AppointmentResponseDTO[]>([]);
+  const [activeAppointments, setActiveAppointments] = useState<TodayAppointment[]>([]);
+  const [inactiveAppointments, setInactiveAppointments] = useState<TodayAppointment[]>([]);
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const lastFetchedDate = useRef<string | null>(null);
 
@@ -70,6 +74,32 @@ export default function DashboardPage() {
     setAllAppointments(allAppointmentsPage.content || []);
   };
 
+  const fetchTodayAppointmentsByStatus = async () => {
+    if (!todayAppointments.length || !allAppointments.length) return;
+
+    const appointmentMap = new Map(
+      allAppointments.map(a => [a.id, a])
+    );
+
+    const active: TodayAppointment[] = [];
+    const inactive: TodayAppointment[] = [];
+
+    for (const today of todayAppointments) {
+      const related = appointmentMap.get(today.ruleId);
+
+      if (!related) continue;
+
+      if (related.isActive) {
+        active.push(today);
+      } else {
+        inactive.push(today);
+      }
+    }
+
+    setActiveAppointments(active);
+    setInactiveAppointments(inactive);
+  };
+
   useEffect(() => {
 
     const dateKey = format(selectedDate, 'yyyy-MM-dd');
@@ -81,6 +111,10 @@ export default function DashboardPage() {
     fetchTodayAppointments();
     fetchAllAppointments();
   }, [selectedDate]);
+
+  useEffect(() => {
+    fetchTodayAppointmentsByStatus();
+  }, [todayAppointments, allAppointments]);
 
   const markAsPerformedHandle = async (id: UUID) => {
     await markAsPerformed(id);
@@ -157,6 +191,20 @@ export default function DashboardPage() {
             title="Todos os agendamentos"
             icon={Users}
             value={allAppointments.length}
+            titleClassName="text-[#0D4F97]"
+            valueClassName="text-[#0D4F97]"
+          />
+          <InfoCard
+            title="Ativos"
+            icon={UserRoundCheck}
+            value={activeAppointments.length}
+            titleClassName="text-[#0D4F97]"
+            valueClassName="text-[#0D4F97]"
+          />
+          <InfoCard
+            title="Inativos"
+            icon={UserRoundX}
+            value={inactiveAppointments.length}
             titleClassName="text-[#0D4F97]"
             valueClassName="text-[#0D4F97]"
           />

--- a/apps/apae/src/app/services/appointmentService.ts
+++ b/apps/apae/src/app/services/appointmentService.ts
@@ -248,7 +248,7 @@ export async function getAppointments(
   date?: string,
   time?: string,
   page: number = 0,
-  size: number = 20,
+  size: number = 100,
 ): Promise<Page<AppointmentResponseDTO>> {
   const query = new URLSearchParams({
     page: `${page}`,


### PR DESCRIPTION
# O que esse PR forneceu?

- Adição de dois novos cards exibindo o número de agendamentos ativos e inativos, com ícones correspondentes.
- Implementado cruzamento entre TodayAppointment e AppointmentResponseDTO, carregados no front-end, via ruleId para identificar o status dos agendamentos.
- Com base no isActive, os agendamentos do dia são classificados em:
  - ativos (activeAppointments)
  - inativos (inactiveAppointments)


# Coleta de evidências

- Total de 3 agendamentos do dia. Dois estão ativos e um está inativo.

<img width="2261" height="584" alt="image" src="https://github.com/user-attachments/assets/f57198c7-c5e2-4e88-93e5-65ad6b9b4fb9" />
