### PR TITLE
[Chore] Separar docker-compose em perfis de desenvolvimento e produção

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,32 @@
+apae-sistema-geral:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
+    container_name: apae-sistema-geral
+    ports:
+      - "3000:3000"
+      - "${API_PORT}:8090"
+    environment:
+      - DB_URL=jdbc:postgresql://db:5432/${POSTGRES_DB}
+      - DB_USERNAME=${DB_USERNAME}
+      - DB_PASSWORD=${DB_PASSWORD}
+      - MINIO_URL=http://minio:9000
+      - MINIO_PUBLIC_URL=http://localhost:9000
+      - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}
+      - MINIO_SECRET_KEY=${MINIO_SECRET_KEY}
+      - JWT_SECRET=${JWT_SECRET}
+      - JWT_EXPIRATION_HOURS=${JWT_EXPIRATION_HOURS}
+      - MAIL_HOST=${MAIL_HOST}
+      - MAIL_PORT=${MAIL_PORT}
+      - MAIL_USERNAME=${MAIL_USERNAME}
+      - MAIL_PASSWORD=${MAIL_PASSWORD}
+      - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS}
+      - APP_FRONTEND_RESET_PASSWORD_URL=${APP_FRONTEND_RESET_PASSWORD_URL}
+    depends_on:
+      - db
+      - minio
+    networks:
+      - apae-network
+    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,38 +33,6 @@ services:
       - apae-network
     restart: unless-stopped
 
-  apae-sistema-geral:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      args:
-        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
-    container_name: apae-sistema-geral
-    ports:
-      - "3000:3000"
-      - "${API_PORT}:8090"
-    environment:
-      - DB_URL=jdbc:postgresql://db:5432/${POSTGRES_DB}
-      - DB_USERNAME=${DB_USERNAME}
-      - DB_PASSWORD=${DB_PASSWORD}
-      - MINIO_URL=http://minio:9000
-      - MINIO_PUBLIC_URL=http://localhost:9000
-      - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}
-      - MINIO_SECRET_KEY=${MINIO_SECRET_KEY}
-      - JWT_SECRET=${JWT_SECRET}
-      - JWT_EXPIRATION_HOURS=${JWT_EXPIRATION_HOURS}
-      - MAIL_HOST=${MAIL_HOST}
-      - MAIL_PORT=${MAIL_PORT}
-      - MAIL_USERNAME=${MAIL_USERNAME}
-      - MAIL_PASSWORD=${MAIL_PASSWORD}
-      - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS}
-      - APP_FRONTEND_RESET_PASSWORD_URL=${APP_FRONTEND_RESET_PASSWORD_URL}
-    depends_on:
-      - db
-      - minio
-    networks:
-      - apae-network
-    restart: unless-stopped
 
 volumes:
   apae-postgres-data:


### PR DESCRIPTION
### O que foi feito?

Foi separado o build da imagem `apae-sistema-geral` do docker-compose principal, estando agora em `docker-compose.prod.yml`, este arquivo utiliza o `docker-compose.yml` como base para subir os demais serviços, porém, para isso é necessário executa-lo com:

```bash
docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
```

### Mudanças realizadas

- Remoção do serviço `apae-sistema-geral` do `docker-compose.yml`.
- Criação do arquivo `docker-compose.prod.yml`.
- Adição do build do serviço em `docker-compose.prod.yml`

Agora, em ambiente de desenvolvimento, ao utilizar o `pnpm dev` o build da imagem do sistema geral não é feito, garantindo que as portas estejam livres e não apresentem problemas.