### PR TITLE
fix: aplicar validações do cadastro na edição e corrigir feedback vis…

### DIFF
--- a/apps/apae/src/app/person/[id]/edit/layout.tsx
+++ b/apps/apae/src/app/person/[id]/edit/layout.tsx
@@ -105,7 +105,7 @@ function EditPatientDataLoader({ children }: { children: React.ReactNode }) {
                number: data.guardian?.address?.number || "",
                noNumber: data.guardian?.address?.number === "SN" || false,
                complement: data.guardian?.address?.complement || "",
-               district: data.address?.district || "",
+               district: data.guardian?.address?.district || "",
              } 
            },
            kinships: data.parents?.map((p: any) => ({

--- a/apps/apae/src/app/person/register/responsible/page.tsx
+++ b/apps/apae/src/app/person/register/responsible/page.tsx
@@ -64,7 +64,8 @@ export default function MembersRegisterGuardianPage() {
   }, [isNoNumber, form]);
 
   useEffect(() => {
-    if (guardian && Object.keys(guardian).length > 0) {
+      if (guardian && guardian.name !== "") { 
+
       form.reset({
         ...guardian,
         address: {

--- a/apps/apae/src/components/AnnualRegistryEditModal.tsx
+++ b/apps/apae/src/components/AnnualRegistryEditModal.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-
 import { useEffect, useState, useRef } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
@@ -13,10 +12,8 @@ import { AnnualRegistryFormSchema, AnnualRegistryFormValues } from "@/schemas/an
 import { toast } from "react-toastify";
 import { Loader2, Upload, FileText, RefreshCw, ExternalLink } from "lucide-react";
 
-
 import { StringMultiSelect } from "@/components/StringMultiSelect";
 import { GenericDatabaseSelect } from "@/components/GenericDatabaseSelect";
-
 
 interface DocumentDTO {
     id: string;
@@ -25,7 +22,6 @@ interface DocumentDTO {
     type: string;
     url: string;
 }
-
 
 interface AnnualRegistryEditModalProps {
     isOpen: boolean;
@@ -37,43 +33,50 @@ interface AnnualRegistryEditModalProps {
 }
 
 interface DisorderItem {
-  id?: string | number;
-  name?: string;
-  label?: string;
-  value?: string;
+    id?: string | number;
+    name?: string;
+    label?: string;
+    value?: string;
 }
 
 interface ServiceAreaItem {
-  id?: string | number;
-  area?: string;
-  name?: string;
-  label?: string;
-  value?: string;
+    id?: string | number;
+    area?: string;
+    name?: string;
+    label?: string;
+    value?: string;
 }
 
 interface RegistroAnual {
-  id?: string;
-  bpc: boolean | string;
-  familyIncome: number | string;
-  diseases: string;
-  continuousMedication: string;
-  disorders?: DisorderItem[];
-  serviceAreas?: ServiceAreaItem[];
-  serviceArea?: ServiceAreaItem[];
-  serviceTypes?: ServiceAreaItem[];
+    id?: string;
+    bpc: boolean | string;
+    familyIncome: number | string;
+    diseases: string;
+    continuousMedication: string;
+    medications?: string;
+    medicamentos?: string;
+    medication?: string;
+    disorders?: DisorderItem[];
+    serviceAreas?: ServiceAreaItem[];
+    serviceArea?: ServiceAreaItem[];
+    serviceTypes?: ServiceAreaItem[];
 }
 
 interface FullPatientData {
-  vaccineNames?: { name: string }[] | string[];
-  allergies?: string;
-  address?: Record<string, string | null | undefined>;
-  guardian?: Record<string, string | Record<string, string> | null | undefined>;
-  parents?: Array<Record<string, string | boolean>>;
-  nationality?: string;
-  birthplace?: string;
-  [key: string]: unknown;
+    vaccineNames?: { name: string }[] | string[];
+    allergies?: string;
+    additionals?: {
+        medications?: string;
+        diseases?: string;
+        [key: string]: any;
+    };
+    address?: Record<string, string | null | undefined>;
+    guardian?: Record<string, string | Record<string, string> | null | undefined>;
+    parents?: Array<Record<string, string | boolean>>;
+    nationality?: string;
+    birthplace?: string;
+    [key: string]: unknown;
 }
-
 
 const MEDICAL_DOC_TYPES = [
     { value: "MEDICAL_REPORT", label: "Laudo Médico" },
@@ -91,13 +94,13 @@ const docTypeTranslations: Record<string, string> = {
 };
 
 export default function AnnualRegistryEditModal({
-                                                    isOpen,
-                                                    onClose,
-                                                    patientId,
-                                                    currentYear,
-                                                    initialData,
-                                                    mode = "edit"
-                                                }: AnnualRegistryEditModalProps) {
+    isOpen,
+    onClose,
+    patientId,
+    currentYear,
+    initialData,
+    mode = "edit"
+}: AnnualRegistryEditModalProps) {
 
     const [documents, setDocuments] = useState<DocumentDTO[]>([]);
     const [isLoadingDocs, setIsLoadingDocs] = useState(false);
@@ -107,15 +110,12 @@ export default function AnnualRegistryEditModal({
     const [fullPatientData, setFullPatientData] = useState<FullPatientData | null>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
 
-
     const currentYearInt = new Date().getFullYear();
-
-
     const availableYears = Array.from({ length: 32 }, (_, i) => (currentYearInt + 1 - i).toString());
-
 
     const form = useForm<AnnualRegistryFormValues>({
         resolver: zodResolver(AnnualRegistryFormSchema),
+        mode: "onChange",
         defaultValues: {
             year: currentYear || currentYearInt.toString(),
             bpc: "false",
@@ -129,9 +129,7 @@ export default function AnnualRegistryEditModal({
         },
     });
 
-
-    const { isSubmitting } = form.formState;
-
+    const { isSubmitting, errors } = form.formState;
 
     useEffect(() => {
         if (isOpen && patientId) {
@@ -141,54 +139,60 @@ export default function AnnualRegistryEditModal({
         }
     }, [isOpen, patientId, mode]);
 
-
     useEffect(() => {
         if (isOpen) {
             if (mode === "edit" && initialData) {
                 const rawBpc = initialData.bpc;
                 const bpcString = (rawBpc === true || String(rawBpc) === "true") ? "true" : "false";
 
-
                 const vaccineList = Array.isArray(fullPatientData?.vaccineNames)
-                    ? fullPatientData.vaccineNames.map((v: { name?: string } | string) => (typeof v === 'string' ? { name: v } : v))
+                    ? fullPatientData.vaccineNames.map((v: any) => (typeof v === 'string' ? { name: v } : v))
                     : [];
 
-
                 const sourceServiceAreas = initialData.serviceArea || initialData.serviceAreas || initialData.serviceTypes || [];
-                const serviceTypeList = Array.isArray(sourceServiceAreas) ? sourceServiceAreas.map((s: { id?: string | number; area?: string; name?: string }) => ({
+                const serviceTypeList = Array.isArray(sourceServiceAreas) ? sourceServiceAreas.map((s: any) => ({
                     id: s.id,
                     area: s.area || s.name,
                     name: s.name || s.area
                 })) : [];
 
-
                 const disorderList = Array.isArray(initialData.disorders) ? initialData.disorders : [];
+
+                const medicationValue = initialData.continuousMedication || 
+                                        initialData.medications || 
+                                        initialData.medicamentos || 
+                                        (initialData as any).medication || "";
 
                 form.reset({
                     year: currentYear,
                     bpc: bpcString,
                     familyIncome: initialData.familyIncome ? formatCurrencyForDisplay(initialData.familyIncome) : "",
                     diseases: initialData.diseases ?? "",
-                    continuousMedication: initialData.continuousMedication ?? "",
+                    continuousMedication: medicationValue,
                     allergies: fullPatientData?.allergies ?? "",
                     disorders: disorderList,
                     vaccines: vaccineList,
                     serviceTypes: serviceTypeList
                 });
 
-
             } else if (mode === "create") {
                 const vaccineList = Array.isArray(fullPatientData?.vaccineNames)
-                    ? fullPatientData.vaccineNames.map((v: string | { name: string }) => (typeof v === 'string' ? { name: v } : v))
+                    ? fullPatientData.vaccineNames.map((v: any) => (typeof v === 'string' ? { name: v } : v))
                     : [];
+                
+                const existingMedication = fullPatientData?.additionals?.medications || 
+                                          (fullPatientData as any)?.medications || 
+                                          (fullPatientData as any)?.continuousMedication || "";
 
+                const existingDiseases = fullPatientData?.additionals?.diseases || 
+                                         (fullPatientData as any)?.diseases || "";
 
                 form.reset({
                     year: currentYearInt.toString(),
                     bpc: "false",
                     familyIncome: "",
-                    diseases: "",
-                    continuousMedication: "",
+                    diseases: existingDiseases,
+                    continuousMedication: existingMedication,
                     allergies: fullPatientData?.allergies ?? "",
                     disorders: [],
                     vaccines: vaccineList,
@@ -206,10 +210,9 @@ export default function AnnualRegistryEditModal({
                 const data = await response.json().catch(() => []);
                 setDocuments(Array.isArray(data) ? data : []);
             }
-        } catch (error) { console.error("Erro fetch docs:", error); }
+        } catch (error) { console.error(error); }
         finally { setIsLoadingDocs(false); }
     };
-
 
     const fetchPatientData = async () => {
         try {
@@ -217,7 +220,6 @@ export default function AnnualRegistryEditModal({
             if (response.ok) setFullPatientData(await response.json());
         } catch (error) { console.error(error); }
     };
-
 
     const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
         const file = e.target.files?.[0];
@@ -233,14 +235,13 @@ export default function AnnualRegistryEditModal({
                 method: "POST",
                 body: formData,
             });
-            if (!res.ok) throw new Error("Falha no upload");
+            if (!res.ok) throw new Error();
             toast.success("Documento anexado!");
             fetchDocuments();
             if (fileInputRef.current) fileInputRef.current.value = "";
         } catch { toast.error("Erro ao enviar documento."); }
         finally { setIsUploading(false); }
     };
-
 
     const cleanCurrency = (value: string) => (!value ? "0.00" : value.replace(/[^\d,]/g, '').replace(',', '.'));
     const formatCurrencyForDisplay = (value: number | string) => (!value ? "" : Number(value).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' }));
@@ -251,87 +252,41 @@ export default function AnnualRegistryEditModal({
         onChange((parseFloat(value) / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" }));
     };
 
-
-    interface PatientDataToClean {
-      documents?: unknown;
-      annualRegistry?: unknown;
-      createdAt?: unknown;
-      updatedAt?: unknown;
-      deleted?: unknown;
-      isDeleted?: unknown;
-      age?: unknown;
-      [key: string]: unknown;
-    }
-
-    const cleanPatientData = (data: PatientDataToClean | null | undefined) => {
-    if (!data) return {};
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { documents, annualRegistry, createdAt, updatedAt, deleted, isDeleted, age, ...rest } = data;
-    return rest;
+    const cleanPatientData = (data: any) => {
+        if (!data) return {};
+        const { documents, annualRegistry, createdAt, updatedAt, deleted, isDeleted, age, ...rest } = data;
+        return rest;
     };
-
 
     const onSubmit = async (data: AnnualRegistryFormValues) => {
         try {
             const registryId = initialData?.id;
-
-            const finalDiseases = (data.diseases && data.diseases.trim() !== "") ? data.diseases : "Nenhuma";
-            const finalMedication = (data.continuousMedication && data.continuousMedication.trim() !== "") ? data.continuousMedication : "Nenhum";
-            const finalAllergies = (data.allergies && data.allergies.trim() !== "") ? data.allergies : "Nenhuma";
-
             const income = parseFloat(cleanCurrency(data.familyIncome));
             const bpcToSend = data.bpc === "true";
 
-
-            const formattedDisorders = (data.disorders || []).map((d: DisorderItem) => ({
-                name: d.name || d.label || d.value,
-                id: d.id
-            }));
-
-
-            const formattedServiceAreas = (data.serviceTypes || []).map((s: ServiceAreaItem) => ({
-                id: s.id,
-                area: s.area || s.name || s.label || s.value
-            }));
-
-
-            interface RegistryPayload {
-              bpc: boolean;
-              familyIncome: number;
-              diseases: string;
-              continuousMedication: string;
-              disorders: Array<{ name: string | undefined; id: string | number | undefined }>;
-              serviceArea: Array<{ id: string | number | undefined; area: string | undefined }>;
-              serviceAreas: Array<{ id: string | number | undefined; area: string | undefined }>;
-              year?: number;
-            }
-
-            const regPayload: RegistryPayload = {
+            const regPayload: any = {
                 bpc: bpcToSend,
                 familyIncome: income,
-                diseases: finalDiseases,
-                continuousMedication: finalMedication,
-                disorders: formattedDisorders,
-                serviceArea: formattedServiceAreas,
-                serviceAreas: formattedServiceAreas
+                diseases: data.diseases || "Nenhuma",
+                continuousMedication: data.continuousMedication || "Nenhum",
+                medications: data.continuousMedication || "Nenhum",
+                medicamentos: data.continuousMedication || "Nenhum",
+                disorders: (data.disorders || []).map((d: any) => ({ name: d.name || d.label || d.value, id: d.id })),
+                serviceArea: (data.serviceTypes || []).map((s: any) => ({ id: s.id, area: s.area || s.name || s.label })),
+                serviceAreas: (data.serviceTypes || []).map((s: any) => ({ id: s.id, area: s.area || s.name || s.label })),
+                ano: parseInt(data.year),
+                year: parseInt(data.year)
             };
 
-
             let regRes;
-
-
             if (mode === "create") {
-                regPayload.year = parseInt(data.year);
-
-
                 regRes = await fetch(`/api/pessoas/${patientId}/registro-anual`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify(regPayload),
                 });
             } else {
-                if (!registryId) throw new Error("ID do registro não encontrado.");
-
+                if (!registryId) throw new Error();
                 regRes = await fetch(`/api/pessoas/${patientId}/registro-anual/${registryId}`, {
                     method: 'PUT',
                     headers: { 'Content-Type': 'application/json' },
@@ -339,58 +294,29 @@ export default function AnnualRegistryEditModal({
                 });
             }
 
-
-            if (!regRes.ok) {
-                const errorText = await regRes.text();
-                console.error("Erro Backend:", errorText);
-                if (regRes.status === 409) {
-                    throw new Error(`Já existe um registro para o ano de ${data.year}.`);
-                }
-                throw new Error("Erro ao salvar registro anual.");
-            }
-
+            if (!regRes.ok) throw new Error();
 
             if (fullPatientData) {
-                const vaccineList = (data.vaccines || []).map((v: { name?: string; label?: string; value?: string; id?: string | number }) => ({ name: v.name || v.label || v.value, id: v.id }));
+                const vaccineList = (data.vaccines || []).map((v: any) => ({ name: v.name || v.label || v.value, id: v.id }));
                 const baseData = cleanPatientData(fullPatientData);
-                const safeNationality = baseData.nationality || baseData.birthplace || "Brasileira";
-
-
                 const patientPayload = {
                     ...baseData,
-                    nationality: safeNationality,
-                    allergies: finalAllergies,
+                    allergies: data.allergies || "Nenhuma",
                     vaccineNames: vaccineList,
-                    address: fullPatientData.address ? { ...fullPatientData.address } : null,
-                    guardian: fullPatientData.guardian ? { ...fullPatientData.guardian } : null,
-                    parents: fullPatientData.parents?.map((p: Record<string, string | boolean>) => ({
-                        id: p.id as string, name: p.name as string, rg: p.rg as string, cpf: p.cpf as string, profession: p.profession as string, isAlive: p.isAlive as boolean, kinship: p.kinship as string
-                    })) ?? []
                 };
-
-
                 await fetch(`/api/pessoas/${patientId}`, {
                     method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(patientPayload)
                 });
             }
 
-
-            const savedYear = mode === "create" ? data.year : undefined;
-            onClose(savedYear);
-
+            onClose(mode === "create" ? data.year : undefined);
             toast.success(mode === "create" ? "Registro criado com sucesso!" : "Alterações salvas!");
-
-
-        } catch (error: unknown) {
-            console.error(error);
-            const errorMessage = error instanceof Error ? error.message : "Erro ao salvar.";
-            toast.error(errorMessage);
+        } catch (error: any) {
+            toast.error("Erro ao salvar.");
         }
     };
 
-
     const isCreateMode = mode === "create";
-
 
     return (
         <Dialog open={isOpen} onOpenChange={() => onClose()}>
@@ -407,10 +333,13 @@ export default function AnnualRegistryEditModal({
                 <div className="flex-1 overflow-y-auto p-5 pb-24">
                     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 h-full">
                         <div className="bg-white p-5 rounded-xl shadow-sm border border-slate-200 h-fit">
-                            <h3 className="text-[#0D4F97] font-bold text-base mb-4 pb-2 border-b border-slate-100 flex items-center gap-2"><span className="bg-blue-50 p-1.5 rounded-lg text-[#0D4F97]"><FileText className="h-4 w-4" /></span>Dados Clínicos e Sociais</h3>
+                            <h3 className="text-[#0D4F97] font-bold text-base mb-4 pb-2 border-b border-slate-100 flex items-center gap-2">
+                                <span className="bg-blue-50 p-1.5 rounded-lg text-[#0D4F97]"><FileText className="h-4 w-4" /></span>
+                                Dados Clínicos e Sociais
+                            </h3>
                             <Form {...form}>
                                 <form id="health-form" onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-
+                                    
                                     {isCreateMode && (
                                         <FormField control={form.control} name="year" render={({ field }) => (
                                             <FormItem>
@@ -428,82 +357,106 @@ export default function AnnualRegistryEditModal({
                                         )} />
                                     )}
 
-
                                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                                         <FormField control={form.control} name="bpc" render={({ field }) => (
-                                            <FormItem><FormLabel className="text-slate-700 font-bold text-xs">Recebe BPC?</FormLabel>
-                                                <Select
-                                                    onValueChange={field.onChange}
-                                                    value={field.value}
-                                                    defaultValue={field.value}
-                                                >
+                                            <FormItem>
+                                                <FormLabel className="text-slate-700 font-bold text-xs">Recebe BPC?</FormLabel>
+                                                <Select onValueChange={field.onChange} value={field.value}>
                                                     <FormControl><SelectTrigger className="bg-slate-50 border-slate-200 h-10 text-sm"><SelectValue placeholder="Selecione" /></SelectTrigger></FormControl>
-                                                    <SelectContent><SelectItem value="true">Sim</SelectItem><SelectItem value="false">Não</SelectItem></SelectContent>
-                                                </Select><FormMessage />
-                                            </FormItem>)} />
+                                                    <SelectContent>
+                                                        <SelectItem value="true">Sim</SelectItem>
+                                                        <SelectItem value="false">Não</SelectItem>
+                                                    </SelectContent>
+                                                </Select>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )} />
+
                                         <FormField control={form.control} name="familyIncome" render={({ field }) => (
-                                            <FormItem><FormLabel className="text-slate-700 font-bold text-xs">Renda Familiar</FormLabel><FormControl><Input className="bg-slate-50 border-slate-200 h-10 text-sm" placeholder="R$ 0,00" value={field.value} onChange={(e) => handleMoneyChange(e, field.onChange)} /></FormControl><FormMessage /></FormItem>)} />
+                                            <FormItem>
+                                                <FormLabel className={`font-bold text-xs ${errors.familyIncome ? "text-red-500" : "text-slate-700"}`}>
+                                                    Renda Familiar
+                                                </FormLabel>
+                                                <FormControl>
+                                                    <Input 
+                                                        {...field}
+                                                        className={`bg-slate-50 h-10 text-sm ${errors.familyIncome ? "border-red-500 focus-visible:ring-red-500" : "border-slate-200"}`} 
+                                                        placeholder="R$ 0,00" 
+                                                        value={field.value} 
+                                                        onChange={(e) => handleMoneyChange(e, field.onChange)} 
+                                                    />
+                                                </FormControl>
+                                                <FormMessage className="text-red-500 text-[10px]" />
+                                            </FormItem>
+                                        )} />
                                     </div>
+
                                     <div className="space-y-3">
                                         <FormField control={form.control} name="diseases" render={({ field }) => (
-                                            <FormItem><FormLabel className="text-slate-700 font-bold text-xs">Doenças</FormLabel>
-                                                <FormControl><StringMultiSelect value={field.value || ""} onChange={field.onChange} placeholder="Digite doenças (ex: Diabetes)..." /></FormControl><FormMessage /></FormItem>)} />
+                                            <FormItem>
+                                                <FormLabel className={`font-bold text-xs ${errors.diseases ? "text-red-500" : "text-slate-700"}`}>Doenças</FormLabel>
+                                                <FormControl>
+                                                    <div className={errors.diseases ? "border-red-500 border rounded-md" : ""}>
+                                                        <StringMultiSelect value={field.value || ""} onChange={field.onChange} placeholder="Digite doenças..." />
+                                                    </div>
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )} />
 
                                         <FormField control={form.control} name="allergies" render={({ field }) => (
-                                            <FormItem><FormLabel className="text-slate-700 font-bold text-xs">Alergias</FormLabel>
-                                                <FormControl><StringMultiSelect value={field.value || ""} onChange={field.onChange} placeholder="Digite alergias (ex: Dipirona)..." /></FormControl><FormMessage /></FormItem>)} />
+                                            <FormItem>
+                                                <FormLabel className={`font-bold text-xs ${errors.allergies ? "text-red-500" : "text-slate-700"}`}>Alergias</FormLabel>
+                                                <FormControl>
+                                                    <div className={errors.allergies ? "border-red-500 border rounded-md" : ""}>
+                                                        <StringMultiSelect value={field.value || ""} onChange={field.onChange} placeholder="Digite alergias..." />
+                                                    </div>
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )} />
 
                                         <FormField control={form.control} name="continuousMedication" render={({ field }) => (
-                                            <FormItem><FormLabel className="text-slate-700 font-bold text-xs">Medicamentos</FormLabel>
-                                                <FormControl><StringMultiSelect value={field.value || ""} onChange={field.onChange} placeholder="Digite medicamentos..." /></FormControl><FormMessage /></FormItem>)} />
+                                            <FormItem>
+                                                <FormLabel className={`font-bold text-xs ${errors.continuousMedication ? "text-red-500" : "text-slate-700"}`}>Medicamentos</FormLabel>
+                                                <FormControl>
+                                                    <div className={errors.continuousMedication ? "border-red-500 border rounded-md" : ""}>
+                                                        <StringMultiSelect value={field.value || ""} onChange={field.onChange} placeholder="Digite medicamentos..." />
+                                                    </div>
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )} />
 
                                         <FormField control={form.control} name="vaccines" render={({ field }) => (
                                             <FormItem>
-                                                <FormLabel className="text-slate-700 font-bold text-xs">Vacinas</FormLabel>
+                                                <FormLabel className={`font-bold text-xs ${errors.vaccines ? "text-red-500" : "text-slate-700"}`}>Vacinas</FormLabel>
                                                 <FormControl>
-                                                    <GenericDatabaseSelect
-                                                        value={field.value || []}
-                                                        onChange={field.onChange}
-                                                        endpoint="/api/vacinas"
-                                                        labelSingular="Vacina"
-                                                        labelKey="name"
-                                                        placeholder="Selecione ou crie vacinas..."
-                                                    />
-                                                </FormControl><FormMessage /></FormItem>)}
-                                        />
+                                                    <GenericDatabaseSelect value={field.value || []} onChange={field.onChange} endpoint="/api/vacinas" labelSingular="Vacina" labelKey="name" placeholder="Selecione vacinas..." />
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )} />
                                     </div>
                                     <div className="pt-1 space-y-3">
                                         <FormField control={form.control} name="disorders" render={({ field }) => (
                                             <FormItem>
-                                                <FormLabel className="text-slate-700 font-bold text-xs mb-1.5 block">Transtornos</FormLabel>
+                                                <FormLabel className={`font-bold text-xs ${errors.disorders ? "text-red-500" : "text-slate-700"} mb-1.5 block`}>Transtornos</FormLabel>
                                                 <FormControl>
-                                                    <GenericDatabaseSelect
-                                                        value={field.value || []}
-                                                        onChange={field.onChange}
-                                                        endpoint="/api/transtornos"
-                                                        labelSingular="Transtorno"
-                                                        labelKey="name"
-                                                        placeholder="Selecione ou crie transtornos..."
-                                                    />
-                                                </FormControl><FormMessage /></FormItem>)}
-                                        />
-
-
+                                                    <GenericDatabaseSelect value={field.value || []} onChange={field.onChange} endpoint="/api/transtornos" labelSingular="Transtorno" labelKey="name" placeholder="Selecione transtornos..." />
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )} />
                                         <FormField control={form.control} name="serviceTypes" render={({ field }) => (
                                             <FormItem>
-                                                <FormLabel className="text-slate-700 font-bold text-xs mb-1.5 block">Tipos de Atendimento</FormLabel>
+                                                <FormLabel className={`font-bold text-xs ${errors.serviceTypes ? "text-red-500" : "text-slate-700"} mb-1.5 block`}>Tipos de Atendimento</FormLabel>
                                                 <FormControl>
-                                                    <GenericDatabaseSelect
-                                                        value={field.value || []}
-                                                        onChange={field.onChange}
-                                                        endpoint="/api/tipo-atendimento"
-                                                        labelSingular="Tipo de Atendimento"
-                                                        placeholder="Selecione ou crie tipos..."
-                                                        labelKey="area"
-                                                        menuPlacement="top"
-                                                    />
-                                                </FormControl><FormMessage /></FormItem>)}
-                                        />
+                                                    <GenericDatabaseSelect value={field.value || []} onChange={field.onChange} endpoint="/api/tipo-atendimento" labelSingular="Tipo" placeholder="Selecione tipos..." labelKey="area" menuPlacement="top" />
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )} />
                                     </div>
                                 </form>
                             </Form>
@@ -511,7 +464,7 @@ export default function AnnualRegistryEditModal({
                         <div className="flex flex-col h-full bg-white p-5 rounded-xl shadow-sm border border-slate-200">
                             <h3 className="text-[#0D4F97] font-bold text-base mb-4 pb-2 border-b border-slate-100 flex items-center justify-between">
                                 <div className="flex items-center gap-2"><span className="bg-green-50 p-1.5 rounded-lg text-green-700"><FileText className="h-4 w-4" /></span>Documentação Digital</div>
-                                <Button variant="ghost" size="sm" className="h-8 w-8 p-0 hover:bg-slate-100 rounded-full" onClick={fetchDocuments} disabled={isLoadingDocs}><RefreshCw className={`h-4 w-4 ${isLoadingDocs ? 'animate-spin' : ''}`} /></Button>
+                                <Button variant="ghost" size="sm" onClick={fetchDocuments} disabled={isLoadingDocs}><RefreshCw className={`h-4 w-4 ${isLoadingDocs ? 'animate-spin' : ''}`} /></Button>
                             </h3>
                             <div className="flex-1 flex flex-col">
                                 {isCreateMode ? (
@@ -521,33 +474,33 @@ export default function AnnualRegistryEditModal({
                                     </div>
                                 ) : (
                                     <>
-                                        <div className="bg-slate-50 p-5 rounded-xl border-2 border-dashed border-slate-300 mb-6 hover:border-[#0D4F97]/40 transition-all duration-300 group">
-                                            <label className="text-xs font-bold text-slate-500 uppercase mb-3 block text-center tracking-widest group-hover:text-[#0D4F97] transition-colors">Adicionar Novo Documento</label>
+                                        <div className="bg-slate-50 p-5 rounded-xl border-2 border-dashed border-slate-300 mb-6 group">
+                                            <label className="text-xs font-bold text-slate-500 uppercase mb-3 block text-center tracking-widest group-hover:text-[#0D4F97]">Adicionar Novo Documento</label>
                                             <div className="flex flex-col gap-3 max-w-sm mx-auto w-full">
                                                 <Select value={docType} onValueChange={setDocType}>
-                                                    <SelectTrigger className="w-full bg-white shadow-sm border-slate-200 h-10 text-sm"><SelectValue /></SelectTrigger>
+                                                    <SelectTrigger className="w-full bg-white border-slate-200 h-10 text-sm"><SelectValue /></SelectTrigger>
                                                     <SelectContent>{MEDICAL_DOC_TYPES.map(t => <SelectItem key={t.value} value={t.value}>{t.label}</SelectItem>)}</SelectContent>
                                                 </Select>
                                                 <input type="file" ref={fileInputRef} onChange={handleFileUpload} className="hidden" accept=".pdf,.jpg,.png,.jpeg" disabled={isUploading} />
-                                                <Button variant="outline" className="w-full bg-white text-[#0D4F97] border-[#0D4F97]/20 hover:bg-[#0D4F97] hover:text-white shadow-sm h-10 transition-all text-sm" onClick={() => fileInputRef.current?.click()} disabled={isUploading}>{isUploading ? <Loader2 className="mr-2 h-4 w-4 animate-spin"/> : <Upload className="mr-2 h-4 w-4"/>} Selecionar Arquivo</Button>
+                                                <Button variant="outline" className="w-full bg-white text-[#0D4F97] border-[#0D4F97]/20 hover:bg-[#0D4F97] hover:text-white h-10 transition-all text-sm" onClick={() => fileInputRef.current?.click()} disabled={isUploading}>{isUploading ? <Loader2 className="mr-2 h-4 w-4 animate-spin"/> : <Upload className="mr-2 h-4 w-4"/>} Selecionar Arquivo</Button>
                                             </div>
                                         </div>
-                                        <div className="flex-1 overflow-y-auto max-h-[400px] pr-2 custom-scrollbar">
+                                        <div className="flex-1 overflow-y-auto max-h-[400px] pr-2">
                                             <h4 className="text-[10px] font-bold text-slate-400 uppercase mb-3 tracking-widest">Arquivos Anexados ({documents.length})</h4>
                                             <div className="space-y-2">
                                                 {documents.length === 0 ? (
                                                     <div className="flex flex-col items-center justify-center h-32 text-slate-400 border-2 border-slate-100 rounded-xl bg-slate-50/50"><FileText className="h-8 w-8 mb-2 opacity-20" /><p className="text-xs font-medium opacity-60">Nenhum documento encontrado.</p></div>
                                                 ) : (
                                                     documents.map((doc) => (
-                                                        <div key={doc.id} className="group flex items-center justify-between p-3 bg-white border border-slate-100 rounded-xl shadow-sm hover:shadow-md hover:border-[#0D4F97]/20 transition-all duration-200">
+                                                        <div key={doc.id} className="group flex items-center justify-between p-3 bg-white border border-slate-100 rounded-xl shadow-sm hover:border-[#0D4F97]/20 transition-all duration-200">
                                                             <div className="flex items-center gap-3 overflow-hidden">
                                                                 <div className="bg-blue-50 p-2 rounded-lg group-hover:bg-[#0D4F97] group-hover:text-white transition-colors duration-300"><FileText className="h-4 w-4" /></div>
                                                                 <div className="flex flex-col min-w-0">
-                                                                <span className="text-sm font-semibold truncate text-slate-700 group-hover:text-[#0D4F97] transition-colors" 
-                                                                title={doc.name}>{doc.name}</span>
-                                                                <span className="text-[10px] text-slate-400 font-bold uppercase tracking-wide mt-0.5">{docTypeTranslations[doc.type] || doc.type}</span></div>
+                                                                    <span className="text-sm font-semibold truncate text-slate-700 group-hover:text-[#0D4F97] transition-colors" title={doc.name}>{doc.name}</span>
+                                                                    <span className="text-[10px] text-slate-400 font-bold uppercase tracking-wide mt-0.5">{docTypeTranslations[doc.type] || doc.type}</span>
+                                                                </div>
                                                             </div>
-                                                            {doc.url && (<a href={doc.url} target="_blank" rel="noreferrer" className="p-2 text-slate-400 hover:text-[#0D4F97] hover:bg-blue-50 rounded-full transition-all" title="Abrir em nova aba"><ExternalLink className="h-4 w-4" /></a>)}
+                                                            {doc.url && (<a href={doc.url} target="_blank" rel="noreferrer" className="p-2 text-slate-400 hover:text-[#0D4F97] hover:bg-blue-50 rounded-full transition-all"><ExternalLink className="h-4 w-4" /></a>)}
                                                         </div>
                                                     ))
                                                 )}
@@ -559,15 +512,15 @@ export default function AnnualRegistryEditModal({
                         </div>
                     </div>
                 </div>
-                <DialogFooter className="px-6 py-4 bg-white border-t border-slate-100 shrink-0 flex justify-end gap-3 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.05)] z-10">
-                    <Button variant="ghost" onClick={() => onClose()} type="button" className="text-slate-500 hover:text-slate-800 hover:bg-slate-100 h-10 px-5 rounded-lg font-medium transition-colors text-sm">Cancelar</Button>
+                <DialogFooter className="px-6 py-4 bg-white border-t border-slate-100 shrink-0 flex justify-end gap-3 z-10">
+                    <Button variant="ghost" onClick={() => onClose()} type="button" className="text-slate-500 h-10 px-5 text-sm">Cancelar</Button>
                     <Button
                         form="health-form"
                         type="submit"
                         disabled={isSubmitting}
-                        className="text-white bg-[#0D4F97] hover:bg-[#0b427d] shadow-lg shadow-blue-900/10 h-10 px-6 rounded-lg font-bold tracking-wide transition-all transform active:scale-95 text-sm disabled:opacity-70 disabled:cursor-not-allowed"
+                        className="text-white bg-[#0D4F97] hover:bg-[#0b427d] h-10 px-6 rounded-lg font-bold transition-all text-sm disabled:opacity-70"
                     >
-                        {isSubmitting ? <><Loader2 className="mr-2 h-4 w-4 animate-spin" /> {isCreateMode ? "Criar Registro" : "Salvar Alterações"}</> : (isCreateMode ? "Criar Registro" : "Salvar Alterações")}
+                        {isSubmitting ? <><Loader2 className="mr-2 h-4 w-4 animate-spin" /> Salvando...</> : (isCreateMode ? "Criar Registro" : "Salvar Alterações")}
                     </Button>
                 </DialogFooter>
             </DialogContent>

--- a/apps/apae/src/components/AnnualRegistryEditModal.tsx
+++ b/apps/apae/src/components/AnnualRegistryEditModal.tsx
@@ -156,8 +156,6 @@ export default function AnnualRegistryEditModal({
                     name: s.name || s.area
                 })) : [];
 
-                const disorderList = Array.isArray(initialData.disorders) ? initialData.disorders : [];
-
                 const medicationValue = initialData.continuousMedication || 
                                         initialData.medications || 
                                         initialData.medicamentos || 
@@ -170,7 +168,7 @@ export default function AnnualRegistryEditModal({
                     diseases: initialData.diseases ?? "",
                     continuousMedication: medicationValue,
                     allergies: fullPatientData?.allergies ?? "",
-                    disorders: disorderList,
+                    disorders: initialData.disorders || [],
                     vaccines: vaccineList,
                     serviceTypes: serviceTypeList
                 });
@@ -259,6 +257,7 @@ export default function AnnualRegistryEditModal({
     };
 
     const onSubmit = async (data: AnnualRegistryFormValues) => {
+        toast.dismiss();
         try {
             const registryId = initialData?.id;
             const income = parseFloat(cleanCurrency(data.familyIncome));
@@ -286,7 +285,7 @@ export default function AnnualRegistryEditModal({
                     body: JSON.stringify(regPayload),
                 });
             } else {
-                if (!registryId) throw new Error();
+                if (!registryId) throw new Error("ID do registro não encontrado.");
                 regRes = await fetch(`/api/pessoas/${patientId}/registro-anual/${registryId}`, {
                     method: 'PUT',
                     headers: { 'Content-Type': 'application/json' },
@@ -294,7 +293,17 @@ export default function AnnualRegistryEditModal({
                 });
             }
 
-            if (!regRes.ok) throw new Error();
+            if (!regRes.ok) {
+                const errorData = await regRes.json().catch(() => ({}));
+                const details = errorData.details || "";
+                const message = errorData.message || "";
+
+                if (regRes.status === 409 || details.includes("Conflito") || details.includes("já existe") || message.includes("já existe")) {
+                    form.setError("year", { type: "manual", message: "Este ano já possui um registro cadastrado." });
+                    throw new Error(`O ano ${data.year} já possui um registro. Escolha outro ano.`);
+                }
+                throw new Error("Erro ao salvar registro no servidor.");
+            }
 
             if (fullPatientData) {
                 const vaccineList = (data.vaccines || []).map((v: any) => ({ name: v.name || v.label || v.value, id: v.id }));
@@ -303,6 +312,7 @@ export default function AnnualRegistryEditModal({
                     ...baseData,
                     allergies: data.allergies || "Nenhuma",
                     vaccineNames: vaccineList,
+                    continuousMedication: data.continuousMedication || "Nenhum"
                 };
                 await fetch(`/api/pessoas/${patientId}`, {
                     method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(patientPayload)
@@ -312,7 +322,7 @@ export default function AnnualRegistryEditModal({
             onClose(mode === "create" ? data.year : undefined);
             toast.success(mode === "create" ? "Registro criado com sucesso!" : "Alterações salvas!");
         } catch (error: any) {
-            toast.error("Erro ao salvar.");
+            toast.error(error.message || "Erro ao salvar.");
         }
     };
 
@@ -343,16 +353,20 @@ export default function AnnualRegistryEditModal({
                                     {isCreateMode && (
                                         <FormField control={form.control} name="year" render={({ field }) => (
                                             <FormItem>
-                                                <FormLabel className="text-slate-700 font-bold text-xs">Ano de Referência</FormLabel>
+                                                <FormLabel className={`font-bold text-xs ${errors.year ? "text-red-500" : "text-slate-700"}`}>Ano de Referência</FormLabel>
                                                 <Select onValueChange={field.onChange} defaultValue={field.value}>
-                                                    <FormControl><SelectTrigger className="bg-slate-50 border-slate-200 h-10 text-sm"><SelectValue placeholder="Selecione o ano" /></SelectTrigger></FormControl>
+                                                    <FormControl>
+                                                        <SelectTrigger className={`bg-slate-50 h-10 text-sm ${errors.year ? "border-red-500 ring-red-500" : "border-slate-200"}`}>
+                                                            <SelectValue placeholder="Selecione o ano" />
+                                                        </SelectTrigger>
+                                                    </FormControl>
                                                     <SelectContent className="max-h-60">
                                                         {availableYears.map(year => (
                                                             <SelectItem key={year} value={year}>{year}</SelectItem>
                                                         ))}
                                                     </SelectContent>
                                                 </Select>
-                                                <FormMessage />
+                                                <FormMessage className="text-red-500 text-[10px]" />
                                             </FormItem>
                                         )} />
                                     )}

--- a/apps/apae/src/hooks/use-members-register-context.tsx
+++ b/apps/apae/src/hooks/use-members-register-context.tsx
@@ -262,13 +262,11 @@ export function MembersRegisterProvider({
   const params = useParams();
   const hasHydrated = useRef(false);
 
-  // 1. CHAVE DE CACHE
   const STORAGE_KEY = useMemo(() => {
     const patientId = params?.id as string;
     return patientId ? `apae_edit_cache_${patientId}` : "apae_register_cache";
   }, [params?.id]);
 
-  // 2. FUNÇÃO DE RECONSTRUÇÃO
   const reconstructFiles = useCallback((obj: any) => {
     if (obj.additionals?.disability?.report?.base64) {
       obj.additionals.disability.report = base64ToFile(
@@ -300,7 +298,6 @@ export function MembersRegisterProvider({
     return obj;
   }, []);
 
-  // 3. SETTERS
   const setters = {
     setPersonalData: useCallback(
       (data: Partial<PersonalData>) =>
@@ -345,9 +342,7 @@ export function MembersRegisterProvider({
     ),
   };
 
-  // 4. EFEITO DE HIDRATAÇÃO (executa apenas uma vez)
   useEffect(() => {
-    // Evita hidratação duplicada
     if (hasHydrated.current) return;
     if (typeof window === "undefined") return;
 
@@ -370,14 +365,11 @@ export function MembersRegisterProvider({
     hasHydrated.current = true;
   }, [STORAGE_KEY, reconstructFiles]);
 
-  // 5. EFEITO DE SALVAMENTO AUTOMÁTICO
   useEffect(() => {
     if (typeof window === "undefined") return;
-    // Não salva se ainda não foi hidratado
     if (!hasHydrated.current) return;
 
     const saveDraft = async () => {
-      // Não salva se está em modo de edição e state está vazio
       if (params?.id && state.personal.name === "") return;
 
       try {
@@ -419,7 +411,6 @@ export function MembersRegisterProvider({
     return () => clearTimeout(timer);
   }, [state, STORAGE_KEY, params?.id]);
 
-  // 6. FUNÇÃO REGISTER
   const register = useCallback(
     async (id?: string) => {
       const { personal, address, additionals, guardian, kinships, profile } =
@@ -427,14 +418,11 @@ export function MembersRegisterProvider({
 
       const formatDate = (date: Date | string | number | null | undefined) => {
         if (!date) return null;
-
         const d = new Date(date);
         if (isNaN(d.getTime())) return null;
-
         const year = d.getFullYear();
         const month = String(d.getMonth() + 1).padStart(2, "0");
         const day = String(d.getDate()).padStart(2, "0");
-
         return `${year}-${month}-${day}`;
       };
 
@@ -459,8 +447,9 @@ export function MembersRegisterProvider({
         cpf: string;
         cns: string;
         nis: string;
-        registrationDate: Date | null;
+        registrationDate: Date | string | null;
         allergies: string;
+        continuousMedication: string; 
         isStudent: boolean;
         address: {
           city: string;
@@ -494,15 +483,28 @@ export function MembersRegisterProvider({
           kinship: string;
         }[];
         vaccineNames: { name: string }[];
-        annualRegistry?: {
+        annualRegistry: {
           bpc: boolean;
           diseases: string;
+          continuousMedication: string; 
           serviceArea: { area: string }[];
           familyIncome: number;
           year: number;
           disorders: { name: string }[];
         };
       }
+
+      const annualRegistryData = {
+        bpc: additionals.bpc,
+        diseases: additionals.diseases || "Nenhuma",
+        continuousMedication: additionals.medications || "Nenhum", 
+        serviceArea: additionals.care.types.map((area: string) => ({ area })),
+        familyIncome: parseIncome(additionals.householdIncome),
+        year: new Date().getFullYear(),
+        disorders: additionals.disability.types.map((name: string) => ({
+          name,
+        })),
+      };
 
       const patient: PatientPayload = {
         fullName: personal.name || "Não informado",
@@ -519,8 +521,10 @@ export function MembersRegisterProvider({
         cpf: personal.cpf,
         cns: personal.cns || "000 0000 0000 0000",
         nis: personal.nis || "0",
-        registrationDate: personal.rg.issuing.date,
+        registrationDate: formatDate(personal.rg.issuing.date),
         allergies: additionals.allergies || "Nenhuma",
+        continuousMedication: additionals.medications || "Nenhum", 
+
         isStudent: profile.role === "student",
         address: {
           city: address.city || "Não informado",
@@ -554,6 +558,7 @@ export function MembersRegisterProvider({
           kinship: k.type || "Pai/Mãe",
         })),
         vaccineNames: additionals.vaccines.map((v) => ({ name: v })),
+        annualRegistry: annualRegistryData, 
       };
 
       if (id) {
@@ -570,7 +575,6 @@ export function MembersRegisterProvider({
         if (profile.photo instanceof File && res.ok) {
           const photoFormData = new FormData();
           photoFormData.append("photo", profile.photo);
-
           await fetch(`/api/pessoas/${id}/photo`, {
             method: "PUT",
             body: photoFormData,
@@ -580,18 +584,8 @@ export function MembersRegisterProvider({
         const data = await res.json().catch(() => ({}));
         return { status: res.status, data };
       } else {
-        patient.registrationDate = new Date();
-        patient.annualRegistry = {
-          bpc: additionals.bpc,
-          diseases: additionals.diseases,
-          serviceArea: additionals.care.types.map((area: string) => ({ area })),
-          familyIncome: parseIncome(additionals.householdIncome),
-          year: new Date().getFullYear(),
-          disorders: additionals.disability.types.map((name: string) => ({
-            name,
-          })),
-        };
-
+        patient.registrationDate = new Date().toISOString();
+        
         const formData = new FormData();
         formData.append(
           "patient",

--- a/apps/apae/src/schemas/anualRegistrySchema.ts
+++ b/apps/apae/src/schemas/anualRegistrySchema.ts
@@ -1,31 +1,22 @@
-import { z } from "zod";
-
-export interface AnnualRegistryFormValues {
-  year: string;
-  bpc: string;
-  familyIncome: string;
-  diseases: string;
-  allergies: string;
-  continuousMedication: string;
-  vaccines: { id?: string | number; name?: string; area?: string }[];
-  disorders: { id?: string | number; name?: string; area?: string }[];
-  serviceTypes: { id?: string | number; name?: string; area?: string }[];
-}
-
-const GenericItemSchema = z.object({
-  id: z.union([z.string(), z.number()]).optional(),
-  name: z.string().optional(),
-  area: z.string().optional(),
-});
+import * as z from "zod";
 
 export const AnnualRegistryFormSchema = z.object({
-  year: z.string().min(4, "Selecione um ano"),
-  bpc: z.string(),
-  familyIncome: z.string(),
-  diseases: z.string(),
-  allergies: z.string(),
-  continuousMedication: z.string(),
-  vaccines: z.array(GenericItemSchema),
-  disorders: z.array(GenericItemSchema),
-  serviceTypes: z.array(GenericItemSchema),
+  year: z.string().min(4, "Ano inválido"),
+  bpc: z.enum(["true", "false"]),
+  
+  familyIncome: z.string().min(1, "A renda é obrigatória")
+    .refine(val => {
+        const num = parseFloat(val.replace(/[^\d]/g, ""));
+        return num >= 20000;
+    }, "Mínimo R$ 200,00"),
+
+  diseases: z.string().min(1, "Informe as doenças ou 'Nenhuma'"),
+  continuousMedication: z.string().min(1, "Informe os medicamentos ou 'Nenhum'"),
+  allergies: z.string().min(1, "Informe as alergias ou 'Nenhuma'"),
+
+  vaccines: z.array(z.any()).min(1, "Selecione ao menos uma vacina"),
+  disorders: z.array(z.any()).min(1, "Selecione ao menos um transtorno"),
+  serviceTypes: z.array(z.any()).min(1, "Selecione ao menos um atendimento"),
 });
+
+export type AnnualRegistryFormValues = z.infer<typeof AnnualRegistryFormSchema>;

--- a/apps/apae/src/schemas/edit-member-schemas.ts
+++ b/apps/apae/src/schemas/edit-member-schemas.ts
@@ -1,5 +1,6 @@
 import * as z from "zod";
 import { Personal, Address, Additionals, Guardian, Profile } from "./member-schemas";
+
 export const EditAdditionals = Additionals.extend({
   disability: z.object({
     types: z.array(z.string().min(1)).min(1, "O tipo de atendimento é obrigatório."),
@@ -14,7 +15,6 @@ export const EditAdditionals = Additionals.extend({
 export const EditProfile = Profile.extend({
   photo: z.union([z.instanceof(File), z.string()]).optional(), 
 });
-
 
 export const EditPersonal = Personal;
 export const EditAddress = Address;

--- a/apps/apae/src/schemas/edit-member-schemas.ts
+++ b/apps/apae/src/schemas/edit-member-schemas.ts
@@ -1,70 +1,21 @@
-import z, { number } from "zod";
-
-// 1. Endereço relaxado 
-export const EditAddress = z.object({
-  cep: z.string().min(1, "CEP é obrigatório"),
-  state: z.string().min(1, "Obrigatório"),
-  city: z.string().min(1, "Obrigatório"),
-  neighborhood: z.string().min(1, "Obrigatório"),
-  street: z.string().min(1, "Obrigatório"),
-  number: z.string().min(1, "Número é obrigatório"),
-  noNumber: z.boolean().optional(),
-  complement: z.string().optional(),
-});
-
-// 2. Dados Pessoais relaxados
-export const EditPersonal = z.object({
-  name: z.string().min(2, "Nome é obrigatório"),
-  cpf: z.string().min(1, "CPF é obrigatório"),
-  phone: z.string().min(1, "Telefone é obrigatório"),
-  rg: z.object({
-    number: z.string().min(1, "RG é obrigatório"),
-    issuing: z.object({
-      body: z.string().min(1, "Órgão emissor é obrigatório"),
-      date: z.coerce.date(), 
-    }),
+import * as z from "zod";
+import { Personal, Address, Additionals, Guardian, Profile } from "./member-schemas";
+export const EditAdditionals = Additionals.extend({
+  disability: z.object({
+    types: z.array(z.string().min(1)).min(1, "O tipo de atendimento é obrigatório."),
+    report: z.union([z.instanceof(File), z.string()]), 
   }),
-  cns: z.string().optional().or(z.literal("")),
-  nis: z
-    .string()
-    .min(1, "NIS é obrigatório")
-    .length(11, "O NIS deve ter exatamente 11 dígitos")
-    .regex(/^\d+$/, "O NIS deve conter apenas números"),
-  birth: z.object({
-    certificate: z.string().min(1, "Obrigatório"),
-    date: z.coerce.date(),
-    place: z.string().min(1, "Obrigatório"),
+  care: z.object({
+    types: z.array(z.string().min(1)).min(1, "O tipo de atendimento é obrigatório."),
+    referral: z.union([z.instanceof(File), z.string()]), 
   }),
 });
 
-// 3. Adicionais relaxados
-export const EditAdditionals = z.object({
-  diseases: z.string().optional(),
-  medications: z.string().optional(),
-  vaccines: z.array(z.string()).optional(),
-  allergies: z.string().optional(),
-  bpc: z.boolean().optional(),
-  householdIncome: z.string().optional(),
-  disability: z.object({ types: z.array(z.string()).optional(), report: z.union([z.instanceof(File), z.string()]).optional() }).optional(),
-  care: z.object({ types: z.array(z.string()).optional(), referral: z.union([z.instanceof(File), z.string()]).optional() }).optional(),
+export const EditProfile = Profile.extend({
+  photo: z.union([z.instanceof(File), z.string()]).optional(), 
 });
 
-// 4. RESPONSÁVEL 
-export const EditGuardian = z.object({
-  name: z.string().min(2, "Nome é obrigatório"),
-  contact: z.string().min(1, "Contato é obrigatório"),
-  kinship: z.string().min(1, "Parentesco é obrigatório"),
-  address: EditAddress, 
-});
 
-// 5. Perfil relaxado
-export const EditProfile = z.object({
-  role: z.enum(["student", "patient"]),
-  photo: z.union([z.instanceof(File), z.string()]).optional(),
-});
-
-export type EditAddressData = z.infer<typeof EditAddress>;
-export type EditPersonalData = z.infer<typeof EditPersonal>;
-export type EditAdditionalsData = z.infer<typeof EditAdditionals>;
-export type EditGuardianData = z.infer<typeof EditGuardian>;
-export type EditProfileData = z.infer<typeof EditProfile>;
+export const EditPersonal = Personal;
+export const EditAddress = Address;
+export const EditGuardian = Guardian;

--- a/apps/apae/src/schemas/member-schemas.ts
+++ b/apps/apae/src/schemas/member-schemas.ts
@@ -159,10 +159,10 @@ export const Additionals = z.object({
   householdIncome: z
     .string()
     .min(1, "A renda familiar é obrigatória.")
-    .refine(
-      (value) => Number(value.replace(/\D/g, "")) >= 20000,
-      "A renda familiar deve ser pelo menos R$ 200,00.",
-    ),
+    .refine((val) => {
+      const num = parseFloat(val.replace(/[^\d]/g, ""));
+      return !isNaN(num) && num >= 20000; 
+    }, "A renda familiar deve ser pelo menos R$ 200,00"),
 });
 
 export const Kinship = z.object({

--- a/apps/apae/src/schemas/member-schemas.ts
+++ b/apps/apae/src/schemas/member-schemas.ts
@@ -121,7 +121,10 @@ export const Address = z.object({
     .string()
     .min(3, "Estado deve ser o nome completo (ex: Paraíba)")
     .regex(/^[a-zA-ZÀ-ÿ\s]+$/, "O estado deve conter apenas letras"),
-  city: z.string().min(2, "Cidade inválida"),
+  city: z
+    .string()
+    .min(2, "Cidade inválida")
+    .regex(/^[a-zA-ZÀ-ÿ\s]+$/, "A cidade deve conter apenas letras"),
   neighborhood: z.string().min(2, "Bairro inválido"),
   street: z
     .string()
@@ -176,6 +179,7 @@ export const Kinship = z.object({
       z
         .string()
         .min(2, "Nome muito curto")
+        .regex(/^[a-zA-ZÀ-ÿ\s]+$/, "O nome não pode conter números ou símbolos")
         .refine((val) => val.split(/\s+/).length >= 2, {
           message: "Digite o nome completo do parente",
         }),
@@ -203,7 +207,14 @@ export const Guardian = z.object({
           message: "Digite o nome completo do responsável (nome e sobrenome)",
         }),
     ),
-  contact: z.string().min(1, "Contato de emergência é obrigatório."),
+  contact: z
+    .string()
+    .min(1, "Contato de emergência é obrigatório.")
+    .refine((val) => {
+      const apenasNumeros = val.replace(/\D/g, ""); 
+      return apenasNumeros.length >= 10; 
+    }, "O telefone deve ter no mínimo 10 dígitos (DDD + número)"),
+
   kinship: z.string().min(1, "Informar o parentesco é obrigatório."),
   address: Address,
 });

--- a/apps/apae/tsconfig.json
+++ b/apps/apae/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
Descrição:
Este PR resolve a inconsistência de validações entre os fluxos de cadastro e edição de pacientes, além de melhorar a experiência do usuário no Registro Anual, garantindo que erros de preenchimento sejam sinalizados visualmente.

O que foi feito:
Unificação de Validações:
Sincronizei os Schemas do Zod (EditGuardian, EditPersonal, etc.) para que a edição exija os mesmos critérios rigorosos do cadastro (CPF, RG, NIS, etc.).
Feedback Visual de Erro:
Implementei classes condicionais do Tailwind (border-red-500) e mensagens de erro (FormMessage) nos campos de Renda Familiar e outros campos obrigatórios. Agora, campos inválidos são destacados em vermelho com uma mensagem clara logo abaixo do input.
Correção de Persistência no Registro Anual:
Corrigi o objeto de envio (annualRegistryData) na criação do paciente para incluir o campo de medicamentos, que anteriormente era perdido no primeiro registro de 2026.
Adicionei mapeamentos extras para o campo de medicamentos (continuousMedication, medications, medicamentos) para garantir compatibilidade com o retorno da API Java.
Melhoria na Sincronização de Dados:
Ajustei a lógica de form.reset na edição para aguardar o carregamento real dos dados da API, evitando que os campos ficassem vermelhos por erro de validação durante o carregamento.
Ajuste no Modal de Registro Anual:
Habilitei o campo de Renda com validação mínima de R$ 200,00 e impedi o fechamento/envio silencioso em caso de erro.


https://github.com/user-attachments/assets/bb98d07d-1bc4-4794-9939-7eaddb74a18c

