### PR TITLE
feat: integra tela de validação de e-mail e código de verificação com o backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,7 +37,7 @@ MAIL_PASSWORD=
 
 CORS_ALLOWED_ORIGINS=http://localhost:3000
 
-APP_FRONTEND_RESET_PASSWORD_URL=http://localhost:3000/reset-password
+APP_FRONTEND_RESET_PASSWORD_URL=http://localhost:3000/auth/reset-password
 
 
 # =========================

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ MAIL_HOST=smtp.gmail.com
 MAIL_PORT=587
 MAIL_USERNAME=seu-email@gmail.com
 MAIL_PASSWORD=sua_senha_de_app
-APP_FRONTEND_RESET_PASSWORD_URL=http://localhost:3000/reset-password
+APP_FRONTEND_RESET_PASSWORD_URL=http://localhost:3000/auth/reset-password
 ```
 
 3. Agora pode seguir com a execução normal do projeto, indo para seção **Como Executar**

--- a/apps/apae/src/app/auth/recovery/page.tsx
+++ b/apps/apae/src/app/auth/recovery/page.tsx
@@ -27,7 +27,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 
 import { recoverySchema, FormRecovery } from "@/schemas/authSchema";
-import { createBaseApi } from "@/lib/axios";
+import axios from "axios";
 
 export default function RecoveryPage() {
   const router = useRouter();
@@ -40,21 +40,13 @@ export default function RecoveryPage() {
     mode: "all",
   });
 
-  const handleSendCode = async () => {
-    const email = form.getValues("email");
+  const API_URL = process.env.NEXT_PUBLIC_API || "http://localhost:8090/api";
 
-    if (!email) {
-      form.setError("email", {
-        message: "E-mail é obrigatório",
-      });
-      return;
-    }
-
+  const handleSendCode = async (data: FormRecovery) => {
     try {
-      const api = await createBaseApi();
 
-      await api.post("/auth/password-recovery", {
-        email: email,
+      await axios.post(`${API_URL}/auth/password-recovery/request`, {
+        email: data.email,
       });
 
       toast.success("Se o e-mail existir, um link de recuperação foi enviado.");
@@ -63,14 +55,10 @@ export default function RecoveryPage() {
     }
   };
 
-  const onSubmit = async () => {
-    await handleSendCode();
-  };
-
   return (
     <Form {...form}>
       <form
-        onSubmit={form.handleSubmit(onSubmit)}
+        onSubmit={form.handleSubmit(handleSendCode)}
         className="w-full h-full flex justify-center"
       >
         <Card

--- a/apps/apae/src/app/auth/reset-password/page.tsx
+++ b/apps/apae/src/app/auth/reset-password/page.tsx
@@ -26,6 +26,7 @@ export default function NewPasswordPage() {
   });
 
   React.useEffect(() => {
+    // Conexão com a tela de validação vencida, atualize para o link enviado por email
     const email = sessionStorage.getItem("reset_email");
     const code = sessionStorage.getItem("reset_code");
 

--- a/apps/apae/src/middleware.ts
+++ b/apps/apae/src/middleware.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const PUBLIC_PATHS = ["/auth/login", "/auth/recovery", "/auth/new-password"];
+const PUBLIC_PATHS = ["/auth/login", "/auth/recovery", "/auth/reset-password"];
 
 export function middleware(req: NextRequest) {
   const session = req.cookies.get("session")?.value;

--- a/apps/api/src/main/resources/application.yaml
+++ b/apps/api/src/main/resources/application.yaml
@@ -53,7 +53,7 @@ app:
   token:
     secret: ${JWT_SECRET}
   frontend:
-    reset-password-url: ${APP_FRONTEND_RESET_PASSWORD_URL:http://localhost:3000/reset-password}
+    reset-password-url: ${APP_FRONTEND_RESET_PASSWORD_URL:http://localhost:3000/auth/reset-password}
 
 minio:
   access:


### PR DESCRIPTION
## O que mudou?
A tela de validação de e-mail e código de verificação está funcional, foi integrada a ela a rota do back-end referente a lógica para enviar ao email informado e que esteja cadastrado no banco o link de acesso a tela de redefinição de senha.

### Issue : https://github.com/IFPBEsp/APAE/issues/591

## Tarefas Relacionas
- Integração do fluxo de recuperação de senha: Conexão da interface de usuário com o serviço de envio de e-mails do backend.
- Configuração de ambiente: Definição das variáveis de ambiente (NEXT_PUBLIC_API) para apontar para o servidor Spring Boot (Porta 8090).
- Validação de e-mail: Implementação de feedback visual para o usuário através de toasts e estados de carregamento no botão.
- Atualização de rota e padronização conforme ao do back-end.
## Mudanças realizadas
- Chamada de API Isolada: Implementada a chamada para o endpoint /auth/password-recovery/request utilizando uma instância limpa do Axios, garantindo que rotas públicas de autenticação não sejam bloqueadas por interceptores de Token JWT.
- Fallback de URL: Adicionada lógica de fallback para a URL da API, permitindo o funcionamento tanto em ambiente de desenvolvimento (localhost) quanto em produção via variáveis de ambiente.

## Evidências

https://github.com/user-attachments/assets/4b3c0332-db62-4255-a088-bc15ce711c23

