### PR TITLE
699 fix corrigir formatacao de mensagem de erro

### DIFF
--- a/apps/apae/src/app/api/appointments/[id]/route.ts
+++ b/apps/apae/src/app/api/appointments/[id]/route.ts
@@ -56,7 +56,7 @@ export async function PATCH(
       }
 
       return NextResponse.json(
-        { message: "Erro ao editar agendamento" },
+        { message: error.response?.data.message },
         { status: error.response?.status ?? 500 },
       );
     }

--- a/apps/apae/src/app/services/appointmentService.ts
+++ b/apps/apae/src/app/services/appointmentService.ts
@@ -291,10 +291,10 @@ export async function updateAppointment(
   });
 
   if (!response.ok) {
-    const errorText = await response.text();
-    throw new Error(
-      `Erro ao atualizar regra do agendamento: ${response.status} - ${errorText}`,
-    );
+    const error = await response.json();
+
+    const message = error?.message || "Erro ao atualizar regra do agendamento";
+    throw new Error(`Erro: ${message}`);
   }
 
   return await response.json();

--- a/apps/api/src/main/java/br/org/apae/api/patient/application/exceptions/PatientExceptionHandler.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/application/exceptions/PatientExceptionHandler.java
@@ -1,7 +1,5 @@
 package br.org.apae.api.patient.application.exceptions;
 
-import org.springframework.core.Ordered;
-import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -25,7 +23,6 @@ import br.org.apae.api.patient.domain.exceptions.VaccineNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 
 @ControllerAdvice
-@Order(Ordered.HIGHEST_PRECEDENCE)
 public class PatientExceptionHandler {
   @ExceptionHandler(InvalidDataException.class)
   public ResponseEntity<ErrorResponse> handleInvalidData(InvalidDataException ex, HttpServletRequest request) {


### PR DESCRIPTION
# O que esse PR forneceu?

- Retorno de mensagem de erro retornada da API de forma acertiva.
- Com base da exceção que estoura na API, a sua mensagem é retornada ao cliente.
 
# Coleta de evidências

- Ao tentar agendar para uma data passada a mensagem de erro da API é retornada e exibida na tela

<img width="643" height="719" alt="image" src="https://github.com/user-attachments/assets/c34cde3e-1a10-46a8-a3a8-8dbb9a1f1f76" />

<img width="1227" height="431" alt="image" src="https://github.com/user-attachments/assets/654e0e9c-4d5f-47e7-9663-4e99ee18a0d0" />

<img width="1227" height="431" alt="image" src="https://github.com/user-attachments/assets/7a2e1563-a990-4403-9b3a-9353886a4a31" />  

- Ao tentar agendar em um dia que o profissional não tem disponibilidade

<img width="1920" height="816" alt="image" src="https://github.com/user-attachments/assets/2131c03f-613b-486d-851b-ff12d347b0f1" />
