### PR TITLE
[Feature] Integração do frontend com o backend da redefinição de senha

### DIFF
--- a/apps/apae/src/app/api/auth/recovery/route.ts
+++ b/apps/apae/src/app/api/auth/recovery/route.ts
@@ -1,0 +1,46 @@
+import { createBaseApi } from "@/lib/axios";
+import { AxiosError } from "axios";
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  try {
+    const { email } = await req.json();
+
+    if (!email) {
+      return NextResponse.json(
+        { message: "E-mail obrigatório" },
+        { status: 400 }
+      );
+    }
+
+    const api = await createBaseApi();
+
+    await api.post("/auth/password-recovery/request", {
+      email,
+    });
+
+    return NextResponse.json(
+      {
+        message:
+          "Se o e-mail existir, um link de recuperação foi enviado.",
+      },
+      { status: 200 }
+    );
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      return NextResponse.json(
+        {
+          message:
+            error.response?.data?.message ||
+            "Erro ao solicitar recuperação",
+        },
+        { status: error.response?.status || 500 }
+      );
+    }
+
+    return NextResponse.json(
+      { message: "Erro interno" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/apae/src/app/api/auth/reset-password/route.ts
+++ b/apps/apae/src/app/api/auth/reset-password/route.ts
@@ -1,0 +1,34 @@
+import { createBaseApi } from "@/lib/axios";
+import { AxiosError } from "axios";
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+
+    const api = await createBaseApi();
+
+    await api.post("/auth/password-recovery/reset", body);
+
+    return NextResponse.json(
+      { message: "Senha redefinida com sucesso." },
+      { status: 200 }
+    );
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      return NextResponse.json(
+        {
+          message:
+            error.response?.data?.message ||
+            "Erro ao redefinir senha",
+        },
+        { status: error.response?.status || 500 }
+      );
+    }
+
+    return NextResponse.json(
+      { message: "Erro interno" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/apae/src/app/auth/recovery/page.tsx
+++ b/apps/apae/src/app/auth/recovery/page.tsx
@@ -40,16 +40,14 @@ export default function RecoveryPage() {
     mode: "all",
   });
 
-  const API_URL = process.env.NEXT_PUBLIC_API || "http://localhost:8090/api";
-
   const handleSendCode = async (data: FormRecovery) => {
     try {
-
-      await axios.post(`${API_URL}/auth/password-recovery/request`, {
+      await axios.post(`/api/auth/recovery`, {
         email: data.email,
       });
 
       toast.success("Se o e-mail existir, um link de recuperação foi enviado.");
+      form.reset();
     } catch {
       toast.error("Erro ao solicitar recuperação de senha.");
     }
@@ -82,7 +80,7 @@ export default function RecoveryPage() {
                 name="email"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Usuário</FormLabel>
+                    <FormLabel>Email</FormLabel>
                     <FormControl>
                       <Input
                         {...field}

--- a/apps/apae/src/app/auth/reset-password/page.tsx
+++ b/apps/apae/src/app/auth/reset-password/page.tsx
@@ -11,10 +11,12 @@ import { PrimaryButton } from "@/components/buttons/ButtonPrimary";
 import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card";
 import { toast } from "react-toastify";
 import { newPasswordSchema, FormNewPasswordSchema } from "@/schemas/authSchema";
+import { useSearchParams } from "next/navigation";
 
 export default function NewPasswordPage() {
   const router = useRouter();
-  const [sessionData, setSessionData] = React.useState({ email: "", code: "" });
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token");
 
   const form = useForm<FormNewPasswordSchema>({
     resolver: zodResolver(newPasswordSchema),
@@ -26,49 +28,41 @@ export default function NewPasswordPage() {
   });
 
   React.useEffect(() => {
-    // Conexão com a tela de validação vencida, atualize para o link enviado por email
-    const email = sessionStorage.getItem("reset_email");
-    const code = sessionStorage.getItem("reset_code");
-
-    if (!email || !code) {
-      toast.error("Sessão expirada. Identifique-se novamente.");
-      router.push("/auth/reset-password");
-      return;
+    if (!token) {
+      toast.error("Link inválido ou expirado.");
+      router.push("/auth/recovery");
     }
-
-    setSessionData({ email, code });
-  }, [router]);
+  }, [token, router]);
 
   const onSubmit = async (data: FormNewPasswordSchema) => {
     try {
-      const payload = {
-        email: sessionData.email, 
-        code: sessionData.code,   
-        password: data.senha,     
-      };
+      if (!token) {
+        toast.error("Token inválido.");
+        return;
+      }
 
-      // Chamada para o backend 
-      // Exemplo de rota /api/auth/reset-password
       const response = await fetch("/api/auth/reset-password", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(payload),
+        body: JSON.stringify({
+          token,
+          newPassword: data.senha,
+          confirmPassword: data.confirmarSenha,
+        }),
       });
 
+      const result = await response.json();
+
       if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.message || "Erro ao redefinir a senha.");
+        throw new Error(result.message);
       }
 
       toast.success("Senha alterada com sucesso.");
-      sessionStorage.clear(); 
       router.push("/auth/login");
-
     } catch (err: any) {
-      toast.error(err.message || "Ocorreu um erro inesperado. Tente novamente.");
-      console.error("Erro no Reset Password:", err);
+      toast.error(err.message || "Erro inesperado.");
     }
   };
 
@@ -83,7 +77,7 @@ export default function NewPasswordPage() {
             <CardHeader className="flex-shrink-0 pt-10 pb-4">
                 <div className="w-full flex justify-center">
                     <span className="font-baloo2 font-semibold text-[2.25rem] leading-normal mt-10 text-center text-blue-900">
-                        Recuperar Senha
+                        Redefinir Senha
                     </span>
                 </div>
             </CardHeader>


### PR DESCRIPTION
### Descrição
Esse PR traz a funcionalidade de enviar o link de recuperação de senha pelo frontend, além de consertar a tela redefinição de senha.

### Como testar
- Crie sua senha de aplicativo na conta google
- Use seu email e senha de aplicativo no .env
- Clique em `Recuperar senha` na tela inicial
- Digite seu email
- Redefina sua senha

### Issues Relacionadas
#662 

### Checklist
- [x] A tela de redefinição de senha deve enviar o código de verificação e a nova senha para o backend.
- [x] O backend deve validar o código e atualizar a senha do usuário.
- [x] Mensagens de sucesso e erro devem ser exibidas ao usuário conforme resposta da API.
- [x] Após redefinição bem-sucedida, o usuário deve ser redirecionado para a tela de login.

### Evidências
[Gravação de tela de 21-04-2026 22:49:01.webm](https://github.com/user-attachments/assets/c6da314a-c54f-465a-b0b0-97cd2f4a8455)
