### PR TITLE
668 feat exibir agendamentos ativos e inativos na tela todos os agendamentos

### DIFF
--- a/apps/apae/src/app/all-appointments/page.tsx
+++ b/apps/apae/src/app/all-appointments/page.tsx
@@ -49,6 +49,7 @@ import {
   getAppointments,
   getAreasDaSaude,
 } from "../services/appointmentService";
+import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from "@radix-ui/react-tooltip";
 
 type Area = {
   id: number;
@@ -63,6 +64,7 @@ export default function AllApointments() {
   const [appointments, setAppointments] = useState<Appointment[]>([]);
   const initialized = useRef(false);
   const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [selectedStatus, setSelectedStatus] = useState('');
 
 useEffect(() => {
   if (appointments.length > 0) return;
@@ -74,11 +76,8 @@ useEffect(() => {
       initialized.current = true;
 
       const response = await getAppointments(undefined, undefined, 0, 100);
-      
-      const activeAppointments = (response.content as Appointment[]).filter(
-        appointment => appointment.isActive
-      );
-      setAppointments(activeAppointments);
+
+      setAppointments(response.content as Appointment[])
 
       const areasData = await getAreasDaSaude();
       const areasExistentes: Area[] = areasData.map(
@@ -114,13 +113,30 @@ useEffect(() => {
       ? appointment.professional.healthSector === selectedArea
         : true;
 
-    return matchesDate && matchesSearch && matchesArea;
+    const matchesStatus = selectedStatus
+        ? selectedStatus === 'ativo'
+            ? appointment.isActive === true
+            : appointment.isActive === false
+        : true;
+
+    return matchesDate && matchesSearch && matchesArea && matchesStatus;
   });
 
   const clearFilter = () => {
     setSelectedArea('');
     setSearchName('');
     setSelectedDate(undefined);
+    setSelectedStatus('');
+  };
+
+  const getTooltip = (item: Appointment) => {
+    if (!item.isActive && item.replacedByDate) {
+      return `Substituído por agendamento de ${formatDatePTBR(item.replacedByDate)}`;
+    }
+    if (item.isActive && item.updatedFromDate) {
+      return `Atualizado a partir do agendamento de ${formatDatePTBR(item.updatedFromDate)}`;
+    }
+    return 'Agendamento ativo';
   };
 
   return (
@@ -235,6 +251,9 @@ useEffect(() => {
                     Profissional
                   </TableHead>
                   <TableHead className="px-3 py-2 text-xs sm:px-4 sm:py-3 sm:text-sm text-[#0D4F97]">
+                    Status
+                  </TableHead>
+                  <TableHead className="px-3 py-2 text-xs sm:px-4 sm:py-3 sm:text-sm text-[#0D4F97]">
                     Ações
                   </TableHead>
                 </TableRow>
@@ -242,15 +261,41 @@ useEffect(() => {
               <TableBody>
                 {filteredAppointments.map((item, index) => {
                   return (
-                    <TableRow key={index}>
+                    <TableRow key={index} className={!item.isActive ? 'text-gray-400' : ''}>
                       <TableCell className="px-3 py-2 text-xs sm:px-4 sm:py-3 sm:text-sm">
                         {item.annualRegistration.patient.fullName}
                       </TableCell>
-                      <TableCell className="px-3 py-2 text-xs sm:px-4 sm:py-3 sm:text-sm text-gray-800">
+                      <TableCell className={`px-3 py-2 text-xs sm:px-4 sm:py-3 sm:text-sm ${!item.isActive ? 'text-gray-400' : 'text-gray-800'}`}>
                         {formatDatePTBR(item.initialDate)}
                       </TableCell>
                       <TableCell className="px-3 py-2 text-xs sm:px-4 sm:py-3 sm:text-sm">
                         {item.professional.name}
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-1">
+                            <span className={item.isActive ? 'text-green-600 font-medium' : 'text-red-400 font-medium'}>
+                              {item.isActive ? 'Ativo' : 'Inativo'}
+                            </span>
+                          <TooltipProvider>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <span className="cursor-help text-gray-400 text-xs">ⓘ</span>
+                              </TooltipTrigger>
+                              <TooltipContent className="bg-white text-gray-800 shadow-lg border border-gray-200 rounded-lg p-3 max-w-[280px] break-words">
+                                <div className="flex items-center gap-2 mb-2">
+                                  <div className="h-7 w-7 rounded-full bg-[#0D4F97] flex items-center justify-center text-white text-xs font-bold">
+                                    {item.professional.name.charAt(0)}
+                                  </div>
+                                  <div className="flex flex-col">
+                                    <span className="text-xs font-semibold text-gray-800">{item.professional.name}</span>
+                                    <span className="text-[10px] text-gray-400">{formatDatePTBR(item.initialDate)}</span>
+                                  </div>
+                                </div>
+                                <p className="text-xs text-gray-600 break-words whitespace-normal">{getTooltip(item)}</p>
+                              </TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
+                        </div>
                       </TableCell>
                       <TableCell className="px-3 py-2">
                         <Link

--- a/apps/apae/src/app/services/appointmentService.ts
+++ b/apps/apae/src/app/services/appointmentService.ts
@@ -25,6 +25,8 @@ export interface Appointment {
   endDate: string;
   isActive: boolean;
   creationDate: string;
+  replacedByDate?: string;
+  updatedFromDate?: string;
 }
 
 export interface CreateAppointmentDTO {

--- a/apps/api/src/main/java/br/org/apae/api/appointment/application/internal/AppointmentApplicationServiceImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/appointment/application/internal/AppointmentApplicationServiceImpl.java
@@ -420,6 +420,11 @@ public class AppointmentApplicationServiceImpl implements AppointmentApplication
                 null);
         newRule = appointmentRepo.save(newRule);
 
+        current.setReplacedBy(newRule);
+        newRule.setUpdatedFrom(current);
+        appointmentRepo.save(current);
+        appointmentRepo.save(newRule);
+
         generateAppointments(newRule.getId(), startDate, end);
 
         Patient patient = patientRepo.findById(newRule.getAnnualRegistration().getPatientId()).orElseThrow();

--- a/apps/api/src/main/java/br/org/apae/api/appointment/domain/model/Appointment.java
+++ b/apps/api/src/main/java/br/org/apae/api/appointment/domain/model/Appointment.java
@@ -53,6 +53,14 @@ public class Appointment {
   @Column(name = "data_criacao")
   private LocalDateTime creationDate;
 
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "substituido_por_id")
+  private Appointment replacedBy; // aponta para o novo agendamento que substituiu este
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "atualizado_de_id")
+  private Appointment updatedFrom; // aponta para o agendamento original do qual este foi gerado
+
   public Appointment() {
   }
 
@@ -137,4 +145,10 @@ public class Appointment {
   public void setGeneratedAppointments(Set<GeneratedAppointment> generatedAppointments) {
     this.generatedAppointments = generatedAppointments;
   }
+
+  public Appointment getReplacedBy() { return replacedBy; }
+  public void setReplacedBy(Appointment replacedBy) { this.replacedBy = replacedBy; }
+
+  public Appointment getUpdatedFrom() { return updatedFrom; }
+  public void setUpdatedFrom(Appointment updatedFrom) { this.updatedFrom = updatedFrom; }
 }

--- a/apps/api/src/main/java/br/org/apae/api/appointment/mapper/AppointmentMapper.java
+++ b/apps/api/src/main/java/br/org/apae/api/appointment/mapper/AppointmentMapper.java
@@ -96,7 +96,7 @@ public class AppointmentMapper {
         appointment.getEndDate(),
         appointment.getHour(),
         appointment.isActive(),
-        appointment.getCreationDate()
+        appointment.getCreationDate(), appointment.getReplacedBy() != null ? appointment.getReplacedBy().getInitialDate() : null, appointment.getUpdatedFrom() != null ? appointment.getUpdatedFrom().getInitialDate() : null
     );
   }
 

--- a/apps/api/src/main/java/br/org/apae/api/common/dto/appointment/response/appointment/AppointmentResponseDTO.java
+++ b/apps/api/src/main/java/br/org/apae/api/common/dto/appointment/response/appointment/AppointmentResponseDTO.java
@@ -16,5 +16,7 @@ public record AppointmentResponseDTO(
   LocalDate endDate,
   LocalTime hour,
   boolean isActive,
-  LocalDateTime creationDate
+  LocalDateTime creationDate,
+  LocalDate replacedByDate,
+  LocalDate updatedFromDate
 ) {}


### PR DESCRIPTION
Exibir agendamentos ativos e inativos com coluna de Status

O que foi feito:
- A tela "Todos os Agendamentos" agora exibe todos os agendamentos, incluindo os inativos (antes apenas os ativos eram carregados)
- Adicionada coluna **Status** na tabela, exibindo "Ativo" (verde) ou "Inativo" (vermelho)
- Linhas de agendamentos inativos ficam acinzentadas para diferenciação visual
- Adicionado ícone ⓘ com tooltip explicativo ao lado do status, com três casos:
  - *Agendamento ativo*: "Agendamento ativo"
  - *Ativo gerado após edição*: "Atualizado a partir do agendamento de [data]"
  - *Inativo*: "Substituído por agendamento de [data]"
- Adicionado filtro por **Status** (Ativo/Inativo) ao lado do filtro de Área da Saúde

Mudanças no backend:
- Adicionados campos `replacedBy` e `updatedFrom` na entidade `Appointment`
- `AppointmentMapper` atualizado para mapear `replacedByDate` e `updatedFromDate` no DTO de resposta
- Serviço de edição atualizado para vincular o agendamento antigo ao novo ao realizar uma edição

<img width="994" height="599" alt="image" src="https://github.com/user-attachments/assets/4b23ab9d-d2fb-4a63-8dcd-264b400e8d03" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Appointment status visibility: Active/Inactive labels now display in the appointments list with color coding.
  * Status filtering: Filter appointments by active or inactive status.
  * Replacement tracking: Appointments now display associated replacement or update information with professional details and relevant dates via tooltip.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->