### PR TITLE
[Fix] Refatorar seed escolar e mapeamento de views para maior robustez

### DIFF
--- a/.scripts/manuais/create_mock_views_escolar.sql
+++ b/.scripts/manuais/create_mock_views_escolar.sql
@@ -1,19 +1,19 @@
+CREATE TABLE IF NOT EXISTS pacientes (
+    id UUID PRIMARY KEY,
+    nome_completo VARCHAR(255),
+    is_aluno BOOLEAN,
+    is_apagado BOOLEAN,
+    data_de_cadastro TIMESTAMP
+);
+
 DROP VIEW IF EXISTS view_relatorios_escolares CASCADE;
 DROP VIEW IF EXISTS view_avaliacoes_escolares CASCADE;
 
 CREATE VIEW view_relatorios_escolares AS
-WITH aluno_base AS (
-    SELECT p.id, p.nome_completo
-    FROM pacientes p
-    WHERE p.is_aluno = true
-      AND p.is_apagado = false
-    ORDER BY p.data_de_cadastro ASC, p.nome_completo ASC
-    LIMIT 1
-)
 SELECT
-    '11111111-1111-1111-1111-111111111111'::uuid AS relatorio_id,
-    a.id AS aluno_id,
-    a.nome_completo AS aluno_nome,
+    md5(p.id::text || 'relatorio')::uuid AS relatorio_id,
+    p.id AS aluno_id,
+    p.nome_completo AS aluno_nome,
     '22222222-2222-2222-2222-222222222222'::uuid AS professor_id,
     'Professor Teste Escolar'::varchar(255) AS professor_nome,
     '33333333-3333-3333-3333-333333333333'::uuid AS turma_id,
@@ -23,23 +23,19 @@ SELECT
     'Repetição guiada, estímulo visual e reforço positivo.'::text AS estrategias,
     'Cartões ilustrados, caderno pedagógico e lápis adaptado.'::text AS recursos,
     CURRENT_TIMESTAMP AS created_at
-FROM aluno_base a;
+FROM pacientes p
+WHERE p.is_aluno = true
+  AND p.is_apagado = false;
 
 CREATE VIEW view_avaliacoes_escolares AS
-WITH aluno_base AS (
-    SELECT p.id, p.nome_completo
-    FROM pacientes p
-    WHERE p.is_aluno = true
-      AND p.is_apagado = false
-    ORDER BY p.data_de_cadastro ASC, p.nome_completo ASC
-    LIMIT 1
-)
 SELECT
-    '44444444-4444-4444-4444-444444444444'::uuid AS avaliacao_id,
-    a.id AS aluno_id,
-    a.nome_completo AS aluno_nome,
+    md5(p.id::text || 'avaliacao')::uuid AS avaliacao_id,
+    p.id AS aluno_id,
+    p.nome_completo AS aluno_nome,
     '22222222-2222-2222-2222-222222222222'::uuid AS professor_id,
     'Professor Teste Escolar'::varchar(255) AS professor_nome,
     'O aluno apresentou evolução significativa nas atividades propostas, demonstrando maior autonomia e participação nas tarefas escolares.'::text AS descricao,
     CURRENT_DATE AS data_avaliacao
-FROM aluno_base a;
+FROM pacientes p
+WHERE p.is_aluno = true
+  AND p.is_apagado = false;

--- a/.scripts/setup.sh
+++ b/.scripts/setup.sh
@@ -30,6 +30,15 @@ if ! docker exec "$DB_CONTAINER" pg_isready -U "$DB_USERNAME" > /dev/null 2>&1; 
 fi
 
 if docker exec -i "$DB_CONTAINER" psql -U "$DB_USERNAME" -d "$DB_NAME" <<EOF
+CREATE TABLE IF NOT EXISTS usuarios (
+    id UUID PRIMARY KEY,
+    email VARCHAR(255) UNIQUE NOT NULL,
+    cpf VARCHAR(255) UNIQUE NOT NULL,
+    senha VARCHAR(255) NOT NULL,
+    nome_completo VARCHAR(255),
+    cargo VARCHAR(50) NOT NULL
+);
+
 INSERT INTO usuarios (id, email, cpf, senha, nome_completo, cargo)
 VALUES (
   '11111111-1111-4111-8111-111111111111',

--- a/apps/apae/tsconfig.json
+++ b/apps/apae/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {

--- a/apps/api/src/main/java/br/org/apae/api/patient/domain/model/AssessmentView.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/domain/model/AssessmentView.java
@@ -8,11 +8,11 @@ import org.hibernate.annotations.Immutable;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import org.hibernate.annotations.Subselect;
 
 @Entity
 @Immutable
-@Table(name = "view_avaliacoes_escolares")
+@Subselect("SELECT * FROM view_avaliacoes_escolares")
 public class AssessmentView {
 
     @Id

--- a/apps/api/src/main/java/br/org/apae/api/patient/domain/model/ReportView.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/domain/model/ReportView.java
@@ -8,11 +8,11 @@ import org.hibernate.annotations.Immutable;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import org.hibernate.annotations.Subselect;
 
 @Entity
 @Immutable
-@Table(name = "view_relatorios_escolares")
+@Subselect("SELECT * FROM view_relatorios_escolares")
 public class ReportView {
 
     @Id


### PR DESCRIPTION
## O que mudou?
Este PR resolve a quebra de execução do comando `pnpm db:seed` em ambientes limpos, onde o script SQL tentava criar views mockadas referenciando tabelas inexistentes. 

Diferente do esperado, o mapeamento no backend forçava o Hibernate a tentar gerar tabelas físicas para entidades de View. Este trabalho ajusta as anotações do JPA, garante que os schemas mínimos (tabelas e constraints) existam durante a rodada dos scripts bash/SQL antes do deploy da API, e transforma os inserts fixos das views escolares em uma lógica dinâmica e escalável para todos os pacientes da base.

## Tarefas Relacionadas
- Resolves #751

## Mudanças Realizadas
**Backend (Spring/Hibernate):**
- **Tipagem de Entidade de Leitura:** Substituição da anotação `@Table` por `@Subselect` nas classes `ReportView` e `AssessmentView`, impedindo a criação indevida dessas tabelas pelo `ddl-auto`.

**Scripts de Configuração e Banco de Dados (Seed):**
- **Garantia de Criação Prévia:** Adição de `CREATE TABLE IF NOT EXISTS` com colunas mínimas para `pacientes` no `.scripts/manuais/create_mock_views_escolar.sql` e para `usuarios` no `.scripts/setup.sh`, evitando falhas de referência ("relation does not exist").
- **Mock Dinâmico Escalonado:** Remoção do `LIMIT 1` no `SELECT` que compõe as views escolares. Todos os cadastros com `is_aluno = true` agora recebem relatórios automáticos.
- **Identificadores Persistentes:** Inclusão de `md5(p.id::text || 'relatorio')::uuid` na view, trocando o `uuid` fixo por uma geração dinâmica atrelada à integridade de cada paciente, mantendo a consistência dos relatórios.

## Testes Realizados
- Execução limpa do comando `pnpm db:seed` no terminal, validando a criação dos schemas e views sem erros e sem interrupções por dependência circular ou relação não declarada.
- Validação no banco via comando `\d` confirmando a persistência correta e leitura bem sucedida de um select direto na view gerada.

<img width="950" height="453" alt="image" src="https://github.com/user-attachments/assets/81a7ba76-f1cd-439b-8b2d-fe12751fafa1" />
<img width="1129" height="495" alt="image" src="https://github.com/user-attachments/assets/dc1e6d84-6efe-4141-add9-58b17b6335e2" />
