### PR TITLE
bug (profissional-saúde): preserva a availabilities ao editar o profissional

### DIFF
--- a/apps/api/src/main/java/br/org/apae/api/professional/application/mappers/HealthProfessionalMapper.java
+++ b/apps/api/src/main/java/br/org/apae/api/professional/application/mappers/HealthProfessionalMapper.java
@@ -60,25 +60,23 @@ public class HealthProfessionalMapper {
         Address address = addressMapper.toEntity(dto.address());
         ServiceArea serviceArea = serviceAreaMapper.toEntityFromResponse(serviceAreaDto);
 
-        HealthProfessional updatedEntity = new HealthProfessional(
-                professional.getId(),
-                dto.name(),
-                dto.email(),
-                serviceArea,
-                dto.phoneNumber(),
-                dto.identityDocument(),
-                dto.professionalDocument(),
-                address);
+        professional.setName(dto.name());
+        professional.setEmail(dto.email());
+        professional.setServiceArea(serviceArea);
+        professional.setPhoneNumber(dto.phoneNumber());
+        professional.setIdentityDocument(dto.identityDocument());
+        professional.setProfessionalDocument(dto.professionalDocument());
+        professional.setAddress(address);
 
         if (dto.availabilities() != null) {
             List<Availability> newAvailabilities = dto.availabilities().stream()
-                    .map(a -> availabilityMapper.toEntity(a, updatedEntity))
+                    .map(a -> availabilityMapper.toEntity(a, professional))
                     .collect(Collectors.toList());
 
-            updatedEntity.setAvailabilities(newAvailabilities);
+            professional.setAvailabilities(newAvailabilities);
         }
 
-        return updatedEntity;
+        return professional;
     }
 
     public HealthProfessionalResponseDTO toResponseDTO(HealthProfessional professional) {

--- a/apps/api/src/main/java/br/org/apae/api/professional/domain/model/HealthProfessional.java
+++ b/apps/api/src/main/java/br/org/apae/api/professional/domain/model/HealthProfessional.java
@@ -83,28 +83,56 @@ public class HealthProfessional {
         return id;
     }
 
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
     public String getName() {
         return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     public String getEmail() {
         return email;
     }
 
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
     public ServiceArea getServiceArea() {
         return serviceArea;
+    }
+
+    public void setServiceArea(ServiceArea serviceArea) {
+        this.serviceArea = serviceArea;
     }
 
     public String getPhoneNumber() {
         return phoneNumber;
     }
 
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
     public String getProfessionalDocument() {
         return professionalDocument;
     }
 
+    public void setProfessionalDocument(String professionalDocument) {
+        this.professionalDocument = professionalDocument;
+    }
+
     public String getIdentityDocument() {
         return identityDocument;
+    }
+
+    public void setIdentityDocument(String identityDocument) {
+        this.identityDocument = identityDocument;
     }
 
     public Address getAddress() {


### PR DESCRIPTION
## O que mudou?
Agora o profissional quando está inativo e tiver algum dado seu editado, não voltará ao estado de ativo. A situação do profissional se mantem (ativo/inativo) mesmo editando seus dados.

### Issue: https://github.com/IFPBEsp/APAE/issues/744

## Tarefas Relacionadas
- Correção de persistência de estado: Ajuste na lógica do mapper para transitar de criação de novas instâncias para atualização de referências existentes, impedindo o reset do status ativo.
- Padronização de Entidade: Verificação e alinhamento dos métodos getters e setters na classe de domínio HealthProfessional para suportar a atualização parcial de dados.

## Mudanças Realizadas 
- Refatoração do Mapper: O método updateEntityFromDto foi modificado para receber a entidade original do banco de dados e aplicar as alterações do DTO diretamente nela, eliminando o uso do construtor new HealthProfessional() que causava a perda do status de inatividade.

## Evidências

https://github.com/user-attachments/assets/aad91114-4c26-4909-9786-ab0a7992d8e0

