### PR TITLE
feat: padroniza layout das telas de cadastro e edição de paciente #696

### DIFF
--- a/apps/apae/src/app/person/[id]/edit/[step]/page.tsx
+++ b/apps/apae/src/app/person/[id]/edit/[step]/page.tsx
@@ -8,6 +8,7 @@ import KinshipsForm from "../../../register/kinships/page";
 import AddressForm from "../../../register/address/page";
 import ResponsibleForm from "../../../register/responsible/page";
 import ProfileForm from "../../../register/profile/page";
+import AdditionalsForm from "../../../register/additional/page"; 
 
 export default function EditPatientPage() {
   const { state: { step }, setters } = useMembersRegisterContext();
@@ -21,15 +22,16 @@ export default function EditPatientPage() {
   }, [step, id, router, stepFromUrl]);
 
   return (
-    <div className="container mx-auto py-6">
-      <div className="mb-6 px-4"><h1 className="text-3xl font-bold text-[#0D4F97]">Editar Paciente</h1></div>
-      <div className="bg-white rounded-xl shadow-sm border p-4 md:p-8 min-h-[400px]">
+    <div className="w-full h-full max-w-7xl mx-auto py-2">
+      
+      <>
         {step === MembersRegisterStep.PERSONAL && <PersonalForm />}
         {step === MembersRegisterStep.KINSHIPS && <KinshipsForm />}
         {step === MembersRegisterStep.ADDRESS && <AddressForm />}
+        {step === MembersRegisterStep.ADDITIONALS && <AdditionalsForm />} 
         {step === MembersRegisterStep.GUARDIAN && <ResponsibleForm />}
         {step === MembersRegisterStep.PROFILE && <ProfileForm />}
-      </div>
+      </>
     </div>
   );
 }

--- a/apps/apae/src/app/person/[id]/edit/layout.tsx
+++ b/apps/apae/src/app/person/[id]/edit/layout.tsx
@@ -113,39 +113,45 @@ function EditPatientDataLoader({ children }: { children: React.ReactNode }) {
 
 export default function EditPatientLayout({ children }: { children: React.ReactNode }) {
   return (
-    <VaccinesProvider>
-      {/* @ts-ignore */}
-      <DisordersProvider>
-        <MembersRegisterProvider>
-          <EditPatientDataLoader>
-            {/* 🚀 NOVA ESTRUTURA VISUAL (Duas Colunas) */}
-            <div className="h-[90vh] md:h-screen rounded-xl md:rounded-none md:mx-0 mx-4 my-4 md:my-0 relative grid grid-cols-1 md:grid-cols-[1fr_2fr] antialiased overflow-hidden shadow-2xl">
-              
-              {/* Fundo e degradê da coluna esquerda */}
-              <div className="hidden md:block absolute inset-0 bg-cover bg-center bg-no-repeat grayscale-90 w-1/3" style={{ backgroundImage: `url(${Image.src})`, backgroundAttachment: "fixed" }} />
-              <div className="hidden md:block absolute inset-0 w-1/3" style={{ background: "linear-gradient(180deg, rgba(13, 79, 151, 0.9) 0%, rgba(13, 79, 151, 0.95) 100%)" }} />
+  <VaccinesProvider>
+    {/* @ts-ignore */}
+    <DisordersProvider>
+      <MembersRegisterProvider>
+        <EditPatientDataLoader>
 
-              {/* O MENU LATERAL */}
-              <div className="hidden md:flex relative z-10 w-full h-full bg-[#0D4F97]/90 backdrop-blur-sm">
-                <SidebarSteps />
-              </div>
+          <div className="h-screen rounded-lg mx-10 relative grid grid-cols-1 md:grid-cols-[1fr_2fr] antialiased overflow-hidden">
+            
+            <div
+              className="absolute inset-0 bg-cover bg-center bg-no-repeat grayscale-90"
+              style={{
+                backgroundImage: `url(${Image.src})`,
+              }}
+            />
 
-              {/* O FORMULÁRIO (Coluna direita) */}
-              <div className="relative flex flex-col w-full h-full p-4 md:p-12 bg-slate-50 overflow-y-auto">
-                <div className="max-w-3xl mx-auto w-full">
-                  <h1 className="text-2xl md:text-3xl font-bold text-[#0D4F97] mb-6 border-b pb-4">
-                    Edição de Paciente
-                  </h1>
-                  <div className="bg-white p-6 md:p-8 rounded-xl shadow-sm border border-slate-200">
-                    {children}
-                  </div>
-                </div>
-              </div>
+            <div
+              className="absolute inset-0"
+              style={{
+                background:
+                  "linear-gradient(180deg, rgba(13, 79, 151, 0.2) 54.32%, rgba(255, 255, 255, 0.6) 110.28%)",
+              }}
+            />
 
+            <div className="hidden md:flex relative z-10 w-full h-full bg-[#0D4F97]/40 backdrop-blur-sm">
+              <SidebarSteps />
             </div>
-          </EditPatientDataLoader>
-        </MembersRegisterProvider>
-      </DisordersProvider>
-    </VaccinesProvider>
-  );
+
+            <div className="relative flex flex-col w-full h-full p-8 bg-muted overflow-y-auto">
+              <h1 className="text-2xl font-bold text-blue-900 mb-4">
+                Edição de paciente
+              </h1>
+              {children}
+            </div>
+
+          </div>
+
+        </EditPatientDataLoader>
+      </MembersRegisterProvider>
+    </DisordersProvider>
+  </VaccinesProvider>
+);
 }

--- a/apps/apae/src/app/person/[id]/edit/layout.tsx
+++ b/apps/apae/src/app/person/[id]/edit/layout.tsx
@@ -136,7 +136,7 @@ export default function EditPatientLayout({ children }: { children: React.ReactN
               }}
             />
 
-            <div className="hidden md:flex relative z-10 w-full h-full bg-[#0D4F97]/40 backdrop-blur-sm">
+            <div className="hidden md:flex relative z-10 w-full h-full bg-[#0D4F97]/50">
               <SidebarSteps />
             </div>
 

--- a/apps/apae/src/app/person/register/form.tsx
+++ b/apps/apae/src/app/person/register/form.tsx
@@ -21,19 +21,28 @@ function MembersRegisterForm({
   buttons: React.ReactNode;
 } & React.ComponentProps<"form">) {
   return (
-    <>
+    <div className="relative w-full">
       <h2 className="text-xl font-bold text-blue-900/50 mb-4">{title}</h2>
+      
       <form
         onSubmit={onSubmit}
         className={cn(
-          "flex flex-col grow justify-between space-y-7",
+          "flex flex-col w-full", 
           className,
         )}
       >
-        {children}
-        <div className="flex justify-end gap-4">{buttons}</div>
+        <div className="pb-32 space-y-7">
+          {children}
+        </div>
+
+        <div className="fixed bottom-8 right-12 md:right-24 z-[99] pointer-events-none">          
+          <div className="flex gap-4 pointer-events-auto">
+            {buttons}
+          </div>
+          
+        </div>
       </form>
-    </>
+    </div>
   );
 }
 

--- a/apps/apae/src/app/person/register/layout.tsx
+++ b/apps/apae/src/app/person/register/layout.tsx
@@ -71,7 +71,6 @@ export default function MembersRegisterLayout({
                 className="absolute inset-0 bg-cover bg-center bg-no-repeat grayscale-90"
                 style={{
                   backgroundImage: `url(${Image.src})`,
-                  backgroundAttachment: "fixed",
                 }}
               />
 
@@ -79,10 +78,10 @@ export default function MembersRegisterLayout({
                 className="absolute inset-0"
                 style={{
                   background:
-                    "linear-gradient(180deg, rgba(13, 79, 151, 0.7) 54.32%, rgba(255, 255, 255, 0.6) 110.28%)",
+                    "linear-gradient(180deg, rgba(13, 79, 151, 0.2) 54.32%, rgba(255, 255, 255, 0.6) 110.28%)",
                 }}
               />
-               <div className="hidden md:flex relative z-10 w-full h-full bg-[#0D4F97]/90 backdrop-blur-sm">
+               <div className="hidden md:flex relative z-10 w-full h-full bg-[#0D4F97]/40 backdrop-blur-sm">
                 <SidebarSteps />
               </div>
               <div className="relative flex flex-col w-full h-full p-8 bg-muted overflow-y-auto">

--- a/apps/apae/src/app/person/register/layout.tsx
+++ b/apps/apae/src/app/person/register/layout.tsx
@@ -81,7 +81,7 @@ export default function MembersRegisterLayout({
                     "linear-gradient(180deg, rgba(13, 79, 151, 0.2) 54.32%, rgba(255, 255, 255, 0.6) 110.28%)",
                 }}
               />
-               <div className="hidden md:flex relative z-10 w-full h-full bg-[#0D4F97]/40 backdrop-blur-sm">
+               <div className="hidden md:flex relative z-10 w-full h-full bg-[#0D4F97]/50">
                 <SidebarSteps />
               </div>
               <div className="relative flex flex-col w-full h-full p-8 bg-muted overflow-y-auto">

--- a/apps/apae/src/components/sidebar/sidebar.module.css
+++ b/apps/apae/src/components/sidebar/sidebar.module.css
@@ -1,7 +1,10 @@
 .sidebar {
-    background-color: #B2D7EC;
+    background-color: rgba(178, 215, 236, 0.75) !important; 
     color: #0D4F97;
     border-radius: 24px !important;
+    
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
 }
 
 .header {


### PR DESCRIPTION
Padronização completa do layout das telas de Cadastro e Edição de Paciente, alinhando a tela de edição ao padrão visual da tela de cadastro.

Mudanças

Removidos os cards adicionais da tela de edição (container branco com sombra e bordas arredondadas)
Layout da edição ajustado para seguir o mesmo grid com imagem de fundo do cadastro
Transparência da sidebar restaurada em ambas as telas 
Botões de ação (Voltar, Próximo, Salvar Alterações) ajustados para ficarem sempre visíveis sem necessidade de scroll

Critérios atendidos

Tela de edição sem cards adicionais
Layout de edição igual ao cadastro
Sidebar azul padronizada e com transparência restaurada
Steps com boa legibilidade
Botões sempre visíveis em ambas as telas
Navegação entre etapas funcionando corretamente

https://github.com/user-attachments/assets/03fa699e-a5bd-4546-a659-8d2dc9c63adf

