### PR TITLE
[Fix] corrigir seleção via mouse nos dropdowns de Saúde e Social (#640)

### DIFF
--- a/apps/apae/src/components/GenericDatabaseSelect.tsx
+++ b/apps/apae/src/components/GenericDatabaseSelect.tsx
@@ -167,7 +167,9 @@ export const GenericDatabaseSelect = ({
       blurInputOnSelect={false}
       maxMenuHeight={250}
       menuPlacement={menuPlacement}
-      menuPortalTarget={typeof document !== "undefined" ? document.body : null} // CORREÇÃO 5: Tira o menu de dentro do clipping do modal
+      captureMenuScroll={false} // Evita bugs de scroll no modal
+      closeMenuOnSelect={false} // Bom para MultiSelect
+      tabSelectsValue={false}   // Melhora a acessibilidade no teclado 
     />
   );
 };


### PR DESCRIPTION
## O que mudou?
Este PR corrige a inconsistência na seleção de opções nos campos de Vacinas, Transtornos e Tipos de Atendimento. O problema impedia que usuários selecionassem itens utilizando o mouse (clique), embora a navegação via teclado funcionasse normalmente.

A causa raiz era um conflito de foco entre o Radix UI (base do Modal/Dialog) e o React Select. Ao renderizar o menu em um Portal externo (body), o Modal interceptava o clique do mouse como uma "interação fora do contexto", fechando o dropdown antes de processar a escolha. A solução consistiu em manter a renderização do menu dentro da hierarquia do Modal, garantindo que o clique seja reconhecido corretamente.

Tarefas Relacionadas
Resolves #640 

Mudanças Realizadas
Front-end (React/Next.js):

Componente GenericDatabaseSelect: - Remoção da propriedade menuPortalTarget. Isso faz com que o menu do Select seja injetado diretamente no DOM do Modal, evitando o bloqueio de eventos pelo Focus Trap do Radix UI.

Adição de captureMenuScroll={false} para evitar conflitos de rolagem entre o dropdown e o corpo do modal.

Ajuste de z-index no customStyles para garantir que o menu flutue sobre os demais elementos do formulário sem ser cortado.


Impacto
Melhora significativa na usabilidade e acessibilidade da plataforma.

https://github.com/user-attachments/assets/965f7288-b23a-4d18-a288-48be4fcf7004

