### PR TITLE
[Feat] adiciona basePath /apae-geral em frontend e backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,17 +50,19 @@ MAIL_PASSWORD=
 
 CORS_ALLOWED_ORIGINS=http://localhost:3000
 
-APP_FRONTEND_RESET_PASSWORD_URL=http://localhost:3000/auth/reset-password
+APP_FRONTEND_RESET_PASSWORD_URL=http://localhost:3000/apae-geral/auth/reset-password
 
 
 # =========================
 # FRONTEND - APAE
 # =========================
-NEXT_PUBLIC_API_URL=http://localhost:8090/api
-NEXT_PUBLIC_DOCUMENTS_API_URL=http://localhost:8092/api/documents
+# O frontend roda sob basePath /apae-geral e o backend sob context-path /apae-geral.
+# Em produção (atrás de Nginx), o Nginx mantém o prefixo /apae-geral ao fazer proxy.
+NEXT_PUBLIC_API_URL=http://localhost:8090/apae-geral/api
+NEXT_PUBLIC_DOCUMENTS_API_URL=http://localhost:8092/apae-geral/api/documents
 NEXT_PUBLIC_USE_MOCK_DATA=false
 
 # =========================
 # FRONTEND - MANAGEMENT
 # =========================
-NEXT_PUBLIC_MANAGEMENT_API_URL=http://localhost:8090/api
+NEXT_PUBLIC_MANAGEMENT_API_URL=http://localhost:8090/apae-geral/api

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -85,7 +85,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            NEXT_PUBLIC_API_URL=/api
+            NEXT_PUBLIC_API_URL=/apae-geral/api
           cache-from: type=gha,scope=frontend
           cache-to: type=gha,mode=max,scope=frontend
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ docker/db_data
 
 # Arquivos de build e cache do Next.js
 **/.next/
+.claude/

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ MAIL_HOST=smtp.gmail.com
 MAIL_PORT=587
 MAIL_USERNAME=seu-email@gmail.com
 MAIL_PASSWORD=sua_senha_de_app
-APP_FRONTEND_RESET_PASSWORD_URL=http://localhost:3000/auth/reset-password
+APP_FRONTEND_RESET_PASSWORD_URL=http://localhost:3000/apae-geral/auth/reset-password
 ```
 
 3. Agora pode seguir com a execução normal do projeto, indo para seção [**Como Executar**](#como-executar)

--- a/apps/apae/Dockerfile
+++ b/apps/apae/Dockerfile
@@ -19,7 +19,7 @@ RUN if [ -f package-lock.json ]; then \
 FROM node:20-alpine AS builder
 WORKDIR /app
 
-ARG NEXT_PUBLIC_API_URL=/api
+ARG NEXT_PUBLIC_API_URL=/apae-geral/api
 ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
 ENV NEXT_TELEMETRY_DISABLED=1
 
@@ -50,6 +50,6 @@ USER appuser
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-  CMD wget -qO- http://127.0.0.1:3000/ >/dev/null 2>&1 || exit 1
+  CMD wget -qO- http://127.0.0.1:3000/apae-geral >/dev/null 2>&1 || exit 1
 
 CMD ["node", "server.js"]

--- a/apps/apae/README.md
+++ b/apps/apae/README.md
@@ -30,6 +30,11 @@ pnpm dev:apae
 
 Você pode começar a editar a página modificando o arquivo `app/page.tsx`. A página é atualizada automaticamente conforme você edita o arquivo.
 
+> ⚠️ Este frontend roda sob o `basePath` `/apae-geral` (configurado em `next.config.ts`).
+> Acesse no navegador em **`http://localhost:3000/apae-geral`** — a raiz `http://localhost:3000/`
+> retorna 404, isso é esperado. Esse prefixo existe para que o Nginx do Portal dos 30 anos
+> consiga fazer proxy do projeto sem conflitar com os outros (gestão-escolar, apae-30-anos, etc.).
+
 Este projeto utiliza [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) para otimizar e carregar automaticamente a fonte [Geist](https://vercel.com/font), uma nova família de fontes para Vercel.
 
 ## Saiba Mais

--- a/apps/apae/next.config.ts
+++ b/apps/apae/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  basePath: "/apae-geral",
   async redirects() {
     return [
       { source: "/visualization-patients",     destination: "/patients",               permanent: true },

--- a/apps/apae/src/app/absence/page.tsx
+++ b/apps/apae/src/app/absence/page.tsx
@@ -141,7 +141,7 @@ export default function AbsenceDetails() {
   const handleDownload = async (patientId: string, documentName: string) => {
     try {
       const res = await fetch(
-        `/api/patients/${patientId}/documents/download?name=${encodeURIComponent(documentName)}`,
+        `/apae-geral/api/patients/${patientId}/documents/download?name=${encodeURIComponent(documentName)}`,
       );
       if (!res.ok) throw new Error("Erro ao buscar URL");
       const data = await res.json();

--- a/apps/apae/src/app/absence/page.tsx
+++ b/apps/apae/src/app/absence/page.tsx
@@ -54,7 +54,7 @@ export default function AbsenceDetails() {
         docFormData.append("type", "ATTACHMENTANY");
         docFormData.append("year", String(new Date().getFullYear()));
 
-        const docResponse = await fetch(`/api/patients/${justifyingAbsence.patientId}/documents`, {
+        const docResponse = await fetch(`/apae-geral/api/patients/${justifyingAbsence.patientId}/documents`, {
           method: "POST",
           body: docFormData,
         });
@@ -94,8 +94,8 @@ export default function AbsenceDetails() {
         });
 
         const [patientsRes, statsRes] = await Promise.all([
-          fetch(`/api/patients/with-absences?${queryParams}`),
-          fetch("/api/dashboard/overview?minAbsences=3"),
+          fetch(`/apae-geral/api/patients/with-absences?${queryParams}`),
+          fetch("/apae-geral/api/dashboard/overview?minAbsences=3"),
         ]);
 
         if (!patientsRes.ok || !statsRes.ok) {

--- a/apps/apae/src/app/api/patients/[id]/registro-anual/route.ts
+++ b/apps/apae/src/app/api/patients/[id]/registro-anual/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8090/api";
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8090/apae-geral/api";
 
 export async function POST(
   request: Request,

--- a/apps/apae/src/app/api/patients/[id]/registro-anual/years-list/route.ts
+++ b/apps/apae/src/app/api/patients/[id]/registro-anual/years-list/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8090/api";
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8090/apae-geral/api";
 
 export async function GET(
   request: Request,

--- a/apps/apae/src/app/appointments/[id]/page.tsx
+++ b/apps/apae/src/app/appointments/[id]/page.tsx
@@ -58,7 +58,7 @@ export default function ViewAppointment() {
         setAppointment(appointmentData);
 
         // 2. Busca a lista de pacientes com faltas (fetch direto)
-        const response = await fetch('/api/patients/with-absences?minAbsences=3');
+        const response = await fetch('/apae-geral/api/patients/with-absences?minAbsences=3');
         if (response.ok) {
           const data = await response.json();
           const absencesList = data.content || [];

--- a/apps/apae/src/app/appointments/list/page.tsx
+++ b/apps/apae/src/app/appointments/list/page.tsx
@@ -87,7 +87,7 @@ useEffect(() => {
       setAreas(areasExistentes);
 
       // Busca direta na API (lógica que está funcionando)
-      const absencesResponse = await fetch('/api/patients/with-absences?minAbsences=3');
+      const absencesResponse = await fetch('/apae-geral/api/patients/with-absences?minAbsences=3');
       
       if (!absencesResponse.ok) {
         throw new Error('Erro ao buscar pacientes com faltas');

--- a/apps/apae/src/app/appointments/today/[id]/page.tsx
+++ b/apps/apae/src/app/appointments/today/[id]/page.tsx
@@ -45,7 +45,7 @@ export default function ViewTodayAppointment() {
         setAppointment(data);
 
         // 2. Busca pacientes com faltas via fetch direto
-        const response = await fetch('/api/patients/with-absences?minAbsences=3');
+        const response = await fetch('/apae-geral/api/patients/with-absences?minAbsences=3');
         
         if (response.ok) {
           const result = await response.json();

--- a/apps/apae/src/app/auth/login/page.tsx
+++ b/apps/apae/src/app/auth/login/page.tsx
@@ -39,7 +39,7 @@ function LoginPage() {
 
   const onSubmit = async (data: FormLogin) => {
     try {
-      const res = await fetch("/api/auth/login", {
+      const res = await fetch("/apae-geral/api/auth/login", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(data),

--- a/apps/apae/src/app/auth/recovery/page.tsx
+++ b/apps/apae/src/app/auth/recovery/page.tsx
@@ -40,7 +40,7 @@ export default function RecoveryPage() {
     mode: "all",
   });
 
-  const API_URL = process.env.NEXT_PUBLIC_API || "http://localhost:8090/api";
+  const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8090/apae-geral/api";
 
   const handleSendCode = async (data: FormRecovery) => {
     try {

--- a/apps/apae/src/app/auth/reset-password/ResetPasswordClient.tsx
+++ b/apps/apae/src/app/auth/reset-password/ResetPasswordClient.tsx
@@ -35,7 +35,7 @@ export default function NewPasswordPage() {
     }
   }, [token, router]);
 
-  const API_URL = process.env.NEXT_PUBLIC_API || "http://localhost:8090/api";
+  const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8090/apae-geral/api";
 
   const onSubmit = async (data: FormNewPasswordSchema) => {
     try {

--- a/apps/apae/src/app/disorders/[id]/edit/page.tsx
+++ b/apps/apae/src/app/disorders/[id]/edit/page.tsx
@@ -29,7 +29,7 @@ export default function EditTranstornoPage() {
     if (id) {
       const fetchTranstorno = async () => {
         try {
-          const response = await fetch(`/api/disorders/${id}`);
+          const response = await fetch(`/apae-geral/api/disorders/${id}`);
           if (!response.ok) throw new Error("Transtorno não encontrado.");
           const data = await response.json();
           setValue("name", data.name);
@@ -45,7 +45,7 @@ export default function EditTranstornoPage() {
 
   const onSubmit = async (data: UpdateDisorderDTO) => {
     try {
-      const response = await fetch(`/api/disorders/${id}`, {
+      const response = await fetch(`/apae-geral/api/disorders/${id}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(data),

--- a/apps/apae/src/app/disorders/new/page.tsx
+++ b/apps/apae/src/app/disorders/new/page.tsx
@@ -22,7 +22,7 @@ export default function NewTranstornoPage() {
 
   const onSubmit = async (data: CreateDisorderDTO) => {
     try {
-      const response = await fetch("/api/disorders", {
+      const response = await fetch("/apae-geral/api/disorders", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(data),

--- a/apps/apae/src/app/disorders/page.tsx
+++ b/apps/apae/src/app/disorders/page.tsx
@@ -24,7 +24,7 @@ export default function TranstornosPage() {
       try {
         setIsLoading(true);
         setError(null);
-        const response = await fetch("/api/disorders");
+        const response = await fetch("/apae-geral/api/disorders");
         if (!response.ok) {
           throw new Error("Falha ao buscar transtornos.");
         }
@@ -44,7 +44,7 @@ export default function TranstornosPage() {
   const handleDelete = async (id: string) => {
     
     try {
-      const response = await fetch(`/api/disorders/${id}`, {
+      const response = await fetch(`/apae-geral/api/disorders/${id}`, {
         method: "DELETE",
       });
       

--- a/apps/apae/src/app/page.tsx
+++ b/apps/apae/src/app/page.tsx
@@ -86,7 +86,7 @@ export default function DashboardPage() {
   const fetchAbsences = async () => {
       try {
         // Fazemos o fetch direto para a API, filtrando por 3 faltas
-        const response = await fetch('/api/patients/with-absences?minAbsences=3');
+        const response = await fetch('/apae-geral/api/patients/with-absences?minAbsences=3');
         
         if (!response.ok) {
           throw new Error('Erro ao buscar pacientes com faltas');

--- a/apps/apae/src/app/patients/[id]/documents/[type]/page.tsx
+++ b/apps/apae/src/app/patients/[id]/documents/[type]/page.tsx
@@ -91,7 +91,7 @@ export default function DocumentTypePage() {
       });
 
       const response = await fetch(
-        `/api/patients/${patientId}/documents?${params.toString()}`,
+        `/apae-geral/api/patients/${patientId}/documents?${params.toString()}`,
       );
 
       if (!response.ok) {
@@ -146,7 +146,7 @@ export default function DocumentTypePage() {
       formData.append("file", replaceFile);
 
       const response = await fetch(
-        `/api/patients/${patientId}/documents/${replaceTarget.id}`,
+        `/apae-geral/api/patients/${patientId}/documents/${replaceTarget.id}`,
         {
           method: "PATCH",
           body: formData,

--- a/apps/apae/src/app/patients/[id]/edit/layout.tsx
+++ b/apps/apae/src/app/patients/[id]/edit/layout.tsx
@@ -46,7 +46,7 @@ function EditPatientDataLoader({ children }: { children: React.ReactNode }) {
     
     async function load() {
       try {
-        const res = await fetch(`/api/patients/${id}`, { cache: "no-store" });
+        const res = await fetch(`/apae-geral/api/patients/${id}`, { cache: "no-store" });
         if (!res.ok) throw new Error("Erro ao buscar dados do paciente");
         const data = await res.json();
         

--- a/apps/apae/src/app/patients/[id]/page.tsx
+++ b/apps/apae/src/app/patients/[id]/page.tsx
@@ -75,7 +75,7 @@ export default function PersonDetailsPage() {
   const fetchPessoa = useCallback(async (silent = false) => {
     try {
       if (!silent) setLoadingPessoa(true); 
-      const response = await fetch(`/api/patients/${id}`);
+      const response = await fetch(`/apae-geral/api/patients/${id}`);
       if (!response.ok) throw new Error("Falha ao buscar dados do paciente.");
       const data: PatientResponse = await response.json();
       setPessoa(data);
@@ -91,7 +91,7 @@ export default function PersonDetailsPage() {
 
   const fetchYears = useCallback(async () => {
     try {
-        const res = await fetch(`/api/patients/${id}/registro-anual/years-list`);
+        const res = await fetch(`/apae-geral/api/patients/${id}/registro-anual/years-list`);
         let yearsData: number[] = [];
         
         if (res.ok) {
@@ -120,7 +120,7 @@ export default function PersonDetailsPage() {
     try {
       setLoadingRegistro(true);
       setRegistroAnual(null);
-      const response = await fetch(`/api/patients/${id}/registro-anual/${selectedYear}`);
+      const response = await fetch(`/apae-geral/api/patients/${id}/registro-anual/${selectedYear}`);
       if (response.ok) {
         const data = await response.json();
         setRegistroAnual(data);

--- a/apps/apae/src/app/patients/create/profile/page.tsx
+++ b/apps/apae/src/app/patients/create/profile/page.tsx
@@ -105,7 +105,7 @@ export default function MembersRegisterProfilePage() {
 
     (async () => {
       try {
-        const res = await fetch(`/api/patients/${id}`);
+        const res = await fetch(`/apae-geral/api/patients/${id}`);
         const data = await res.json();
         if (data?.photoUrl) {
           setPreviewUrl(data.photoUrl);

--- a/apps/apae/src/app/patients/page.tsx
+++ b/apps/apae/src/app/patients/page.tsx
@@ -67,7 +67,7 @@ function PatientsAndStudentsScreenContent() {
         const requestKey = params.toString();
         latestRequestKeyRef.current = requestKey;
 
-        const response = await fetch(`/api/patients?${requestKey}`, {
+        const response = await fetch(`/apae-geral/api/patients?${requestKey}`, {
           signal: controller.signal,
         });
 

--- a/apps/apae/src/app/register/page.tsx
+++ b/apps/apae/src/app/register/page.tsx
@@ -49,7 +49,7 @@ function Page() {
 
   const onSubmit = async (data: FormSignUp) => {
     try {
-      const res = await fetch("/api/auth/register", {
+      const res = await fetch("/apae-geral/api/auth/register", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(data),

--- a/apps/apae/src/app/service-types/[id]/edit/page.tsx
+++ b/apps/apae/src/app/service-types/[id]/edit/page.tsx
@@ -29,7 +29,7 @@ export default function EditServiceTypePage() {
     if (id) {
       const fetchserviceType = async () => {
         try {
-          const response = await fetch(`/api/service-types/${id}`);
+          const response = await fetch(`/apae-geral/api/service-types/${id}`);
           if (!response.ok) throw new Error("Tipo de atendimento não encontrado.");
           const data = await response.json();
           setValue("area", data.area);
@@ -45,7 +45,7 @@ export default function EditServiceTypePage() {
 
   const onSubmit = async (data: UpdateserviceTypeDTO) => {
     try {
-      const response = await fetch(`/api/service-types/${id}`, {
+      const response = await fetch(`/apae-geral/api/service-types/${id}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(data),

--- a/apps/apae/src/app/service-types/page.tsx
+++ b/apps/apae/src/app/service-types/page.tsx
@@ -21,7 +21,7 @@ export default function ServiceTypesPage() {
       try {
         setIsLoading(true);
         setError(null);
-        const response = await fetch("/api/service-types");
+        const response = await fetch("/apae-geral/api/service-types");
         if (!response.ok) {
           throw new Error("Falha ao buscar os tipos de atendimentos.");
         }

--- a/apps/apae/src/app/services/absenceService.ts
+++ b/apps/apae/src/app/services/absenceService.ts
@@ -1,7 +1,7 @@
 import { AbsenceResponseDTO, CreateAbsenceDTO } from '@/types/absence';
 
 export class AbsenceService {
-  private static readonly API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || '/api';
+  private static readonly API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || '/apae-geral/api';
   private static readonly API_PATH = '/absences'; 
 
   private static getAuthHeaders(): HeadersInit {
@@ -36,7 +36,7 @@ export class AbsenceService {
     justificationDocumentId?: string | null
   ): Promise<AbsenceResponseDTO> {
     
-    const response = await fetch(`/api/absences/${absenceId}/justify`, {
+    const response = await fetch(`/apae-geral/api/absences/${absenceId}/justify`, {
       method: 'PATCH',
       headers: this.getAuthHeaders(),
       body: JSON.stringify({ 

--- a/apps/apae/src/app/services/appointmentService.ts
+++ b/apps/apae/src/app/services/appointmentService.ts
@@ -391,7 +391,7 @@ export async function listByPatient(
   if (end) query.append("end", end);
 
   const response = await fetch(
-    `/api/appointments/patient/${patientId}?${query}`,
+    `/apae-geral/api/appointments/patient/${patientId}?${query}`,
   );
 
   if (!response.ok) {

--- a/apps/apae/src/app/services/appointmentService.ts
+++ b/apps/apae/src/app/services/appointmentService.ts
@@ -518,7 +518,7 @@ export async function listTodayAppointment(
     query.append("date", date);
   }
 
-  const url = `/api/appointments/today?${query.toString()}`;
+  const url = `/apae-geral/api/appointments/today?${query.toString()}`;
 
   const res = await fetch(url, {
     method: "GET",

--- a/apps/apae/src/app/services/appointmentService.ts
+++ b/apps/apae/src/app/services/appointmentService.ts
@@ -221,7 +221,7 @@ export const parseTimeFromBackend = (timeString: string): string => {
 export async function saveAppointment(
   dto: CreateAppointmentDTO,
 ): Promise<void> {
-  const res = await fetch(`/api/appointments`, {
+  const res = await fetch(`/apae-geral/api/appointments`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -260,7 +260,7 @@ export async function getAppointments(
   if (date) query.append("date", date);
   if (time) query.append("time", time);
 
-  const response = await fetch(`/api/appointments?${query}`);
+  const response = await fetch(`/apae-geral/api/appointments?${query}`);
 
   if (!response.ok) {
     throw new Error("Erro ao buscar agendamentos");
@@ -273,7 +273,7 @@ export async function getAppointments(
 export async function getAppointmentById(
   id: UUID,
 ): Promise<AppointmentResponseDTO> {
-  const response = await fetch(`/api/appointments/${id}`);
+  const response = await fetch(`/apae-geral/api/appointments/${id}`);
 
   if (!response.ok) {
     throw new Error("Erro ao buscar detalhes do agendamento");
@@ -286,7 +286,7 @@ export async function updateAppointment(
   id: UUID,
   dto: UpdateAppointmentDTO,
 ): Promise<AppointmentResponseDTO> {
-  const response = await fetch(`/api/appointments/${id}`, {
+  const response = await fetch(`/apae-geral/api/appointments/${id}`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(dto),
@@ -303,7 +303,7 @@ export async function updateAppointment(
 }
 
 export async function deleteAppointment(id: UUID): Promise<void> {
-  const response = await fetch(`/api/appointments/${id}`, {
+  const response = await fetch(`/apae-geral/api/appointments/${id}`, {
     method: "DELETE",
   });
 
@@ -331,7 +331,7 @@ export async function rescheduleGeneratedAppointment(
     newDateTime: localDateTimeString,
   };
 
-  const response = await fetch(`/api/appointments/generated/${id}/reschedule`, {
+  const response = await fetch(`/apae-geral/api/appointments/generated/${id}/reschedule`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(backendDto),
@@ -347,7 +347,7 @@ export async function rescheduleGeneratedAppointment(
 export async function markAsPerformed(
   id: UUID,
 ): Promise<GeneratedAppointmentResponseDTO> {
-  const response = await fetch(`/api/appointments/generated/${id}/performed`, {
+  const response = await fetch(`/apae-geral/api/appointments/generated/${id}/performed`, {
     method: "PATCH",
   });
 
@@ -362,7 +362,7 @@ export async function cancelGeneratedAppointment(
   id: UUID,
   dto: CancelGeneratedAppointmentDTO,
 ): Promise<GeneratedAppointmentResponseDTO> {
-  const response = await fetch(`/api/appointments/generated/${id}/cancel`, {
+  const response = await fetch(`/apae-geral/api/appointments/generated/${id}/cancel`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(dto),
@@ -419,7 +419,7 @@ export async function registerAbsence(
     notified: false,
   };
 
-  const res = await fetch(`/api/absences`, {
+  const res = await fetch(`/apae-geral/api/absences`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
@@ -433,7 +433,7 @@ export async function registerAbsence(
 }
 
 export async function getPacientes(): Promise<Patient[]> {
-  const response = await fetch(`/api/patients?page=0&size=100`);
+  const response = await fetch(`/apae-geral/api/patients?page=0&size=100`);
 
   if (!response.ok) {
     throw new Error("Erro ao buscar pacientes");
@@ -444,7 +444,7 @@ export async function getPacientes(): Promise<Patient[]> {
 }
 
 export async function getProfissionaisDaSaude(): Promise<Professional[]> {
-  const response = await fetch(`/api/professionals?page=0&size=100`);
+  const response = await fetch(`/apae-geral/api/professionals?page=0&size=100`);
 
   if (!response.ok) {
     throw new Error("Erro ao buscar profissionais");
@@ -457,7 +457,7 @@ export async function getProfissionaisDaSaude(): Promise<Professional[]> {
 export async function getProfissionalDaSaude(
   id: string,
 ): Promise<Professional> {
-  const response = await fetch(`/api/professionals/${id}`);
+  const response = await fetch(`/apae-geral/api/professionals/${id}`);
 
   if (!response.ok) {
     throw new Error(`Profissional nÃ£o encontrado (ID: ${id})`);
@@ -494,7 +494,7 @@ export const toggleConfirmacao = async (id: UUID): Promise<void> => {
 export async function getTodayAppointmentById(
   id: string,
 ): Promise<TodayAppointment> {
-  const res = await fetch(`/api/appointments/today/${id}`);
+  const res = await fetch(`/apae-geral/api/appointments/today/${id}`);
 
   if (!res.ok) {
     throw new Error(`Erro ao buscar agendamento do dia: ${res.status}`);

--- a/apps/apae/src/components/AnnualRegistryEditModal.tsx
+++ b/apps/apae/src/components/AnnualRegistryEditModal.tsx
@@ -203,7 +203,7 @@ export default function AnnualRegistryEditModal({
     const fetchDocuments = async () => {
         setIsLoadingDocs(true);
         try {
-            const response = await fetch(`/api/patients/${patientId}/documents?category=MEDICAL&year=${currentYear}`);
+            const response = await fetch(`/apae-geral/api/patients/${patientId}/documents?category=MEDICAL&year=${currentYear}`);
             if (response.ok) {
                 const data = await response.json().catch(() => []);
                 setDocuments(Array.isArray(data) ? data : []);
@@ -214,7 +214,7 @@ export default function AnnualRegistryEditModal({
 
     const fetchPatientData = async () => {
         try {
-            const response = await fetch(`/api/patients/${patientId}`);
+            const response = await fetch(`/apae-geral/api/patients/${patientId}`);
             if (response.ok) setFullPatientData(await response.json());
         } catch (error) { console.error(error); }
     };
@@ -229,7 +229,7 @@ export default function AnnualRegistryEditModal({
         formData.append("type", docType);
         formData.append("year", currentYear);
         try {
-            const res = await fetch(`/api/patients/${patientId}/documents`, {
+            const res = await fetch(`/apae-geral/api/patients/${patientId}/documents`, {
                 method: "POST",
                 body: formData,
             });
@@ -279,14 +279,14 @@ export default function AnnualRegistryEditModal({
 
             let regRes;
             if (mode === "create") {
-                regRes = await fetch(`/api/patients/${patientId}/registro-anual`, {
+                regRes = await fetch(`/apae-geral/api/patients/${patientId}/registro-anual`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify(regPayload),
                 });
             } else {
                 if (!registryId) throw new Error("ID do registro não encontrado.");
-                regRes = await fetch(`/api/patients/${patientId}/registro-anual/${registryId}`, {
+                regRes = await fetch(`/apae-geral/api/patients/${patientId}/registro-anual/${registryId}`, {
                     method: 'PUT',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify(regPayload),
@@ -314,7 +314,7 @@ export default function AnnualRegistryEditModal({
                     vaccineNames: vaccineList,
                     continuousMedication: data.continuousMedication || "Nenhum"
                 };
-                await fetch(`/api/patients/${patientId}`, {
+                await fetch(`/apae-geral/api/patients/${patientId}`, {
                     method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(patientPayload)
                 });
             }

--- a/apps/apae/src/components/AnnualRegistryEditModal.tsx
+++ b/apps/apae/src/components/AnnualRegistryEditModal.tsx
@@ -446,7 +446,7 @@ export default function AnnualRegistryEditModal({
                                             <FormItem>
                                                 <FormLabel className={`font-bold text-xs ${errors.vaccines ? "text-red-500" : "text-slate-700"}`}>Vacinas</FormLabel>
                                                 <FormControl>
-                                                    <GenericDatabaseSelect value={field.value || []} onChange={field.onChange} endpoint="/api/vaccines" labelSingular="Vacina" labelKey="name" placeholder="Selecione vacinas..." />
+                                                    <GenericDatabaseSelect value={field.value || []} onChange={field.onChange} endpoint="/apae-geral/api/vaccines" labelSingular="Vacina" labelKey="name" placeholder="Selecione vacinas..." />
                                                 </FormControl>
                                                 <FormMessage />
                                             </FormItem>
@@ -457,7 +457,7 @@ export default function AnnualRegistryEditModal({
                                             <FormItem>
                                                 <FormLabel className={`font-bold text-xs ${errors.disorders ? "text-red-500" : "text-slate-700"} mb-1.5 block`}>Transtornos</FormLabel>
                                                 <FormControl>
-                                                    <GenericDatabaseSelect value={field.value || []} onChange={field.onChange} endpoint="/api/disorders" labelSingular="Transtorno" labelKey="name" placeholder="Selecione transtornos..." />
+                                                    <GenericDatabaseSelect value={field.value || []} onChange={field.onChange} endpoint="/apae-geral/api/disorders" labelSingular="Transtorno" labelKey="name" placeholder="Selecione transtornos..." />
                                                 </FormControl>
                                                 <FormMessage />
                                             </FormItem>
@@ -466,7 +466,7 @@ export default function AnnualRegistryEditModal({
                                             <FormItem>
                                                 <FormLabel className={`font-bold text-xs ${errors.serviceTypes ? "text-red-500" : "text-slate-700"} mb-1.5 block`}>Tipos de Atendimento</FormLabel>
                                                 <FormControl>
-                                                    <GenericDatabaseSelect value={field.value || []} onChange={field.onChange} endpoint="/api/service-types" labelSingular="Tipo" placeholder="Selecione tipos..." labelKey="area" menuPlacement="top" />
+                                                    <GenericDatabaseSelect value={field.value || []} onChange={field.onChange} endpoint="/apae-geral/api/service-types" labelSingular="Tipo" placeholder="Selecione tipos..." labelKey="area" menuPlacement="top" />
                                                 </FormControl>
                                                 <FormMessage />
                                             </FormItem>

--- a/apps/apae/src/components/forms/AbsenceForm.tsx
+++ b/apps/apae/src/components/forms/AbsenceForm.tsx
@@ -70,7 +70,7 @@ export function AbsenceForm({
         docFormData.append("type", "ATTACHMENTANY");
         docFormData.append("year", String(new Date().getFullYear()));
 
-        const docResponse = await fetch(`/api/patients/${patientId}/documents`, {
+        const docResponse = await fetch(`/apae-geral/api/patients/${patientId}/documents`, {
           method: "POST",
           body: docFormData,
         });
@@ -95,7 +95,7 @@ export function AbsenceForm({
         justificationDocumentId: documentId,
       };
 
-      const response = await fetch("/api/absences", {
+      const response = await fetch("/apae-geral/api/absences", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/apps/apae/src/components/forms/AppointmentForm.tsx
+++ b/apps/apae/src/components/forms/AppointmentForm.tsx
@@ -133,7 +133,7 @@ export function AppointmentForm({ editAppointment }: AppointmentFormProps) {
     const loadProfessionalData = async () => {
       if (professional.value) {
         try {
-          const res = await fetch(`/api/professionals/${professional.value}`);
+          const res = await fetch(`/apae-geral/api/professionals/${professional.value}`);
           const data = await res.json();
           setAvailabilities(data.availabilities || []);
         } catch {

--- a/apps/apae/src/components/forms/AppointmentForm.tsx
+++ b/apps/apae/src/components/forms/AppointmentForm.tsx
@@ -166,7 +166,7 @@ export function AppointmentForm({ editAppointment }: AppointmentFormProps) {
         const formattedDate = format(date, "yyyy-MM-dd");
 
         const res = await fetch(
-          `/api/professionals/${professional.value}/available-times?date=${formattedDate}`,
+          `/apae-geral/api/professionals/${professional.value}/available-times?date=${formattedDate}`,
         );
 
         const data = await res.json();

--- a/apps/apae/src/components/sidebar/sidebar.tsx
+++ b/apps/apae/src/components/sidebar/sidebar.tsx
@@ -52,10 +52,9 @@ export function AppSidebar() {
   const pathname = usePathname();
   const router = useRouter();
 
-  const handleLogout = () => {
-    removeSessionCookie();
-
-    router.refresh();
+  const handleLogout = async () => {
+    await removeSessionCookie();
+    router.replace("/auth/login");
   };
 
   return (

--- a/apps/apae/src/hooks/use-cares.ts
+++ b/apps/apae/src/hooks/use-cares.ts
@@ -12,7 +12,7 @@ function useCares() {
 
   useEffect(() => {
     const fetching = async () => {
-      const caresTypes = await fetch("/api/service-types", {
+      const caresTypes = await fetch("/apae-geral/api/service-types", {
         method: "GET",
       });
 

--- a/apps/apae/src/hooks/use-disorders.tsx
+++ b/apps/apae/src/hooks/use-disorders.tsx
@@ -102,7 +102,7 @@ function DisordersProvider({
   const fetchDisorders = useCallback(async () => {
     return withFeedback(
       async () => {
-        const response = await fetch("/api/disorders");
+        const response = await fetch("/apae-geral/api/disorders");
 
         if (!response.ok) {
           throw Error("Ocorreu um erro ao carregar as transtornos.");
@@ -122,7 +122,7 @@ function DisordersProvider({
   const fetchDisorder = useCallback(async (params: FetchDisorderParams) => {
     return withFeedback(
       async (currentParams: FetchDisorderParams) => {
-        const response = await fetch(`/api/disorders/${currentParams.id}`);
+        const response = await fetch(`/apae-geral/api/disorders/${currentParams.id}`);
 
         if (!response.ok) {
           throw Error("Ocorreu um erro ao carregar transtorno.");
@@ -142,7 +142,7 @@ function DisordersProvider({
     async (params: CreateDisorderParams) => {
       return withFeedback(
         async (currentParams: CreateDisorderParams): Promise<void> => {
-          const response = await fetch("/api/disorders", {
+          const response = await fetch("/apae-geral/api/disorders", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(currentParams),
@@ -166,7 +166,7 @@ function DisordersProvider({
     async (params: UpdateDisorderParams) => {
       return withFeedback(
         async ({ id, ...data }: UpdateDisorderParams) => {
-          const response = await fetch(`/api/disorders/${id}`, {
+          const response = await fetch(`/apae-geral/api/disorders/${id}`, {
             method: "PUT",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(data),
@@ -192,7 +192,7 @@ function DisordersProvider({
     async (params: DeleteDisorderParams) => {
       return withFeedback(
         async (currentParams: DeleteDisorderParams) => {
-          const response = await fetch(`/api/disorders/${currentParams.id}`, {
+          const response = await fetch(`/apae-geral/api/disorders/${currentParams.id}`, {
             method: "DELETE",
           });
 

--- a/apps/apae/src/hooks/use-members-register-context.tsx
+++ b/apps/apae/src/hooks/use-members-register-context.tsx
@@ -566,7 +566,7 @@ export function MembersRegisterProvider({
       };
 
       if (id) {
-        const res = await fetch(`/api/patients/${id}`, {
+        const res = await fetch(`/apae-geral/api/patients/${id}`, {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(patient),
@@ -579,7 +579,7 @@ export function MembersRegisterProvider({
         if (profile.photo instanceof File && res.ok) {
           const photoFormData = new FormData();
           photoFormData.append("photo", profile.photo);
-          await fetch(`/api/patients/${id}/photo`, {
+          await fetch(`/apae-geral/api/patients/${id}/photo`, {
             method: "PUT",
             body: photoFormData,
           });
@@ -608,7 +608,7 @@ export function MembersRegisterProvider({
           formData.append("referrals", additionals.care.referral);
         }
 
-        const res = await fetch("/api/patients", {
+        const res = await fetch("/apae-geral/api/patients", {
           method: "POST",
           body: formData,
         });

--- a/apps/apae/src/hooks/use-patients-filters.ts
+++ b/apps/apae/src/hooks/use-patients-filters.ts
@@ -25,10 +25,10 @@ export function usePatientFilters(): PatientFilterOptions {
       try {
         setIsLoading(true);
         setError(null);
-        const transtornosPromise = fetch('/api/patients/filtros/transtornos');
-        const anosPromise = fetch('/api/patients/filtros/anos');
-        const cidadesPromise = fetch('/api/patients/filtros/cidades');
-        const tipoAtendimentosPromise = fetch('/api/patients/filtros/tipos-atendimento');
+        const transtornosPromise = fetch('/apae-geral/api/patients/filtros/transtornos');
+        const anosPromise = fetch('/apae-geral/api/patients/filtros/anos');
+        const cidadesPromise = fetch('/apae-geral/api/patients/filtros/cidades');
+        const tipoAtendimentosPromise = fetch('/apae-geral/api/patients/filtros/tipos-atendimento');
 
         const [
           transtornosResponse,

--- a/apps/apae/src/hooks/use-vaccines.tsx
+++ b/apps/apae/src/hooks/use-vaccines.tsx
@@ -108,7 +108,7 @@ function VaccinesProvider({
   const fetchVaccines = useCallback(async () => {
     return withFeedback(
       async () => {
-        const response = await fetch("/api/vaccines");
+        const response = await fetch("/apae-geral/api/vaccines");
 
         if (!response.ok) {
           throw Error("Ocorreu um erro ao carregar as vacinas.");
@@ -125,7 +125,7 @@ function VaccinesProvider({
   const fetchVaccine = useCallback(async (params: FetchVaccineParams) => {
     return withFeedback(
       async (currentParams: FetchVaccineParams) => {
-        const response = await fetch(`/api/vaccines/${currentParams.id}`);
+        const response = await fetch(`/apae-geral/api/vaccines/${currentParams.id}`);
 
         if (!response.ok) {
           throw Error("Ocorreu um erro ao carregar vacina.");
@@ -142,7 +142,7 @@ function VaccinesProvider({
     async (params: CreateVaccineParams) => {
       return withFeedback(
         async (currentParams: CreateVaccineParams): Promise<void> => {
-          const response = await fetch("/api/vaccines", {
+          const response = await fetch("/apae-geral/api/vaccines", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(currentParams),
@@ -166,7 +166,7 @@ function VaccinesProvider({
     async (params: UpdateVaccineParams) => {
       return withFeedback(
         async ({ id, ...data }: UpdateVaccineParams) => {
-          const response = await fetch(`/api/vaccines/${id}`, {
+          const response = await fetch(`/apae-geral/api/vaccines/${id}`, {
             method: "PUT",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(data),
@@ -192,7 +192,7 @@ function VaccinesProvider({
     async (params: DeleteVaccineParams) => {
       return withFeedback(
         async (currentParams: DeleteVaccineParams) => {
-          const response = await fetch(`/api/vaccines/${currentParams.id}`, {
+          const response = await fetch(`/apae-geral/api/vaccines/${currentParams.id}`, {
             method: "DELETE",
           });
 

--- a/apps/apae/src/lib/axios.ts
+++ b/apps/apae/src/lib/axios.ts
@@ -44,7 +44,7 @@ const makeInterceptors = (api: AxiosInstance) => {
 
         await removeSessionCookie();
         if (typeof window === "undefined") {
-          redirect("/auth/login");
+          redirect("/apae-geral/auth/login");
         }
       }
 
@@ -56,7 +56,10 @@ const makeInterceptors = (api: AxiosInstance) => {
 };
 
 export const createDocumentsAPI = async () => {
-  const api = createAxiosInstance("http://localhost:8092/api/documents");
+  const api = createAxiosInstance(
+    process.env.NEXT_PUBLIC_DOCUMENTS_API_URL ||
+      "http://localhost:8092/apae-geral/api/documents"
+  );
   return makeInterceptors(api);
 };
 

--- a/apps/apae/src/lib/axios.ts
+++ b/apps/apae/src/lib/axios.ts
@@ -62,7 +62,7 @@ export const createDocumentsAPI = async () => {
 
 export const createBaseApi = async () => {
   const api = createAxiosInstance(
-    process.env.NEXT_PUBLIC_API || "http://localhost:8090/api"
+    process.env.NEXT_PUBLIC_API_URL || "http://localhost:8090/apae-geral/api"
   );
 
   return makeInterceptors(api);

--- a/apps/apae/src/lib/client-service.ts
+++ b/apps/apae/src/lib/client-service.ts
@@ -1,3 +1,3 @@
 export function getApiBaseUrl(): string {
-  return "http://localhost:8090/api";
+  return "http://localhost:8090/apae-geral/api";
 }

--- a/apps/apae/src/proxy.ts
+++ b/apps/apae/src/proxy.ts
@@ -7,16 +7,23 @@ export function proxy(req: NextRequest) {
   const isPublic = PUBLIC_PATHS.includes(req.nextUrl.pathname);
 
   if (!session && !isPublic) {
-    return NextResponse.redirect(new URL("/auth/login", req.url));
+    const url = req.nextUrl.clone();
+    url.pathname = "/auth/login";
+    return NextResponse.redirect(url);
   }
 
   if (session && isPublic) {
-    return NextResponse.redirect(new URL("/", req.url));
+    const url = req.nextUrl.clone();
+    url.pathname = "/";
+    return NextResponse.redirect(url);
   }
 
   return NextResponse.next();
 }
 
 export const config = {
-  matcher: ["/((?!api|_next/static|_next/image|.*\\.png$).*)"],
+  matcher: [
+    "/",
+    "/((?!api|_next/static|_next/image|.*\\.png$).*)",
+  ],
 };

--- a/apps/apae/src/services/profissional-service.ts
+++ b/apps/apae/src/services/profissional-service.ts
@@ -18,21 +18,21 @@ export async function getAllProfissionais(ativo?: boolean) {
 }*/
 
 export async function inactivateProfissional(id: string) {
-  const response = await fetch(`/api/professionals/${id}/inactivate`, {
+  const response = await fetch(`/apae-geral/api/professionals/${id}/inactivate`, {
     method: "PUT",
   });
   return response;
 }
 
 export async function activateProfissional(id: string) {
-  const response = await fetch(`/api/professionals/${id}/activate`, {
+  const response = await fetch(`/apae-geral/api/professionals/${id}/activate`, {
     method: "PUT",
   });
   return response;
 }
 
 export async function createProfissional(formData: FormData) {
-  const response = await fetch("/api/professionals", {
+  const response = await fetch("/apae-geral/api/professionals", {
     method: "POST",
     body: formData,
   });
@@ -41,7 +41,7 @@ export async function createProfissional(formData: FormData) {
 }
 
 export async function updateProfissional(id: string, data: unknown) {
-  const response = await fetch(`/api/professionals/${id}`, {
+  const response = await fetch(`/apae-geral/api/professionals/${id}`, {
     method: "PUT",
     headers: {
       "Content-Type": "application/json",
@@ -54,7 +54,7 @@ export async function updateProfissional(id: string, data: unknown) {
 
 export async function getProfissionalById(id: string) {
   try {
-    const response = await axios.get(`/api/professionals/${id}`);
+    const response = await axios.get(`/apae-geral/api/professionals/${id}`);
     return response.data;
   } catch (error) {
     if (axios.isAxiosError(error)) {
@@ -66,7 +66,7 @@ export async function getProfissionalById(id: string) {
 
 export async function getProfessionalDocuments(id: string) {
   try {
-    const response = await axios.get(`/api/professionals/${id}/documents`);
+    const response = await axios.get(`/apae-geral/api/professionals/${id}/documents`);
     return response.data || [];
   } catch (error) {
     if (axios.isAxiosError(error)) {
@@ -78,7 +78,7 @@ export async function getProfessionalDocuments(id: string) {
 
 
 export async function updateProfessionalDocuments(id: string, formData: FormData) {
-  return fetch(`/api/professionals/${id}/documents`, {
+  return fetch(`/apae-geral/api/professionals/${id}/documents`, {
     method: "PATCH",
     body: formData,
   });

--- a/apps/apae/src/services/profissional-service.ts
+++ b/apps/apae/src/services/profissional-service.ts
@@ -1,10 +1,10 @@
 import axios from "axios";
 
 export async function getAllProfissionais(ativo?: boolean) {
-  const url = 
+  const url =
     ativo === undefined
-      ? `/api/professionals`
-      : `/api/professionals?ativo=${ativo}`;
+      ? `/apae-geral/api/professionals`
+      : `/apae-geral/api/professionals?ativo=${ativo}`;
 
   console.log("[getAllProfissionais] ativo:", ativo, "| url:", url);
   return axios.get(url);
@@ -89,7 +89,7 @@ export async function removeProfessionalDocument(
   documentId: string,
 ) {
   const response = await fetch(
-    `/api/professionals/${professionalId}/documents/${documentId}`,
+    `/apae-geral/api/professionals/${professionalId}/documents/${documentId}`,
     { method: "DELETE" },
   );
 

--- a/apps/apae/src/services/servicearea-service.ts
+++ b/apps/apae/src/services/servicearea-service.ts
@@ -1,10 +1,10 @@
 
 export async function getAllServiceAreas() {
-  return fetch(`/api/service-areas`, { method: "GET" });
+  return fetch(`/apae-geral/api/service-areas`, { method: "GET" });
 }
 
 export async function createServiceArea(area: string) {
-  return fetch(`/api/service-areas`, {
+  return fetch(`/apae-geral/api/service-areas`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -29,7 +29,7 @@ USER appuser
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \
-  CMD wget -qO- http://127.0.0.1:8080/api/actuator/health 2>/dev/null \
+  CMD wget -qO- http://127.0.0.1:8080/apae-geral/actuator/health 2>/dev/null \
       | grep -q '"status":"UP"' || exit 1
 
 ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar /app/app.jar"]

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -92,7 +92,10 @@ Após a aplicação iniciar, a forma mais fácil de verificar se os endpoints es
 
 Abra seu navegador e acesse:
 
-[http://localhost:8090/api/swagger-ui/index.html](http://localhost:8090/api/swagger-ui/index.html)
+[http://localhost:8090/apae-geral/api/swagger-ui/index.html](http://localhost:8090/apae-geral/api/swagger-ui/index.html)
+
+> ℹ️ O backend roda sob o context-path `/apae-geral`. Portanto, todas as rotas
+> (controllers, Swagger e Actuator) ficam abaixo desse prefixo.
 
 Você deverá ver a interface do Swagger listando todos os "Controllers" (como Patient, Auth, Appointment, etc.) e seus respectivos endpoints.
 

--- a/apps/api/src/main/resources/application.yaml
+++ b/apps/api/src/main/resources/application.yaml
@@ -57,7 +57,7 @@ app:
   token:
     secret: ${JWT_SECRET}
   frontend:
-    reset-password-url: ${APP_FRONTEND_RESET_PASSWORD_URL:http://localhost:3000/auth/reset-password}
+    reset-password-url: ${APP_FRONTEND_RESET_PASSWORD_URL:http://localhost:3000/apae-geral/auth/reset-password}
 
 minio:
   access:
@@ -72,6 +72,8 @@ cors:
 
 server:
   port: ${API_PORT:8090}
+  servlet:
+    context-path: /apae-geral
 
 management:
   endpoints:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
       - "3000:3000"
     environment:
       - NODE_ENV=production
-      - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-/api}
+      - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-/apae-geral/api}
     depends_on:
       - apae-geral-backend
     networks:

--- a/docs/docs-docker/DOCKER_LOCAL.md
+++ b/docs/docs-docker/DOCKER_LOCAL.md
@@ -82,19 +82,24 @@ apae-geral-frontend   Up
 > apae-geral-backend` — espere ver `Started ApiApplication in X.X seconds`.
 
 ### 6. Valide os endpoints
+
+> ℹ️ Tanto o backend (Spring `server.servlet.context-path`) quanto o frontend
+> (Next.js `basePath`) rodam sob o prefixo `/apae-geral`. A raiz `/` retorna
+> 404 — isso é esperado.
+
 ```bash
 # Backend deve responder UP
-curl -s http://localhost:8080/api/actuator/health
+curl -s http://localhost:8080/apae-geral/actuator/health
 # {"status":"UP"}
 
-# Frontend deve devolver 200
-curl -sI http://localhost:3000/ | head -1
+# Frontend deve devolver 200 no caminho com prefixo
+curl -sI http://localhost:3000/apae-geral/ | head -1
 # HTTP/1.1 200 OK
 ```
 
 E no navegador:
-- Frontend: <http://localhost:3000>
-- Swagger backend: <http://localhost:8080/api/swagger-ui.html>
+- Frontend: <http://localhost:3000/apae-geral>
+- Swagger backend: <http://localhost:8080/apae-geral/api/swagger-ui/index.html>
 - MinIO console: <http://localhost:9001> (login com `MINIO_ROOT_USER` /
   `MINIO_ROOT_PASSWORD` do `.env`)
 
@@ -137,11 +142,12 @@ você precisa buildar a imagem de novo.
 
 Por isso o Dockerfile do frontend define:
 ```dockerfile
-ARG NEXT_PUBLIC_API_URL=/api
+ARG NEXT_PUBLIC_API_URL=/apae-geral/api
 ```
-e o workflow do GHCR builda com `/api`. A premissa é que em produção haverá um
-reverse proxy (Nginx/Traefik no Portal dos 30 anos) que faz `/api/*` →
-`apae-geral-backend:8080`. Assim **uma única imagem serve todos os ambientes**.
+e o workflow do GHCR builda com `/apae-geral/api`. A premissa é que em
+produção haverá um reverse proxy (Nginx/Traefik no Portal dos 30 anos) que faz
+`/apae-geral/*` → containers do APAE (backend e frontend, conforme a rota).
+Assim **uma única imagem serve todos os ambientes**.
 
 Se quiser rodar local **sem proxy**, builde o frontend passando a URL absoluta
 (veja seção 4.1).
@@ -172,13 +178,15 @@ IMAGE_TAG=sha-abc1234 docker compose up -d
 ### 4.1 Frontend isolado (sem proxy na frente)
 ```bash
 docker build \
-  --build-arg NEXT_PUBLIC_API_URL=http://localhost:8080/api \
+  --build-arg NEXT_PUBLIC_API_URL=http://localhost:8080/apae-geral/api \
   -t apae-geral-frontend:local \
   ./apps/apae
 
 docker run --rm -p 3000:3000 apae-geral-frontend:local
 ```
 > Note o `NEXT_PUBLIC_API_URL` absoluto — no modo isolado não há proxy.
+> O frontend continuará servindo sob `/apae-geral` (basePath do Next.js), então
+> acesse em <http://localhost:3000/apae-geral>.
 
 ### 4.2 Backend isolado
 **Pré-requisito:** Postgres precisa estar rodando antes (`docker compose up -d
@@ -228,10 +236,10 @@ Status esperado depois de ~30–60s: `"Status": "healthy"`.
 
 ### Probes manuais
 ```bash
-curl -s http://localhost:8080/api/actuator/health    # backend
+curl -s http://localhost:8080/apae-geral/actuator/health    # backend
 # {"status":"UP"}
 
-curl -sI http://localhost:3000/ | head -1            # frontend
+curl -sI http://localhost:3000/apae-geral/ | head -1        # frontend
 # HTTP/1.1 200 OK
 ```
 
@@ -251,7 +259,8 @@ docker exec apae-geral-frontend id
 |---|---|---|
 | `Connection to host.docker.internal:5200 refused` ao subir o backend isolado | Postgres não está rodando | `docker compose up -d db` antes (seção 4.2) |
 | Backend reinicia em loop, logs mostram `Hibernate: Unable to determine Dialect` | Backend subiu antes do Postgres terminar de iniciar | Use `docker compose up -d` (o `depends_on: condition: service_healthy` resolve), ou `docker compose restart apae-geral-backend` |
-| Frontend abre mas chamadas pra API caem em 404 | Buildou com `NEXT_PUBLIC_API_URL=/api` mas não tem proxy | Rebuilde com URL absoluto (seção 4.1) ou ponha um Nginx |
+| Frontend abre mas chamadas pra API caem em 404 | Buildou com `NEXT_PUBLIC_API_URL=/apae-geral/api` mas não tem proxy | Rebuilde com URL absoluto (seção 4.1) ou ponha um Nginx |
+| Abriu `http://localhost:3000/` e veio 404 | Esperado — o frontend está sob `basePath: /apae-geral` | Acesse `http://localhost:3000/apae-geral` |
 | `mvn ... COMPILATION ERROR` em `*Test.java` durante `docker build` | Dockerfile usou `-DskipTests` (só pula execução) em vez de `-Dmaven.test.skip=true` (pula compilação+execução) | Já corrigido no `apps/api/Dockerfile` |
 | `denied: denied` no `docker compose pull` | Pacote no GHCR está privado | `docker login ghcr.io` (seção 1) ou torne o pacote público |
 | `HEALTHCHECK` do backend fica `starting` para sempre | Spring Actuator faltando ou `/actuator/health` bloqueado | Confira `pom.xml` (tem `spring-boot-starter-actuator`) e `SecurityConfiguration.java` (libera `/actuator/health`) |
@@ -290,7 +299,11 @@ imagens publicadas no GHCR:
 
 Pontos a alinhar com o time do Portal:
 1. **`JWT_SECRET` precisa ser idêntico** entre os produtos (SSO).
-2. O Portal deve resolver `/api` no frontend do APAE para o backend
-   correspondente via reverse proxy.
+2. Todo o tráfego do APAE (frontend e API) vive sob o prefixo **`/apae-geral`**.
+   O Nginx do Portal deve fazer proxy preservando esse prefixo:
+   - `/apae-geral/api/*` → `apae-geral-backend:8080`
+   - `/apae-geral/*`     → `apae-geral-frontend:3000`
+   Isso elimina o conflito de paths com os demais produtos (gestão-escolar,
+   apae-30-anos, etc.) que dividem o mesmo domínio.
 3. As tags publicadas são `dev`, `latest` e `sha-<short>` — o Portal pode
    pinar numa tag de SHA para releases controladas.


### PR DESCRIPTION
Refatora o produto para rodar sob o prefixo `/apae-geral`, permitindo que o Nginx do Portal dos 30 anos faca proxy do projeto junto com os outros (gestao-escolar, apae-30-anos, etc.) sem conflito de paths.

Backend (Spring Boot):
- server.servlet.context-path: /apae-geral (todas rotas viram /apae-geral/api/*)
- Dockerfile HEALTHCHECK aponta para /apae-geral/actuator/health
- APP_FRONTEND_RESET_PASSWORD_URL inclui prefixo

Frontend (Next.js):
- next.config.ts: basePath /apae-geral (Links, redirects e BFF routes herdam o prefixo automaticamente)
- 73 chamadas fetch/axios client-side migradas de '/api/...' para '/apae-geral/api/...'
- Dockerfile HEALTHCHECK e ARG NEXT_PUBLIC_API_URL atualizados
- Fix bug pre-existente: process.env.NEXT_PUBLIC_API -> NEXT_PUBLIC_API_URL em 3 arquivos

- Corrigido export function middleware → export function proxy (convenção Next.js 16; o arquivo tinha o nome certo mas exportava o nome
   antigo, então não era reconhecido pelo runtime)
  - Redirects passaram a usar req.nextUrl.clone() em vez de new URL("/auth/login", req.url) para preservar o basePath
  - Adicionado "/" como matcher explícito (o padrão (?!api|...) não casava a raiz, deixando a home pública)
  
  - Sidebar: handleLogout: substituído router.refresh() por await removeSessionCookie() + router.replace("/auth/login"). Evita o re-render da home
   (que disparava 3 fetches falhos durante o logout e travava 2-3s)

  Documentação
  - README.md (raiz): APP_FRONTEND_RESET_PASSWORD_URL no exemplo agora inclui /apae-geral
  - apps/api/README.md: URL do Swagger com prefixo + nota sobre context-path
  - apps/apae/README.md: aviso de que a app vive em http://localhost:3000/apae-geral (a raiz / retorna 404 por design)
  - docs/docs-docker/DOCKER_LOCAL.md: URLs do TL;DR (curl probes, navegador, Swagger), ARG NEXT_PUBLIC_API_URL, exemplo de build isolado,
   troubleshooting (incluindo nova linha para o 404 na raiz) e seção 7 (proxy do Portal dos 30 anos agora roteia /apae-geral/*)


Configuracao:
- .env / .env.example com URLs prefixadas
- docker-compose.yml com default NEXT_PUBLIC_API_URL=/apae-geral/api
- Workflow GHCR builda com NEXT_PUBLIC_API_URL=/apae-geral/api