### PR TITLE
777 test reativar e atualizar testes do appointmentcontrollerimpl

### DIFF
--- a/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
@@ -397,48 +397,48 @@ class AppointmentControllerImplTest {
             response2.hour().format(DateTimeFormatter.ISO_LOCAL_TIME)));
   }
 
-//  @Test
-//  @WithMockUser(username = "admin", roles = {"ADMIN"})
-//  void shouldReturnNotFoundWhenGetNonExistentAppointment() throws Exception {
-//    UUID id = UUID.randomUUID();
-//
-//    when(service.findById(id)).thenThrow(new AppointmentNotFoundException());
-//
-//    mockMvc.perform(get(URI_WITH_ID, id)
-//                    .with(csrf()))
-//            .andExpect(status().isNotFound());
-//  }
-//
-//  @Test
-//  @WithMockUser(username = "admin", roles = {"ADMIN"})
-//  void shouldReturnNotFoundWhenReschedulingNonExistentAppointment() throws Exception {
-//    UUID id = UUID.randomUUID();
-//    var payload = new RescheduleGeneratedAppointmentDTO(LocalDateTime.now().plusDays(1));
-//
-//    when(service.reschedule(any(), any())).thenThrow(new AppointmentNotFoundException());
-//
-//    mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/reschedule", id)
-//                    .contentType(MediaType.APPLICATION_JSON)
-//                    .content(objectMapper.writeValueAsString(payload))
-//                    .with(csrf()))
-//            .andExpect(status().isNotFound());
-//  }
-//
-//  @Test
-//  @WithMockUser(username = "admin", roles = {"ADMIN"})
-//  void shouldReturnBadRequestWhenCancellingAlreadyCancelledAppointment() throws Exception {
-//    UUID id = UUID.randomUUID();
-//    var payload = new CancelGeneratedAppointmentDTO("Motivo qualquer");
-//
-//    when(service.cancel(eq(id), anyString())).thenThrow(new AppointmentAlreadyCancelledException());
-//
-//    mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/cancel", id)
-//                    .contentType(MediaType.APPLICATION_JSON)
-//                    .content(objectMapper.writeValueAsString(payload))
-//                    .with(csrf()))
-//            .andExpect(status().isBadRequest());
-//  }
-//
+  @Test
+  @WithMockUser(username = "admin", roles = {"ADMIN"})
+  void shouldReturnNotFoundWhenGetNonExistentAppointment() throws Exception {
+    UUID id = UUID.randomUUID();
+
+    when(service.findById(id)).thenThrow(new AppointmentNotFoundException());
+
+    mockMvc.perform(get(URI_WITH_ID, id)
+                    .with(csrf()))
+            .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @WithMockUser(username = "admin", roles = {"ADMIN"})
+  void shouldReturnNotFoundWhenReschedulingNonExistentAppointment() throws Exception {
+    UUID id = UUID.randomUUID();
+    var payload = new RescheduleGeneratedAppointmentDTO(LocalDateTime.now().plusDays(1));
+
+    when(service.reschedule(any(), any())).thenThrow(new AppointmentNotFoundException());
+
+    mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/reschedule", id)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(payload))
+                    .with(csrf()))
+            .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @WithMockUser(username = "admin", roles = {"ADMIN"})
+  void shouldReturnBadRequestWhenCancellingAlreadyCancelledAppointment() throws Exception {
+    UUID id = UUID.randomUUID();
+    var payload = new CancelGeneratedAppointmentDTO("Motivo qualquer");
+
+    when(service.cancel(eq(id), anyString())).thenThrow(new AppointmentAlreadyCancelledException());
+
+    mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/cancel", id)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(payload))
+                    .with(csrf()))
+            .andExpect(status().isBadRequest());
+  }
+
 //  @Test
 //  @WithMockUser(username = "admin", roles = {"ADMIN"})
 //  void shouldReturnBadRequestWhenProfessionalIdIsNull() throws Exception {

--- a/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
@@ -496,7 +496,6 @@ class AppointmentControllerImplTest {
   @Test
   @WithMockUser(username = "admin", roles = {"ADMIN"})
   void shouldReturnBadRequestWhenFrequencyDaysIsZero() throws Exception {
-
     var payload = new CreateAppointmentDTO(
             UUID.randomUUID(),
             UUID.randomUUID(),

--- a/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
@@ -1,4 +1,5 @@
-/*package br.org.apae.api.controllers.appointment;
+package br.org.apae.api.controllers.appointment;
+import br.org.apae.api.appointment.application.interfaces.AppointmentApplicationService;
 import br.org.apae.api.appointment.application.internal.AppointmentApplicationServiceImpl;
 import br.org.apae.api.appointment.domain.exceptions.AppointmentAlreadyCancelledException;
 import br.org.apae.api.appointment.domain.exceptions.AppointmentNotFoundException;
@@ -50,7 +51,7 @@ class AppointmentControllerImplTest {
   @Autowired
   private MockMvc mockMvc;
   @MockitoBean
-  private AppointmentApplicationServiceImpl service;
+  private AppointmentApplicationService service;
   @Autowired
   private ObjectMapper objectMapper;
   @MockitoBean
@@ -61,14 +62,29 @@ class AppointmentControllerImplTest {
   private static final String URI_WITH_ID = URI + "/{id}";
   private static final String GENERATED_URI_WITH_ID = URI + "/generated/{id}";
 
+  private AppointmentResponseDTO createAppointmentDTO(UUID id) {
+    return new AppointmentResponseDTO(
+            id,
+            mock(HealthProfessionalResponseDTO.class),
+            mock(AnnualRegistryResponseDTO.class),
+            7,
+            LocalDate.now(),
+            LocalDate.of(2026, 12, 31),
+            LocalTime.now().withNano(0),
+            true,
+            LocalDateTime.now().withNano(0),
+            null,
+            null
+    );
+  }
+
   @Test
   @WithMockUser(username = "admin", roles = {"ADMIN"})
   void shouldCreateAppointmentSuccessfully() throws Exception {
     var payload = new CreateAppointmentDTO(
         UUID.randomUUID(),
         UUID.randomUUID(),
-        UUID.randomUUID(),
-        7,
+        2,
         LocalDate.now(),
         LocalTime.now()
     );
@@ -94,7 +110,6 @@ class AppointmentControllerImplTest {
         .with(csrf()))
       .andExpect(status().isOk())
       .andExpect(jsonPath("$.id").value(response.id().toString()))
-      .andExpect(jsonPath("$.serviceId").value(response.serviceId().toString()))
       .andExpect(jsonPath("$.frequencyDays").value(response.frequencyDays()))
       .andExpect(jsonPath("$.initialDate").value(response.initialDate().toString()))
       .andExpect(jsonPath("$.endDate").value(response.endDate().toString()))
@@ -103,512 +118,497 @@ class AppointmentControllerImplTest {
       .andExpect(jsonPath("$.creationDate").value(response.creationDate().toString()));
   }
 
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldDeleteAppointmentSuccessfully() throws Exception {
-    UUID id = UUID.randomUUID();
-
-    mockMvc.perform(delete(URI_WITH_ID, id)
-            .with(csrf()))
-        .andExpect(status().isNoContent());
-
-    verify(service, times(1)).delete(id);
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldRescheduleAppointmentSuccessfully() throws Exception {
-    UUID id = UUID.randomUUID();
-    var payload = new RescheduleGeneratedAppointmentDTO(LocalDateTime.now().withNano(0));
-
-    GeneratedAppointmentResponseDTO response = new GeneratedAppointmentResponseDTO(
-        id,
-        UUID.randomUUID(),
-        payload.newDateTime(),
-        null,
-        false,
-        false,
-        null,
-        UUID.randomUUID(),
-        LocalDateTime.now().withNano(0)
-    );
-    when(service.reschedule(id, payload.newDateTime())).thenReturn(response);
-
-    mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/reschedule", id)
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(objectMapper.writeValueAsString(payload))
-        .with(csrf()))
-      .andExpect(status().isOk())
-      .andExpect(jsonPath("$.id").value(response.id().toString()))
-      .andExpect(jsonPath("$.appointmentId").value(response.appointmentId().toString()))
-      .andExpect(jsonPath("$.scheduledDateTime").value(response.scheduledDateTime().toString()))
-      .andExpect(jsonPath("$.overriddenDateTime").isEmpty())
-      .andExpect(jsonPath("$.performed").isBoolean())
-      .andExpect(jsonPath("$.cancelled").isBoolean())
-      .andExpect(jsonPath("$.cancellationReason").isEmpty())
-      .andExpect(jsonPath("$.patientId").value(response.patientId().toString()))
-      .andExpect(jsonPath("$.effectiveDateTime").value(response.effectiveDateTime().toString()));
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldPerformedAppointmentSuccessfully() throws Exception {
-    UUID id = UUID.randomUUID();
-    var response = new GeneratedAppointmentResponseDTO(
-        id,
-        UUID.randomUUID(),
-        null,
-        null,
-        true,
-        false,
-        null,
-        UUID.randomUUID(),
-        LocalDateTime.now().withNano(0)
-    );
-
-    when(service.markAsPerformed(id)).thenReturn(response);
-
-    mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/performed", id)
-            .with(csrf()))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.id").value(response.id().toString()))
-        .andExpect(jsonPath("$.appointmentId").value(response.appointmentId().toString()))
-        .andExpect(jsonPath("$.scheduledDateTime").isEmpty())
-        .andExpect(jsonPath("$.overriddenDateTime").isEmpty())
-        .andExpect(jsonPath("$.performed").value(response.performed()))
-        .andExpect(jsonPath("$.cancelled").value(response.cancelled()))
-        .andExpect(jsonPath("$.cancellationReason").isEmpty())
-        .andExpect(jsonPath("$.patientId").value(response.patientId().toString()))
-        .andExpect(jsonPath("$.effectiveDateTime").value(response.effectiveDateTime().toString()));
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldCancelAppointmentSuccessfully() throws Exception {
-    UUID id = UUID.randomUUID();
-    var payload = new CancelGeneratedAppointmentDTO("cancel reason");
-    var response = new GeneratedAppointmentResponseDTO(
-        id,
-        UUID.randomUUID(),
-        null,
-        null,
-        false,
-        true,
-        payload.reason(),
-        UUID.randomUUID(),
-        LocalDateTime.now().withNano(0)
-    );
-
-    when(service.cancel(id, payload.reason())).thenReturn(response);
-
-    mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/cancel", id)
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(payload))
-            .with(csrf()))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.id").value(response.id().toString()))
-        .andExpect(jsonPath("$.appointmentId").value(response.appointmentId().toString()))
-        .andExpect(jsonPath("$.scheduledDateTime").isEmpty())
-        .andExpect(jsonPath("$.overriddenDateTime").isEmpty())
-        .andExpect(jsonPath("$.performed").value(response.performed()))
-        .andExpect(jsonPath("$.cancelled").value(response.cancelled()))
-        .andExpect(jsonPath("$.cancellationReason").value(response.cancellationReason()))
-        .andExpect(jsonPath("$.patientId").value(response.patientId().toString()))
-        .andExpect(jsonPath("$.effectiveDateTime").value(response.effectiveDateTime().toString()));
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldUpdateAppointmentRuleSuccessfully() throws Exception {
-    UUID id = UUID.randomUUID();
-
-    var payload = new UpdateAppointmentRuleDTO(
-        14,
-        LocalTime.of(10, 30, 0)
-    );
-
-    AppointmentResponseDTO response = new AppointmentResponseDTO(
-        id,
-        mock(HealthProfessionalResponseDTO.class),
-        UUID.randomUUID(),
-        mock(AnnualRegistryResponseDTO.class),
-        payload.newFrequency(),
-        LocalDate.now(),
-        LocalDate.of(2026, 12, 31),
-        payload.newTime(),
-        true,
-        LocalDateTime.now().withNano(0)
-    );
-
-    when(service.updateAppointment(id, payload.newFrequency(), payload.newTime())).thenReturn(response);
-
-    mockMvc.perform(patch(URI_WITH_ID + "/rule", id)
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(payload))
-            .with(csrf()))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.id").value(response.id().toString()))
-        .andExpect(jsonPath("$.serviceId").value(response.serviceId().toString()))
-        .andExpect(jsonPath("$.frequencyDays").value(response.frequencyDays()))
-        .andExpect(jsonPath("$.hour").value(response.hour().format(DateTimeFormatter.ISO_LOCAL_TIME)))
-        .andExpect(jsonPath("$.isActive").value(response.isActive()))
-        .andExpect(jsonPath("$.creationDate").value(response.creationDate().toString()));
-
-    verify(service, times(1)).updateAppointment(id, payload.newFrequency(), payload.newTime());
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldListGeneratedAppointmentsByPatientSuccessfully() throws Exception {
-    UUID patientId = UUID.randomUUID();
-
-    LocalDate start = LocalDate.of(2026, 1, 1);
-    LocalDate end = LocalDate.of(2026, 1, 31);
-
-    var response = new GeneratedAppointmentResponseDTO(
-        UUID.randomUUID(),
-        UUID.randomUUID(),
-        LocalDateTime.now().withNano(0),
-        null,
-        false,
-        false,
-        null,
-        patientId,
-        null
-    );
-
-    Page<GeneratedAppointmentResponseDTO> page =
-        new PageImpl<>(List.of(response), PageRequest.of(0, 10), 1);
-
-    when(service.listByPatient(eq(patientId), eq(start), eq(end), any(Pageable.class)))
-        .thenReturn(page);
-
-    mockMvc.perform(get(URI + "/patient/{patientId}", patientId)
-            .param("start", start.toString())
-            .param("end", end.toString())
-            .param("page", "0")
-            .param("size", "10")
-            .with(csrf()))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.content").isArray())
-        .andExpect(jsonPath("$.content.length()").value(1))
-        .andExpect(jsonPath("$.content[0].id").value(response.id().toString()))
-        .andExpect(jsonPath("$.content[0].appointmentId").value(response.appointmentId().toString()))
-        .andExpect(jsonPath("$.content[0].scheduledDateTime").value(response.scheduledDateTime().toString()))
-        .andExpect(jsonPath("$.content[0].performed").value(response.performed()))
-        .andExpect(jsonPath("$.content[0].cancelled").value(response.cancelled()))
-        .andExpect(jsonPath("$.content[0].patientId").value(response.patientId().toString()));
-
-    verify(service, times(1))
-        .listByPatient(eq(patientId), eq(start), eq(end), any(Pageable.class));
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldListTodayAppointmentsSuccessfully() throws Exception {
-    var response = new TodayAppointmentsResponseDTO(
-        UUID.randomUUID(),
-        mock(PatientResponseDTO.class),
-        mock(HealthProfessionalResponseDTO.class),
-        LocalDateTime.now().withNano(0),
-        null,
-        false,
-        false,
-        null,
-        null,
-        UUID.randomUUID()
-    );
-
-    Page<TodayAppointmentsResponseDTO> page =
-        new PageImpl<>(List.of(response), PageRequest.of(0, 10), 1);
-
-    when(service.listAppointmentForToday(any(Pageable.class)))
-        .thenReturn(page);
-
-    mockMvc.perform(get(URI + "/today")
-            .param("page", "0")
-            .param("size", "10")
-            .with(csrf()))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.content").isArray())
-        .andExpect(jsonPath("$.content.length()").value(1))
-        .andExpect(jsonPath("$.content[0].id").value(response.id().toString()))
-        .andExpect(jsonPath("$.content[0].performed").value(response.performed()))
-        .andExpect(jsonPath("$.content[0].cancelled").value(response.cancelled()))
-        .andExpect(jsonPath("$.content[0].ruleId").value(response.ruleId().toString()));
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldGetAllAppointmentsSuccessfully() throws Exception {
-    LocalDate date = LocalDate.of(2026, 1, 21);
-    LocalTime time = LocalTime.of(10, 30);
-
-    AppointmentResponseDTO response1 = createAppointmentDTO(UUID.randomUUID()) ;
-
-    AppointmentResponseDTO response2 = createAppointmentDTO(UUID.randomUUID());
-    Page<AppointmentResponseDTO> page =
-        new PageImpl<>(List.of(response1, response2), PageRequest.of(0, 10), 2);
-
-    when(service.findAll(eq(date), eq(time), any(Pageable.class)))
-        .thenReturn(page);
-
-    mockMvc.perform(get(URI)
-            .param("date", date.toString())
-            .param("time", time.format(DateTimeFormatter.ISO_LOCAL_TIME))
-            .param("page", "0")
-            .param("size", "10")
-            .with(csrf()))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.content").isArray())
-        .andExpect(jsonPath("$.content.length()").value(2))
-        .andExpect(jsonPath("$.content[0].id").value(response1.id().toString()))
-        .andExpect(jsonPath("$.content[0].frequencyDays").value(response1.frequencyDays()))
-        .andExpect(jsonPath("$.content[0].hour").value(
-            response1.hour().format(DateTimeFormatter.ISO_LOCAL_TIME)))
-        .andExpect(jsonPath("$.content[1].id").value(response2.id().toString()))
-        .andExpect(jsonPath("$.content[1].frequencyDays").value(response2.frequencyDays()))
-        .andExpect(jsonPath("$.content[1].hour").value(
-            response2.hour().format(DateTimeFormatter.ISO_LOCAL_TIME)));
-  }
-
-
-  private AppointmentResponseDTO createAppointmentDTO(UUID id) {
-    return new AppointmentResponseDTO(
-        id,
-        mock(HealthProfessionalResponseDTO.class),
-        UUID.randomUUID(),
-        mock(AnnualRegistryResponseDTO.class),
-        7,
-        LocalDate.now(),
-        LocalDate.of(2026, 12, 31),
-        LocalTime.now().withNano(0),
-        true,
-        LocalDateTime.now().withNano(0)
-    );
-  }
-
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldReturnNotFoundWhenGetNonExistentAppointment() throws Exception {
-    UUID id = UUID.randomUUID();
-
-    when(service.findById(id)).thenThrow(new AppointmentNotFoundException());
-
-    mockMvc.perform(get(URI_WITH_ID, id)
-                    .with(csrf()))
-            .andExpect(status().isNotFound());
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldReturnNotFoundWhenReschedulingNonExistentAppointment() throws Exception {
-    UUID id = UUID.randomUUID();
-    var payload = new RescheduleGeneratedAppointmentDTO(LocalDateTime.now().plusDays(1));
-
-    when(service.reschedule(any(), any())).thenThrow(new AppointmentNotFoundException());
-
-    mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/reschedule", id)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(payload))
-                    .with(csrf()))
-            .andExpect(status().isNotFound());
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldReturnBadRequestWhenCancellingAlreadyCancelledAppointment() throws Exception {
-    UUID id = UUID.randomUUID();
-    var payload = new CancelGeneratedAppointmentDTO("Motivo qualquer");
-
-    when(service.cancel(eq(id), anyString())).thenThrow(new AppointmentAlreadyCancelledException());
-
-    mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/cancel", id)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(payload))
-                    .with(csrf()))
-            .andExpect(status().isBadRequest());
-  }
-  
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldReturnBadRequestWhenProfessionalIdIsNull() throws Exception {
-    var payload = new CreateAppointmentDTO(
-        null,
-        UUID.randomUUID(),
-        UUID.randomUUID(),
-        7,
-        LocalDate.now().plusDays(1),
-        LocalTime.now()
-    );
-
-    mockMvc.perform(post(URI)
-            .content(objectMapper.writeValueAsString(payload))
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(csrf()))
-        .andExpect(status().isBadRequest());
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldReturnBadRequestWhenServiceIdIsNull() throws Exception {
-    var payload = new CreateAppointmentDTO(
-        UUID.randomUUID(),
-        null,
-        UUID.randomUUID(),
-        7,
-        LocalDate.now().plusDays(1),
-        LocalTime.now()
-    );
-
-    mockMvc.perform(post(URI)
-            .content(objectMapper.writeValueAsString(payload))
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(csrf()))
-        .andExpect(status().isBadRequest());
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldReturnBadRequestWhenPatientIdIsNull() throws Exception {
-    var payload = new CreateAppointmentDTO(
-        UUID.randomUUID(),
-        UUID.randomUUID(),
-        null,
-        7,
-        LocalDate.now().plusDays(1),
-        LocalTime.now()
-    );
-
-    mockMvc.perform(post(URI)
-            .content(objectMapper.writeValueAsString(payload))
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(csrf()))
-        .andExpect(status().isBadRequest());
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldReturnBadRequestWhenFrequencyDaysIsNull() throws Exception {
-    var payload = new CreateAppointmentDTO(
-        UUID.randomUUID(),
-        UUID.randomUUID(),
-        UUID.randomUUID(),
-        null,
-        LocalDate.now().plusDays(1),
-        LocalTime.now()
-    );
-
-    mockMvc.perform(post(URI)
-            .content(objectMapper.writeValueAsString(payload))
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(csrf()))
-        .andExpect(status().isBadRequest());
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldReturnBadRequestWhenFrequencyDaysIsZeroOrNegative() throws Exception {
-    var payload = new CreateAppointmentDTO(
-        UUID.randomUUID(),
-        UUID.randomUUID(),
-        UUID.randomUUID(),
-        0,
-        LocalDate.now().plusDays(1),
-        LocalTime.now()
-    );
-
-    mockMvc.perform(post(URI)
-            .content(objectMapper.writeValueAsString(payload))
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(csrf()))
-        .andExpect(status().isBadRequest());
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldReturnBadRequestWhenFrequencyDaysIsNegative() throws Exception {
-    var payload = new CreateAppointmentDTO(
-        UUID.randomUUID(),
-        UUID.randomUUID(),
-        UUID.randomUUID(),
-        -5,
-        LocalDate.now().plusDays(1),
-        LocalTime.now()
-    );
-
-    mockMvc.perform(post(URI)
-            .content(objectMapper.writeValueAsString(payload))
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(csrf()))
-        .andExpect(status().isBadRequest());
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldReturnBadRequestWhenInitialDateIsNull() throws Exception {
-    var payload = new CreateAppointmentDTO(
-        UUID.randomUUID(),
-        UUID.randomUUID(),
-        UUID.randomUUID(),
-        7,
-        null,
-        LocalTime.now()
-    );
-
-    mockMvc.perform(post(URI)
-            .content(objectMapper.writeValueAsString(payload))
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(csrf()))
-        .andExpect(status().isBadRequest());
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldReturnBadRequestWhenInitialDateIsInThePast() throws Exception {
-    var payload = new CreateAppointmentDTO(
-        UUID.randomUUID(),
-        UUID.randomUUID(),
-        UUID.randomUUID(),
-        7,
-        LocalDate.now().minusDays(1),
-        LocalTime.now()
-    );
-
-    mockMvc.perform(post(URI)
-            .content(objectMapper.writeValueAsString(payload))
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(csrf()))
-        .andExpect(status().isBadRequest());
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldReturnBadRequestWhenHourIsNull() throws Exception {
-    var payload = new CreateAppointmentDTO(
-        UUID.randomUUID(),
-        UUID.randomUUID(),
-        UUID.randomUUID(),
-        7,
-        LocalDate.now().plusDays(1),
-        null
-    );
-
-    mockMvc.perform(post(URI)
-            .content(objectMapper.writeValueAsString(payload))
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(csrf()))
-        .andExpect(status().isBadRequest());
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldReturnBadRequestWhenCreateBodyIsMissing() throws Exception {
-    mockMvc.perform(post(URI)
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(csrf()))
-        .andExpect(status().isBadRequest());
-  }
+//  @Test
+//  @WithMockUser(username = "admin", roles = {"ADMIN"})
+//  void shouldDeleteAppointmentSuccessfully() throws Exception {
+//    UUID id = UUID.randomUUID();
+//
+//    mockMvc.perform(delete(URI_WITH_ID, id)
+//            .with(csrf()))
+//        .andExpect(status().isNoContent());
+//
+//    verify(service, times(1)).delete(id);
+//  }
+//
+//  @Test
+//  @WithMockUser(username = "admin", roles = {"ADMIN"})
+//  void shouldRescheduleAppointmentSuccessfully() throws Exception {
+//    UUID id = UUID.randomUUID();
+//    var payload = new RescheduleGeneratedAppointmentDTO(LocalDateTime.now().withNano(0));
+//
+//    GeneratedAppointmentResponseDTO response = new GeneratedAppointmentResponseDTO(
+//        id,
+//        UUID.randomUUID(),
+//        payload.newDateTime(),
+//        null,
+//        false,
+//        false,
+//        null,
+//        UUID.randomUUID(),
+//        LocalDateTime.now().withNano(0)
+//    );
+//    when(service.reschedule(id, payload.newDateTime())).thenReturn(response);
+//
+//    mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/reschedule", id)
+//        .contentType(MediaType.APPLICATION_JSON)
+//        .content(objectMapper.writeValueAsString(payload))
+//        .with(csrf()))
+//      .andExpect(status().isOk())
+//      .andExpect(jsonPath("$.id").value(response.id().toString()))
+//      .andExpect(jsonPath("$.appointmentId").value(response.appointmentId().toString()))
+//      .andExpect(jsonPath("$.scheduledDateTime").value(response.scheduledDateTime().toString()))
+//      .andExpect(jsonPath("$.overriddenDateTime").isEmpty())
+//      .andExpect(jsonPath("$.performed").isBoolean())
+//      .andExpect(jsonPath("$.cancelled").isBoolean())
+//      .andExpect(jsonPath("$.cancellationReason").isEmpty())
+//      .andExpect(jsonPath("$.patientId").value(response.patientId().toString()))
+//      .andExpect(jsonPath("$.effectiveDateTime").value(response.effectiveDateTime().toString()));
+//  }
+//
+//  @Test
+//  @WithMockUser(username = "admin", roles = {"ADMIN"})
+//  void shouldPerformedAppointmentSuccessfully() throws Exception {
+//    UUID id = UUID.randomUUID();
+//    var response = new GeneratedAppointmentResponseDTO(
+//        id,
+//        UUID.randomUUID(),
+//        null,
+//        null,
+//        true,
+//        false,
+//        null,
+//        UUID.randomUUID(),
+//        LocalDateTime.now().withNano(0)
+//    );
+//
+//    when(service.markAsPerformed(id)).thenReturn(response);
+//
+//    mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/performed", id)
+//            .with(csrf()))
+//        .andExpect(status().isOk())
+//        .andExpect(jsonPath("$.id").value(response.id().toString()))
+//        .andExpect(jsonPath("$.appointmentId").value(response.appointmentId().toString()))
+//        .andExpect(jsonPath("$.scheduledDateTime").isEmpty())
+//        .andExpect(jsonPath("$.overriddenDateTime").isEmpty())
+//        .andExpect(jsonPath("$.performed").value(response.performed()))
+//        .andExpect(jsonPath("$.cancelled").value(response.cancelled()))
+//        .andExpect(jsonPath("$.cancellationReason").isEmpty())
+//        .andExpect(jsonPath("$.patientId").value(response.patientId().toString()))
+//        .andExpect(jsonPath("$.effectiveDateTime").value(response.effectiveDateTime().toString()));
+//  }
+//
+//  @Test
+//  @WithMockUser(username = "admin", roles = {"ADMIN"})
+//  void shouldCancelAppointmentSuccessfully() throws Exception {
+//    UUID id = UUID.randomUUID();
+//    var payload = new CancelGeneratedAppointmentDTO("cancel reason");
+//    var response = new GeneratedAppointmentResponseDTO(
+//        id,
+//        UUID.randomUUID(),
+//        null,
+//        null,
+//        false,
+//        true,
+//        payload.reason(),
+//        UUID.randomUUID(),
+//        LocalDateTime.now().withNano(0)
+//    );
+//
+//    when(service.cancel(id, payload.reason())).thenReturn(response);
+//
+//    mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/cancel", id)
+//            .contentType(MediaType.APPLICATION_JSON)
+//            .content(objectMapper.writeValueAsString(payload))
+//            .with(csrf()))
+//        .andExpect(status().isOk())
+//        .andExpect(jsonPath("$.id").value(response.id().toString()))
+//        .andExpect(jsonPath("$.appointmentId").value(response.appointmentId().toString()))
+//        .andExpect(jsonPath("$.scheduledDateTime").isEmpty())
+//        .andExpect(jsonPath("$.overriddenDateTime").isEmpty())
+//        .andExpect(jsonPath("$.performed").value(response.performed()))
+//        .andExpect(jsonPath("$.cancelled").value(response.cancelled()))
+//        .andExpect(jsonPath("$.cancellationReason").value(response.cancellationReason()))
+//        .andExpect(jsonPath("$.patientId").value(response.patientId().toString()))
+//        .andExpect(jsonPath("$.effectiveDateTime").value(response.effectiveDateTime().toString()));
+//  }
+//
+//  @Test
+//  @WithMockUser(username = "admin", roles = {"ADMIN"})
+//  void shouldUpdateAppointmentRuleSuccessfully() throws Exception {
+//    UUID id = UUID.randomUUID();
+//
+//    var payload = new UpdateAppointmentRuleDTO(
+//        14,
+//        LocalTime.of(10, 30, 0)
+//    );
+//
+//    AppointmentResponseDTO response = new AppointmentResponseDTO(
+//        id,
+//        mock(HealthProfessionalResponseDTO.class),
+//        UUID.randomUUID(),
+//        mock(AnnualRegistryResponseDTO.class),
+//        payload.newFrequency(),
+//        LocalDate.now(),
+//        LocalDate.of(2026, 12, 31),
+//        payload.newTime(),
+//        true,
+//        LocalDateTime.now().withNano(0)
+//    );
+//
+//    when(service.updateAppointment(id, payload.newFrequency(), payload.newTime())).thenReturn(response);
+//
+//    mockMvc.perform(patch(URI_WITH_ID + "/rule", id)
+//            .contentType(MediaType.APPLICATION_JSON)
+//            .content(objectMapper.writeValueAsString(payload))
+//            .with(csrf()))
+//        .andExpect(status().isOk())
+//        .andExpect(jsonPath("$.id").value(response.id().toString()))
+//        .andExpect(jsonPath("$.serviceId").value(response.serviceId().toString()))
+//        .andExpect(jsonPath("$.frequencyDays").value(response.frequencyDays()))
+//        .andExpect(jsonPath("$.hour").value(response.hour().format(DateTimeFormatter.ISO_LOCAL_TIME)))
+//        .andExpect(jsonPath("$.isActive").value(response.isActive()))
+//        .andExpect(jsonPath("$.creationDate").value(response.creationDate().toString()));
+//
+//    verify(service, times(1)).updateAppointment(id, payload.newFrequency(), payload.newTime());
+//  }
+//
+//  @Test
+//  @WithMockUser(username = "admin", roles = {"ADMIN"})
+//  void shouldListGeneratedAppointmentsByPatientSuccessfully() throws Exception {
+//    UUID patientId = UUID.randomUUID();
+//
+//    LocalDate start = LocalDate.of(2026, 1, 1);
+//    LocalDate end = LocalDate.of(2026, 1, 31);
+//
+//    var response = new GeneratedAppointmentResponseDTO(
+//        UUID.randomUUID(),
+//        UUID.randomUUID(),
+//        LocalDateTime.now().withNano(0),
+//        null,
+//        false,
+//        false,
+//        null,
+//        patientId,
+//        null
+//    );
+//
+//    Page<GeneratedAppointmentResponseDTO> page =
+//        new PageImpl<>(List.of(response), PageRequest.of(0, 10), 1);
+//
+//    when(service.listByPatient(eq(patientId), eq(start), eq(end), any(Pageable.class)))
+//        .thenReturn(page);
+//
+//    mockMvc.perform(get(URI + "/patient/{patientId}", patientId)
+//            .param("start", start.toString())
+//            .param("end", end.toString())
+//            .param("page", "0")
+//            .param("size", "10")
+//            .with(csrf()))
+//        .andExpect(status().isOk())
+//        .andExpect(jsonPath("$.content").isArray())
+//        .andExpect(jsonPath("$.content.length()").value(1))
+//        .andExpect(jsonPath("$.content[0].id").value(response.id().toString()))
+//        .andExpect(jsonPath("$.content[0].appointmentId").value(response.appointmentId().toString()))
+//        .andExpect(jsonPath("$.content[0].scheduledDateTime").value(response.scheduledDateTime().toString()))
+//        .andExpect(jsonPath("$.content[0].performed").value(response.performed()))
+//        .andExpect(jsonPath("$.content[0].cancelled").value(response.cancelled()))
+//        .andExpect(jsonPath("$.content[0].patientId").value(response.patientId().toString()));
+//
+//    verify(service, times(1))
+//        .listByPatient(eq(patientId), eq(start), eq(end), any(Pageable.class));
+//  }
+//
+//  @Test
+//  @WithMockUser(username = "admin", roles = {"ADMIN"})
+//  void shouldListTodayAppointmentsSuccessfully() throws Exception {
+//    var response = new TodayAppointmentsResponseDTO(
+//        UUID.randomUUID(),
+//        mock(PatientResponseDTO.class),
+//        mock(HealthProfessionalResponseDTO.class),
+//        LocalDateTime.now().withNano(0),
+//        null,
+//        false,
+//        false,
+//        null,
+//        null,
+//        UUID.randomUUID()
+//    );
+//
+//    Page<TodayAppointmentsResponseDTO> page =
+//        new PageImpl<>(List.of(response), PageRequest.of(0, 10), 1);
+//
+//    when(service.listAppointmentForToday(any(Pageable.class)))
+//        .thenReturn(page);
+//
+//    mockMvc.perform(get(URI + "/today")
+//            .param("page", "0")
+//            .param("size", "10")
+//            .with(csrf()))
+//        .andExpect(status().isOk())
+//        .andExpect(jsonPath("$.content").isArray())
+//        .andExpect(jsonPath("$.content.length()").value(1))
+//        .andExpect(jsonPath("$.content[0].id").value(response.id().toString()))
+//        .andExpect(jsonPath("$.content[0].performed").value(response.performed()))
+//        .andExpect(jsonPath("$.content[0].cancelled").value(response.cancelled()))
+//        .andExpect(jsonPath("$.content[0].ruleId").value(response.ruleId().toString()));
+//  }
+//
+//  @Test
+//  @WithMockUser(username = "admin", roles = {"ADMIN"})
+//  void shouldGetAllAppointmentsSuccessfully() throws Exception {
+//    LocalDate date = LocalDate.of(2026, 1, 21);
+//    LocalTime time = LocalTime.of(10, 30);
+//
+//    AppointmentResponseDTO response1 = createAppointmentDTO(UUID.randomUUID()) ;
+//
+//    AppointmentResponseDTO response2 = createAppointmentDTO(UUID.randomUUID());
+//    Page<AppointmentResponseDTO> page =
+//        new PageImpl<>(List.of(response1, response2), PageRequest.of(0, 10), 2);
+//
+//    when(service.findAll(eq(date), eq(time), any(Pageable.class)))
+//        .thenReturn(page);
+//
+//    mockMvc.perform(get(URI)
+//            .param("date", date.toString())
+//            .param("time", time.format(DateTimeFormatter.ISO_LOCAL_TIME))
+//            .param("page", "0")
+//            .param("size", "10")
+//            .with(csrf()))
+//        .andExpect(status().isOk())
+//        .andExpect(jsonPath("$.content").isArray())
+//        .andExpect(jsonPath("$.content.length()").value(2))
+//        .andExpect(jsonPath("$.content[0].id").value(response1.id().toString()))
+//        .andExpect(jsonPath("$.content[0].frequencyDays").value(response1.frequencyDays()))
+//        .andExpect(jsonPath("$.content[0].hour").value(
+//            response1.hour().format(DateTimeFormatter.ISO_LOCAL_TIME)))
+//        .andExpect(jsonPath("$.content[1].id").value(response2.id().toString()))
+//        .andExpect(jsonPath("$.content[1].frequencyDays").value(response2.frequencyDays()))
+//        .andExpect(jsonPath("$.content[1].hour").value(
+//            response2.hour().format(DateTimeFormatter.ISO_LOCAL_TIME)));
+//  }
+//
+//
+//
+//
+//  @Test
+//  @WithMockUser(username = "admin", roles = {"ADMIN"})
+//  void shouldReturnNotFoundWhenGetNonExistentAppointment() throws Exception {
+//    UUID id = UUID.randomUUID();
+//
+//    when(service.findById(id)).thenThrow(new AppointmentNotFoundException());
+//
+//    mockMvc.perform(get(URI_WITH_ID, id)
+//                    .with(csrf()))
+//            .andExpect(status().isNotFound());
+//  }
+//
+//  @Test
+//  @WithMockUser(username = "admin", roles = {"ADMIN"})
+//  void shouldReturnNotFoundWhenReschedulingNonExistentAppointment() throws Exception {
+//    UUID id = UUID.randomUUID();
+//    var payload = new RescheduleGeneratedAppointmentDTO(LocalDateTime.now().plusDays(1));
+//
+//    when(service.reschedule(any(), any())).thenThrow(new AppointmentNotFoundException());
+//
+//    mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/reschedule", id)
+//                    .contentType(MediaType.APPLICATION_JSON)
+//                    .content(objectMapper.writeValueAsString(payload))
+//                    .with(csrf()))
+//            .andExpect(status().isNotFound());
+//  }
+//
+//  @Test
+//  @WithMockUser(username = "admin", roles = {"ADMIN"})
+//  void shouldReturnBadRequestWhenCancellingAlreadyCancelledAppointment() throws Exception {
+//    UUID id = UUID.randomUUID();
+//    var payload = new CancelGeneratedAppointmentDTO("Motivo qualquer");
+//
+//    when(service.cancel(eq(id), anyString())).thenThrow(new AppointmentAlreadyCancelledException());
+//
+//    mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/cancel", id)
+//                    .contentType(MediaType.APPLICATION_JSON)
+//                    .content(objectMapper.writeValueAsString(payload))
+//                    .with(csrf()))
+//            .andExpect(status().isBadRequest());
+//  }
+//
+//  @Test
+//  @WithMockUser(username = "admin", roles = {"ADMIN"})
+//  void shouldReturnBadRequestWhenProfessionalIdIsNull() throws Exception {
+//    var payload = new CreateAppointmentDTO(
+//        null,
+//        UUID.randomUUID(),
+//        UUID.randomUUID(),
+//        7,
+//        LocalDate.now().plusDays(1),
+//        LocalTime.now()
+//    );
+//
+//    mockMvc.perform(post(URI)
+//            .content(objectMapper.writeValueAsString(payload))
+//            .contentType(MediaType.APPLICATION_JSON)
+//            .with(csrf()))
+//        .andExpect(status().isBadRequest());
+//  }
+//
+//  @Test
+//  @WithMockUser(username = "admin", roles = {"ADMIN"})
+//  void shouldReturnBadRequestWhenServiceIdIsNull() throws Exception {
+//    var payload = new CreateAppointmentDTO(
+//        UUID.randomUUID(),
+//        null,
+//        UUID.randomUUID(),
+//        7,
+//        LocalDate.now().plusDays(1),
+//        LocalTime.now()
+//    );
+//
+//    mockMvc.perform(post(URI)
+//            .content(objectMapper.writeValueAsString(payload))
+//            .contentType(MediaType.APPLICATION_JSON)
+//            .with(csrf()))
+//        .andExpect(status().isBadRequest());
+//  }
+//
+//  @Test
+//  @WithMockUser(username = "admin", roles = {"ADMIN"})
+//  void shouldReturnBadRequestWhenPatientIdIsNull() throws Exception {
+//    var payload = new CreateAppointmentDTO(
+//        UUID.randomUUID(),
+//        UUID.randomUUID(),
+//        null,
+//        7,
+//        LocalDate.now().plusDays(1),
+//        LocalTime.now()
+//    );
+//
+//    mockMvc.perform(post(URI)
+//            .content(objectMapper.writeValueAsString(payload))
+//            .contentType(MediaType.APPLICATION_JSON)
+//            .with(csrf()))
+//        .andExpect(status().isBadRequest());
+//  }
+//
+//  @Test
+//  @WithMockUser(username = "admin", roles = {"ADMIN"})
+//  void shouldReturnBadRequestWhenFrequencyDaysIsNull() throws Exception {
+//    var payload = new CreateAppointmentDTO(
+//        UUID.randomUUID(),
+//        UUID.randomUUID(),
+//        UUID.randomUUID(),
+//        null,
+//        LocalDate.now().plusDays(1),
+//        LocalTime.now()
+//    );
+//
+//    mockMvc.perform(post(URI)
+//            .content(objectMapper.writeValueAsString(payload))
+//            .contentType(MediaType.APPLICATION_JSON)
+//            .with(csrf()))
+//        .andExpect(status().isBadRequest());
+//  }
+//
+//  @Test
+//  @WithMockUser(username = "admin", roles = {"ADMIN"})
+//  void shouldReturnBadRequestWhenFrequencyDaysIsZeroOrNegative() throws Exception {
+//    var payload = new CreateAppointmentDTO(
+//        UUID.randomUUID(),
+//        UUID.randomUUID(),
+//        UUID.randomUUID(),
+//        0,
+//        LocalDate.now().plusDays(1),
+//        LocalTime.now()
+//    );
+//
+//    mockMvc.perform(post(URI)
+//            .content(objectMapper.writeValueAsString(payload))
+//            .contentType(MediaType.APPLICATION_JSON)
+//            .with(csrf()))
+//        .andExpect(status().isBadRequest());
+//  }
+//
+//  @Test
+//  @WithMockUser(username = "admin", roles = {"ADMIN"})
+//  void shouldReturnBadRequestWhenFrequencyDaysIsNegative() throws Exception {
+//    var payload = new CreateAppointmentDTO(
+//        UUID.randomUUID(),
+//        UUID.randomUUID(),
+//        UUID.randomUUID(),
+//        -5,
+//        LocalDate.now().plusDays(1),
+//        LocalTime.now()
+//    );
+//
+//    mockMvc.perform(post(URI)
+//            .content(objectMapper.writeValueAsString(payload))
+//            .contentType(MediaType.APPLICATION_JSON)
+//            .with(csrf()))
+//        .andExpect(status().isBadRequest());
+//  }
+//
+//  @Test
+//  @WithMockUser(username = "admin", roles = {"ADMIN"})
+//  void shouldReturnBadRequestWhenInitialDateIsNull() throws Exception {
+//    var payload = new CreateAppointmentDTO(
+//        UUID.randomUUID(),
+//        UUID.randomUUID(),
+//        UUID.randomUUID(),
+//        7,
+//        null,
+//        LocalTime.now()
+//    );
+//
+//    mockMvc.perform(post(URI)
+//            .content(objectMapper.writeValueAsString(payload))
+//            .contentType(MediaType.APPLICATION_JSON)
+//            .with(csrf()))
+//        .andExpect(status().isBadRequest());
+//  }
+//
+//  @Test
+//  @WithMockUser(username = "admin", roles = {"ADMIN"})
+//  void shouldReturnBadRequestWhenInitialDateIsInThePast() throws Exception {
+//    var payload = new CreateAppointmentDTO(
+//        UUID.randomUUID(),
+//        UUID.randomUUID(),
+//        UUID.randomUUID(),
+//        7,
+//        LocalDate.now().minusDays(1),
+//        LocalTime.now()
+//    );
+//
+//    mockMvc.perform(post(URI)
+//            .content(objectMapper.writeValueAsString(payload))
+//            .contentType(MediaType.APPLICATION_JSON)
+//            .with(csrf()))
+//        .andExpect(status().isBadRequest());
+//  }
+//
+//  @Test
+//  @WithMockUser(username = "admin", roles = {"ADMIN"})
+//  void shouldReturnBadRequestWhenHourIsNull() throws Exception {
+//    var payload = new CreateAppointmentDTO(
+//        UUID.randomUUID(),
+//        UUID.randomUUID(),
+//        UUID.randomUUID(),
+//        7,
+//        LocalDate.now().plusDays(1),
+//        null
+//    );
+//
+//    mockMvc.perform(post(URI)
+//            .content(objectMapper.writeValueAsString(payload))
+//            .contentType(MediaType.APPLICATION_JSON)
+//            .with(csrf()))
+//        .andExpect(status().isBadRequest());
+//  }
+//
+//  @Test
+//  @WithMockUser(username = "admin", roles = {"ADMIN"})
+//  void shouldReturnBadRequestWhenCreateBodyIsMissing() throws Exception {
+//    mockMvc.perform(post(URI)
+//            .contentType(MediaType.APPLICATION_JSON)
+//            .with(csrf()))
+//        .andExpect(status().isBadRequest());
+//  }
 }
-*/

--- a/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
@@ -548,25 +548,24 @@ class AppointmentControllerImplTest {
         .andExpect(status().isBadRequest());
   }
 
-//  @Test
-//  @WithMockUser(username = "admin", roles = {"ADMIN"})
-//  void shouldReturnBadRequestWhenInitialDateIsInThePast() throws Exception {
-//    var payload = new CreateAppointmentDTO(
-//        UUID.randomUUID(),
-//        UUID.randomUUID(),
-//        UUID.randomUUID(),
-//        7,
-//        LocalDate.now().minusDays(1),
-//        LocalTime.now()
-//    );
-//
-//    mockMvc.perform(post(URI)
-//            .content(objectMapper.writeValueAsString(payload))
-//            .contentType(MediaType.APPLICATION_JSON)
-//            .with(csrf()))
-//        .andExpect(status().isBadRequest());
-//  }
-//
+  @Test
+  @WithMockUser(username = "admin", roles = {"ADMIN"})
+  void shouldReturnBadRequestWhenInitialDateIsInThePast() throws Exception {
+    var payload = new CreateAppointmentDTO(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            7,
+            LocalDate.now().minusDays(1),
+            LocalTime.now()
+    );
+
+    mockMvc.perform(post(URI)
+            .content(objectMapper.writeValueAsString(payload))
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(csrf()))
+        .andExpect(status().isBadRequest());
+  }
+
 //  @Test
 //  @WithMockUser(username = "admin", roles = {"ADMIN"})
 //  void shouldReturnBadRequestWhenHourIsNull() throws Exception {

--- a/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
@@ -493,25 +493,44 @@ class AppointmentControllerImplTest {
         .andExpect(status().isBadRequest());
   }
 
-//  @Test
-//  @WithMockUser(username = "admin", roles = {"ADMIN"})
-//  void shouldReturnBadRequestWhenFrequencyDaysIsZeroOrNegative() throws Exception {
-//    var payload = new CreateAppointmentDTO(
-//        UUID.randomUUID(),
-//        UUID.randomUUID(),
-//        UUID.randomUUID(),
-//        0,
-//        LocalDate.now().plusDays(1),
-//        LocalTime.now()
-//    );
-//
-//    mockMvc.perform(post(URI)
-//            .content(objectMapper.writeValueAsString(payload))
-//            .contentType(MediaType.APPLICATION_JSON)
-//            .with(csrf()))
-//        .andExpect(status().isBadRequest());
-//  }
-//
+  @Test
+  @WithMockUser(username = "admin", roles = {"ADMIN"})
+  void shouldReturnBadRequestWhenFrequencyDaysIsZero() throws Exception {
+
+    var payload = new CreateAppointmentDTO(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            0,
+            LocalDate.now().plusDays(1),
+            LocalTime.now()
+    );
+
+    mockMvc.perform(post(URI)
+            .content(objectMapper.writeValueAsString(payload))
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(csrf()))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser(username = "admin", roles = {"ADMIN"})
+  void shouldReturnBadRequestWhenFrequencyDaysIsNegative() throws Exception {
+
+    var payload = new CreateAppointmentDTO(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            -10,
+            LocalDate.now().plusDays(1),
+            LocalTime.now()
+    );
+
+    mockMvc.perform(post(URI)
+                    .content(objectMapper.writeValueAsString(payload))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .with(csrf()))
+            .andExpect(status().isBadRequest());
+  }
+
 //  @Test
 //  @WithMockUser(username = "admin", roles = {"ADMIN"})
 //  void shouldReturnBadRequestWhenFrequencyDaysIsNegative() throws Exception {

--- a/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
@@ -6,10 +6,7 @@ import br.org.apae.api.appointment.domain.exceptions.AppointmentNotFoundExceptio
 import br.org.apae.api.appointment.domain.model.GeneratedAppointment;
 import br.org.apae.api.auth.application.internal.UserService;
 import br.org.apae.api.auth.infrastructure.security.JwtProvider;
-import br.org.apae.api.common.dto.appointment.request.appointment.CancelGeneratedAppointmentDTO;
-import br.org.apae.api.common.dto.appointment.request.appointment.CreateAppointmentDTO;
-import br.org.apae.api.common.dto.appointment.request.appointment.RescheduleGeneratedAppointmentDTO;
-import br.org.apae.api.common.dto.appointment.request.appointment.UpdateAppointmentRuleDTO;
+import br.org.apae.api.common.dto.appointment.request.appointment.*;
 import br.org.apae.api.common.dto.appointment.response.appointment.AnnualRegistryResponseDTO;
 import br.org.apae.api.common.dto.appointment.response.appointment.AppointmentResponseDTO;
 import br.org.apae.api.common.dto.appointment.response.appointment.GeneratedAppointmentResponseDTO;
@@ -236,49 +233,51 @@ class AppointmentControllerImplTest {
         .andExpect(jsonPath("$.effectiveDateTime").value(response.effectiveDateTime().toString()));
   }
 
-//  @Test
-//  @WithMockUser(username = "admin", roles = {"ADMIN"})
-//  void shouldUpdateAppointmentRuleSuccessfully() throws Exception {
-//    UUID id = UUID.randomUUID();
-//
-//    var payload = new UpdateAppointmentRuleDTO(
-//        14,
-//        LocalTime.of(10, 30, 0)
-//    );
-//
-//    var response = new AppointmentResponseDTO(
-//        id,
-//        mock(HealthProfessionalResponseDTO.class),
-//        mock(AnnualRegistryResponseDTO.class),
-//        payload.newFrequency(),
-//        LocalDate.now(),
-//        LocalDate.of(2026, 12, 31),
-//        payload.newTime(),
-//        true,
-//        LocalDateTime.now().withNano(0),
-//        null,
-//        null
-//    );
-//
-//
-//
-//    when(service.updateAppointment(id, payload.newFrequency(), payload.newTime())).thenReturn(response);
-//
-//    mockMvc.perform(patch(URI_WITH_ID + "/rule", id)
-//            .contentType(MediaType.APPLICATION_JSON)
-//            .content(objectMapper.writeValueAsString(payload))
-//            .with(csrf()))
-//        .andExpect(status().isOk())
-//        .andExpect(jsonPath("$.id").value(response.id().toString()))
-//        .andExpect(jsonPath("$.serviceId").value(response.serviceId().toString()))
-//        .andExpect(jsonPath("$.frequencyDays").value(response.frequencyDays()))
-//        .andExpect(jsonPath("$.hour").value(response.hour().format(DateTimeFormatter.ISO_LOCAL_TIME)))
-//        .andExpect(jsonPath("$.isActive").value(response.isActive()))
-//        .andExpect(jsonPath("$.creationDate").value(response.creationDate().toString()));
-//
-//    verify(service, times(1)).updateAppointment(id, payload.newFrequency(), payload.newTime());
-//  }
-//
+  @Test
+  @WithMockUser(username = "admin", roles = {"ADMIN"})
+  void shouldUpdateAppointmentRuleSuccessfully() throws Exception {
+    UUID id = UUID.randomUUID();
+
+    var payload = new UpdateAppointmentDTO(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            14,
+            LocalDate.now().plusDays(1),
+            LocalTime.of(10, 30, 0),
+            LocalDate.now().plusDays(30)
+    );
+
+    var response = new AppointmentResponseDTO(
+            id,
+            mock(HealthProfessionalResponseDTO.class),
+            mock(AnnualRegistryResponseDTO.class),
+            payload.frequencyDays(),
+            payload.initialDate(),
+            payload.endDate(),
+            payload.hour(),
+            true,
+            LocalDateTime.now().withNano(0),
+            null,
+            null
+    );
+
+    when(service.update(id, payload)).thenReturn(response);
+
+    mockMvc.perform(patch(URI_WITH_ID, id)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(payload))
+            .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(response.id().toString()))
+        .andExpect(jsonPath("$.frequencyDays").value(response.frequencyDays()))
+        .andExpect(jsonPath("$.hour").value(response.hour().format(DateTimeFormatter.ISO_LOCAL_TIME)))
+        .andExpect(jsonPath("$.isActive").value(response.isActive()))
+        .andExpect(jsonPath("$.creationDate").value(response.creationDate().toString()));
+
+    verify(service, times(1)).update(eq(id), any(UpdateAppointmentDTO.class));
+  }
+
 //  @Test
 //  @WithMockUser(username = "admin", roles = {"ADMIN"})
 //  void shouldListGeneratedAppointmentsByPatientSuccessfully() throws Exception {

--- a/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
@@ -278,52 +278,52 @@ class AppointmentControllerImplTest {
     verify(service, times(1)).update(eq(id), any(UpdateAppointmentDTO.class));
   }
 
-//  @Test
-//  @WithMockUser(username = "admin", roles = {"ADMIN"})
-//  void shouldListGeneratedAppointmentsByPatientSuccessfully() throws Exception {
-//    UUID patientId = UUID.randomUUID();
-//
-//    LocalDate start = LocalDate.of(2026, 1, 1);
-//    LocalDate end = LocalDate.of(2026, 1, 31);
-//
-//    var response = new GeneratedAppointmentResponseDTO(
-//        UUID.randomUUID(),
-//        UUID.randomUUID(),
-//        LocalDateTime.now().withNano(0),
-//        null,
-//        false,
-//        false,
-//        null,
-//        patientId,
-//        null
-//    );
-//
-//    Page<GeneratedAppointmentResponseDTO> page =
-//        new PageImpl<>(List.of(response), PageRequest.of(0, 10), 1);
-//
-//    when(service.listByPatient(eq(patientId), eq(start), eq(end), any(Pageable.class)))
-//        .thenReturn(page);
-//
-//    mockMvc.perform(get(URI + "/patient/{patientId}", patientId)
-//            .param("start", start.toString())
-//            .param("end", end.toString())
-//            .param("page", "0")
-//            .param("size", "10")
-//            .with(csrf()))
-//        .andExpect(status().isOk())
-//        .andExpect(jsonPath("$.content").isArray())
-//        .andExpect(jsonPath("$.content.length()").value(1))
-//        .andExpect(jsonPath("$.content[0].id").value(response.id().toString()))
-//        .andExpect(jsonPath("$.content[0].appointmentId").value(response.appointmentId().toString()))
-//        .andExpect(jsonPath("$.content[0].scheduledDateTime").value(response.scheduledDateTime().toString()))
-//        .andExpect(jsonPath("$.content[0].performed").value(response.performed()))
-//        .andExpect(jsonPath("$.content[0].cancelled").value(response.cancelled()))
-//        .andExpect(jsonPath("$.content[0].patientId").value(response.patientId().toString()));
-//
-//    verify(service, times(1))
-//        .listByPatient(eq(patientId), eq(start), eq(end), any(Pageable.class));
-//  }
-//
+  @Test
+  @WithMockUser(username = "admin", roles = {"ADMIN"})
+  void shouldListGeneratedAppointmentsByPatientSuccessfully() throws Exception {
+    UUID patientId = UUID.randomUUID();
+
+    LocalDate start = LocalDate.of(2026, 1, 1);
+    LocalDate end = LocalDate.of(2026, 1, 31);
+
+    var response = new GeneratedAppointmentResponseDTO(
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        LocalDateTime.now().withNano(0),
+        null,
+        false,
+        false,
+        null,
+        patientId,
+        null
+    );
+
+    Page<GeneratedAppointmentResponseDTO> page =
+        new PageImpl<>(List.of(response), PageRequest.of(0, 10), 1);
+
+    when(service.listByPatient(eq(patientId), eq(start), eq(end), any(Pageable.class)))
+        .thenReturn(page);
+
+    mockMvc.perform(get(URI + "/patient/{patientId}", patientId)
+            .param("start", start.toString())
+            .param("end", end.toString())
+            .param("page", "0")
+            .param("size", "10")
+            .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content.length()").value(1))
+        .andExpect(jsonPath("$.content[0].id").value(response.id().toString()))
+        .andExpect(jsonPath("$.content[0].appointmentId").value(response.appointmentId().toString()))
+        .andExpect(jsonPath("$.content[0].scheduledDateTime").value(response.scheduledDateTime().toString()))
+        .andExpect(jsonPath("$.content[0].performed").value(response.performed()))
+        .andExpect(jsonPath("$.content[0].cancelled").value(response.cancelled()))
+        .andExpect(jsonPath("$.content[0].patientId").value(response.patientId().toString()));
+
+    verify(service, times(1))
+        .listByPatient(eq(patientId), eq(start), eq(end), any(Pageable.class));
+  }
+
 //  @Test
 //  @WithMockUser(username = "admin", roles = {"ADMIN"})
 //  void shouldListTodayAppointmentsSuccessfully() throws Exception {

--- a/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
@@ -79,20 +79,6 @@ class AppointmentControllerImplTest {
     );
   }
 
-  private GeneratedAppointmentResponseDTO createGeneratedAppointmentDTO(UUID id, LocalDateTime scheduledDateTime, LocalDateTime effectiveDateTime) {
-    return new GeneratedAppointmentResponseDTO(
-            id,
-            UUID.randomUUID(),
-            scheduledDateTime,
-            null,
-            false,
-            false,
-            null,
-            UUID.randomUUID(),
-            effectiveDateTime
-    );
-  }
-
   @Test
   @WithMockUser(username = "admin", roles = {"ADMIN"})
   void shouldCreateAppointmentSuccessfully() throws Exception {
@@ -149,9 +135,17 @@ class AppointmentControllerImplTest {
   @WithMockUser(username = "admin", roles = {"ADMIN"})
   void shouldRescheduleAppointmentSuccessfully() throws Exception {
     UUID id = UUID.randomUUID();
-    LocalDateTime scheduledDateTime = LocalDateTime.now().withNano(0);
-    LocalDateTime effectiveDateTime = LocalDateTime.now().withNano(0);
-    GeneratedAppointmentResponseDTO response = createGeneratedAppointmentDTO(id, scheduledDateTime, effectiveDateTime);
+    var response = new GeneratedAppointmentResponseDTO(
+            id,
+            UUID.randomUUID(),
+            LocalDateTime.now().withNano(0),
+            null,
+            false,
+            false,
+            null,
+            UUID.randomUUID(),
+            LocalDateTime.now().withNano(0)
+    );
 
     LocalDateTime localDateTime = LocalDateTime.now().withNano(0);
     var payload = new RescheduleGeneratedAppointmentDTO(localDateTime);
@@ -178,8 +172,17 @@ class AppointmentControllerImplTest {
   @WithMockUser(username = "admin", roles = {"ADMIN"})
   void shouldPerformedAppointmentSuccessfully() throws Exception {
     UUID id = UUID.randomUUID();
-    LocalDateTime effectiveDateTime = LocalDateTime.now().withNano(0);
-    var response = createGeneratedAppointmentDTO(id, null, effectiveDateTime);
+    var response = new GeneratedAppointmentResponseDTO(
+            id,
+            UUID.randomUUID(),
+            null,
+            null,
+            false,
+            false,
+            null,
+            UUID.randomUUID(),
+            LocalDateTime.now().withNano(0)
+    );
 
     when(service.markAsPerformed(id)).thenReturn(response);
 
@@ -197,41 +200,42 @@ class AppointmentControllerImplTest {
         .andExpect(jsonPath("$.effectiveDateTime").value(response.effectiveDateTime().toString()));
   }
 
-//  @Test
-//  @WithMockUser(username = "admin", roles = {"ADMIN"})
-//  void shouldCancelAppointmentSuccessfully() throws Exception {
-//    UUID id = UUID.randomUUID();
-//    var payload = new CancelGeneratedAppointmentDTO("cancel reason");
-//    var response = new GeneratedAppointmentResponseDTO(
-//        id,
-//        UUID.randomUUID(),
-//        null,
-//        null,
-//        false,
-//        true,
-//        payload.reason(),
-//        UUID.randomUUID(),
-//        LocalDateTime.now().withNano(0)
-//    );
-//
-//    when(service.cancel(id, payload.reason())).thenReturn(response);
-//
-//    mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/cancel", id)
-//            .contentType(MediaType.APPLICATION_JSON)
-//            .content(objectMapper.writeValueAsString(payload))
-//            .with(csrf()))
-//        .andExpect(status().isOk())
-//        .andExpect(jsonPath("$.id").value(response.id().toString()))
-//        .andExpect(jsonPath("$.appointmentId").value(response.appointmentId().toString()))
-//        .andExpect(jsonPath("$.scheduledDateTime").isEmpty())
-//        .andExpect(jsonPath("$.overriddenDateTime").isEmpty())
-//        .andExpect(jsonPath("$.performed").value(response.performed()))
-//        .andExpect(jsonPath("$.cancelled").value(response.cancelled()))
-//        .andExpect(jsonPath("$.cancellationReason").value(response.cancellationReason()))
-//        .andExpect(jsonPath("$.patientId").value(response.patientId().toString()))
-//        .andExpect(jsonPath("$.effectiveDateTime").value(response.effectiveDateTime().toString()));
-//  }
-//
+  @Test
+  @WithMockUser(username = "admin", roles = {"ADMIN"})
+  void shouldCancelAppointmentSuccessfully() throws Exception {
+    UUID id = UUID.randomUUID();
+    var payload = new CancelGeneratedAppointmentDTO("cancel reason");
+
+    var response = new GeneratedAppointmentResponseDTO(
+        id,
+        UUID.randomUUID(),
+        null,
+        null,
+        false,
+        true,
+        payload.reason(),
+        UUID.randomUUID(),
+        LocalDateTime.now().withNano(0)
+    );
+
+    when(service.cancel(id, payload.reason())).thenReturn(response);
+
+    mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/cancel", id)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(payload))
+            .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(response.id().toString()))
+        .andExpect(jsonPath("$.appointmentId").value(response.appointmentId().toString()))
+        .andExpect(jsonPath("$.scheduledDateTime").isEmpty())
+        .andExpect(jsonPath("$.overriddenDateTime").isEmpty())
+        .andExpect(jsonPath("$.performed").value(response.performed()))
+        .andExpect(jsonPath("$.cancelled").value(response.cancelled()))
+        .andExpect(jsonPath("$.cancellationReason").value(response.cancellationReason()))
+        .andExpect(jsonPath("$.patientId").value(response.patientId().toString()))
+        .andExpect(jsonPath("$.effectiveDateTime").value(response.effectiveDateTime().toString()));
+  }
+
 //  @Test
 //  @WithMockUser(username = "admin", roles = {"ADMIN"})
 //  void shouldUpdateAppointmentRuleSuccessfully() throws Exception {
@@ -242,18 +246,21 @@ class AppointmentControllerImplTest {
 //        LocalTime.of(10, 30, 0)
 //    );
 //
-//    AppointmentResponseDTO response = new AppointmentResponseDTO(
+//    var response = new AppointmentResponseDTO(
 //        id,
 //        mock(HealthProfessionalResponseDTO.class),
-//        UUID.randomUUID(),
 //        mock(AnnualRegistryResponseDTO.class),
 //        payload.newFrequency(),
 //        LocalDate.now(),
 //        LocalDate.of(2026, 12, 31),
 //        payload.newTime(),
 //        true,
-//        LocalDateTime.now().withNano(0)
+//        LocalDateTime.now().withNano(0),
+//        null,
+//        null
 //    );
+//
+//
 //
 //    when(service.updateAppointment(id, payload.newFrequency(), payload.newTime())).thenReturn(response);
 //

--- a/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
@@ -530,25 +530,24 @@ class AppointmentControllerImplTest {
         .andExpect(status().isBadRequest());
   }
 
-//  @Test
-//  @WithMockUser(username = "admin", roles = {"ADMIN"})
-//  void shouldReturnBadRequestWhenInitialDateIsNull() throws Exception {
-//    var payload = new CreateAppointmentDTO(
-//        UUID.randomUUID(),
-//        UUID.randomUUID(),
-//        UUID.randomUUID(),
-//        7,
-//        null,
-//        LocalTime.now()
-//    );
-//
-//    mockMvc.perform(post(URI)
-//            .content(objectMapper.writeValueAsString(payload))
-//            .contentType(MediaType.APPLICATION_JSON)
-//            .with(csrf()))
-//        .andExpect(status().isBadRequest());
-//  }
-//
+  @Test
+  @WithMockUser(username = "admin", roles = {"ADMIN"})
+  void shouldReturnBadRequestWhenInitialDateIsNull() throws Exception {
+    var payload = new CreateAppointmentDTO(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            7,
+            null,
+            LocalTime.now()
+    );
+
+    mockMvc.perform(post(URI)
+            .content(objectMapper.writeValueAsString(payload))
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(csrf()))
+        .andExpect(status().isBadRequest());
+  }
+
 //  @Test
 //  @WithMockUser(username = "admin", roles = {"ADMIN"})
 //  void shouldReturnBadRequestWhenInitialDateIsInThePast() throws Exception {

--- a/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
@@ -459,24 +459,6 @@ class AppointmentControllerImplTest {
 
   @Test
   @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldReturnBadRequestWhenServiceIdIsNull() throws Exception {
-    var payload = new CreateAppointmentDTO(
-            UUID.randomUUID(),
-            null,
-            7,
-            LocalDate.now().plusDays(1),
-            LocalTime.now()
-    );
-
-    mockMvc.perform(post(URI)
-            .content(objectMapper.writeValueAsString(payload))
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(csrf()))
-        .andExpect(status().isBadRequest());
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
   void shouldReturnBadRequestWhenPatientIdIsNull() throws Exception {
     var payload = new CreateAppointmentDTO(
             UUID.randomUUID(),

--- a/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
@@ -515,41 +515,21 @@ class AppointmentControllerImplTest {
   @Test
   @WithMockUser(username = "admin", roles = {"ADMIN"})
   void shouldReturnBadRequestWhenFrequencyDaysIsNegative() throws Exception {
-
     var payload = new CreateAppointmentDTO(
             UUID.randomUUID(),
             UUID.randomUUID(),
-            -10,
+            -5,
             LocalDate.now().plusDays(1),
             LocalTime.now()
     );
 
     mockMvc.perform(post(URI)
-                    .content(objectMapper.writeValueAsString(payload))
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .with(csrf()))
-            .andExpect(status().isBadRequest());
+            .content(objectMapper.writeValueAsString(payload))
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(csrf()))
+        .andExpect(status().isBadRequest());
   }
 
-//  @Test
-//  @WithMockUser(username = "admin", roles = {"ADMIN"})
-//  void shouldReturnBadRequestWhenFrequencyDaysIsNegative() throws Exception {
-//    var payload = new CreateAppointmentDTO(
-//        UUID.randomUUID(),
-//        UUID.randomUUID(),
-//        UUID.randomUUID(),
-//        -5,
-//        LocalDate.now().plusDays(1),
-//        LocalTime.now()
-//    );
-//
-//    mockMvc.perform(post(URI)
-//            .content(objectMapper.writeValueAsString(payload))
-//            .contentType(MediaType.APPLICATION_JSON)
-//            .with(csrf()))
-//        .andExpect(status().isBadRequest());
-//  }
-//
 //  @Test
 //  @WithMockUser(username = "admin", roles = {"ADMIN"})
 //  void shouldReturnBadRequestWhenInitialDateIsNull() throws Exception {

--- a/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
@@ -566,31 +566,30 @@ class AppointmentControllerImplTest {
         .andExpect(status().isBadRequest());
   }
 
-//  @Test
-//  @WithMockUser(username = "admin", roles = {"ADMIN"})
-//  void shouldReturnBadRequestWhenHourIsNull() throws Exception {
-//    var payload = new CreateAppointmentDTO(
-//        UUID.randomUUID(),
-//        UUID.randomUUID(),
-//        UUID.randomUUID(),
-//        7,
-//        LocalDate.now().plusDays(1),
-//        null
-//    );
-//
-//    mockMvc.perform(post(URI)
-//            .content(objectMapper.writeValueAsString(payload))
-//            .contentType(MediaType.APPLICATION_JSON)
-//            .with(csrf()))
-//        .andExpect(status().isBadRequest());
-//  }
-//
-//  @Test
-//  @WithMockUser(username = "admin", roles = {"ADMIN"})
-//  void shouldReturnBadRequestWhenCreateBodyIsMissing() throws Exception {
-//    mockMvc.perform(post(URI)
-//            .contentType(MediaType.APPLICATION_JSON)
-//            .with(csrf()))
-//        .andExpect(status().isBadRequest());
-//  }
+  @Test
+  @WithMockUser(username = "admin", roles = {"ADMIN"})
+  void shouldReturnBadRequestWhenHourIsNull() throws Exception {
+    var payload = new CreateAppointmentDTO(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            7,
+            LocalDate.now().minusDays(1),
+            null
+    );
+
+    mockMvc.perform(post(URI)
+            .content(objectMapper.writeValueAsString(payload))
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(csrf()))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser(username = "admin", roles = {"ADMIN"})
+  void shouldReturnBadRequestWhenCreateBodyIsMissing() throws Exception {
+    mockMvc.perform(post(URI)
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(csrf()))
+        .andExpect(status().isBadRequest());
+  }
 }

--- a/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
@@ -324,41 +324,45 @@ class AppointmentControllerImplTest {
         .listByPatient(eq(patientId), eq(start), eq(end), any(Pageable.class));
   }
 
-//  @Test
-//  @WithMockUser(username = "admin", roles = {"ADMIN"})
-//  void shouldListTodayAppointmentsSuccessfully() throws Exception {
-//    var response = new TodayAppointmentsResponseDTO(
-//        UUID.randomUUID(),
-//        mock(PatientResponseDTO.class),
-//        mock(HealthProfessionalResponseDTO.class),
-//        LocalDateTime.now().withNano(0),
-//        null,
-//        false,
-//        false,
-//        null,
-//        null,
-//        UUID.randomUUID()
-//    );
-//
-//    Page<TodayAppointmentsResponseDTO> page =
-//        new PageImpl<>(List.of(response), PageRequest.of(0, 10), 1);
-//
-//    when(service.listAppointmentForToday(any(Pageable.class)))
-//        .thenReturn(page);
-//
-//    mockMvc.perform(get(URI + "/today")
-//            .param("page", "0")
-//            .param("size", "10")
-//            .with(csrf()))
-//        .andExpect(status().isOk())
-//        .andExpect(jsonPath("$.content").isArray())
-//        .andExpect(jsonPath("$.content.length()").value(1))
-//        .andExpect(jsonPath("$.content[0].id").value(response.id().toString()))
-//        .andExpect(jsonPath("$.content[0].performed").value(response.performed()))
-//        .andExpect(jsonPath("$.content[0].cancelled").value(response.cancelled()))
-//        .andExpect(jsonPath("$.content[0].ruleId").value(response.ruleId().toString()));
-//  }
-//
+  @Test
+  @WithMockUser(username = "admin", roles = {"ADMIN"})
+  void shouldListTodayAppointmentsSuccessfully() throws Exception {
+    LocalDate date = LocalDate.now();
+
+    var response = new TodayAppointmentsResponseDTO(
+        UUID.randomUUID(),
+        mock(PatientResponseDTO.class),
+        mock(HealthProfessionalResponseDTO.class),
+        LocalDateTime.now().withNano(0),
+        null,
+        false,
+        false,
+        null,
+        null,
+        UUID.randomUUID(),
+        false
+    );
+
+    Page<TodayAppointmentsResponseDTO> page =
+        new PageImpl<>(List.of(response), PageRequest.of(0, 10), 1);
+
+    when(service.listAppointmentForToday(eq(date), any(Pageable.class)))
+        .thenReturn(page);
+
+    mockMvc.perform(get(URI + "/today")
+            .param("date", date.toString())
+            .param("page", "0")
+            .param("size", "10")
+            .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content.length()").value(1))
+        .andExpect(jsonPath("$.content[0].id").value(response.id().toString()))
+        .andExpect(jsonPath("$.content[0].performed").value(response.performed()))
+        .andExpect(jsonPath("$.content[0].cancelled").value(response.cancelled()))
+        .andExpect(jsonPath("$.content[0].ruleId").value(response.ruleId().toString()));
+  }
+
 //  @Test
 //  @WithMockUser(username = "admin", roles = {"ADMIN"})
 //  void shouldGetAllAppointmentsSuccessfully() throws Exception {

--- a/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
@@ -363,43 +363,40 @@ class AppointmentControllerImplTest {
         .andExpect(jsonPath("$.content[0].ruleId").value(response.ruleId().toString()));
   }
 
-//  @Test
-//  @WithMockUser(username = "admin", roles = {"ADMIN"})
-//  void shouldGetAllAppointmentsSuccessfully() throws Exception {
-//    LocalDate date = LocalDate.of(2026, 1, 21);
-//    LocalTime time = LocalTime.of(10, 30);
-//
-//    AppointmentResponseDTO response1 = createAppointmentDTO(UUID.randomUUID()) ;
-//
-//    AppointmentResponseDTO response2 = createAppointmentDTO(UUID.randomUUID());
-//    Page<AppointmentResponseDTO> page =
-//        new PageImpl<>(List.of(response1, response2), PageRequest.of(0, 10), 2);
-//
-//    when(service.findAll(eq(date), eq(time), any(Pageable.class)))
-//        .thenReturn(page);
-//
-//    mockMvc.perform(get(URI)
-//            .param("date", date.toString())
-//            .param("time", time.format(DateTimeFormatter.ISO_LOCAL_TIME))
-//            .param("page", "0")
-//            .param("size", "10")
-//            .with(csrf()))
-//        .andExpect(status().isOk())
-//        .andExpect(jsonPath("$.content").isArray())
-//        .andExpect(jsonPath("$.content.length()").value(2))
-//        .andExpect(jsonPath("$.content[0].id").value(response1.id().toString()))
-//        .andExpect(jsonPath("$.content[0].frequencyDays").value(response1.frequencyDays()))
-//        .andExpect(jsonPath("$.content[0].hour").value(
-//            response1.hour().format(DateTimeFormatter.ISO_LOCAL_TIME)))
-//        .andExpect(jsonPath("$.content[1].id").value(response2.id().toString()))
-//        .andExpect(jsonPath("$.content[1].frequencyDays").value(response2.frequencyDays()))
-//        .andExpect(jsonPath("$.content[1].hour").value(
-//            response2.hour().format(DateTimeFormatter.ISO_LOCAL_TIME)));
-//  }
-//
-//
-//
-//
+  @Test
+  @WithMockUser(username = "admin", roles = {"ADMIN"})
+  void shouldGetAllAppointmentsSuccessfully() throws Exception {
+    LocalDate date = LocalDate.of(2026, 1, 21);
+    LocalTime time = LocalTime.of(10, 30);
+
+    AppointmentResponseDTO response1 = createAppointmentDTO(UUID.randomUUID()) ;
+
+    AppointmentResponseDTO response2 = createAppointmentDTO(UUID.randomUUID());
+    Page<AppointmentResponseDTO> page =
+        new PageImpl<>(List.of(response1, response2), PageRequest.of(0, 10), 2);
+
+    when(service.findAll(eq(date), eq(time), any(Pageable.class)))
+        .thenReturn(page);
+
+    mockMvc.perform(get(URI)
+            .param("date", date.toString())
+            .param("time", time.format(DateTimeFormatter.ISO_LOCAL_TIME))
+            .param("page", "0")
+            .param("size", "10")
+            .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content.length()").value(2))
+        .andExpect(jsonPath("$.content[0].id").value(response1.id().toString()))
+        .andExpect(jsonPath("$.content[0].frequencyDays").value(response1.frequencyDays()))
+        .andExpect(jsonPath("$.content[0].hour").value(
+            response1.hour().format(DateTimeFormatter.ISO_LOCAL_TIME)))
+        .andExpect(jsonPath("$.content[1].id").value(response2.id().toString()))
+        .andExpect(jsonPath("$.content[1].frequencyDays").value(response2.frequencyDays()))
+        .andExpect(jsonPath("$.content[1].hour").value(
+            response2.hour().format(DateTimeFormatter.ISO_LOCAL_TIME)));
+  }
+
 //  @Test
 //  @WithMockUser(username = "admin", roles = {"ADMIN"})
 //  void shouldReturnNotFoundWhenGetNonExistentAppointment() throws Exception {

--- a/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
@@ -646,7 +646,8 @@ class AppointmentControllerImplTest {
                     .param("page", "0")
                     .param("size", "10")
                     .with(csrf()))
-            .andExpect(status().isNotFound());
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message").value("Agendamento não encontrado."));
   }
 
   @Test

--- a/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
@@ -399,6 +399,44 @@ class AppointmentControllerImplTest {
 
   @Test
   @WithMockUser(username = "admin", roles = {"ADMIN"})
+  void shouldGetTodayAppointmentByIdSuccessfully() throws Exception {
+    UUID id = UUID.randomUUID();
+
+    var response = new TodayAppointmentsResponseDTO(
+            id,
+            mock(PatientResponseDTO.class),
+            mock(HealthProfessionalResponseDTO.class),
+            LocalDateTime.now().withNano(0),
+            null,
+            false,
+            false,
+            null,
+            LocalDateTime.now().withNano(0),
+            UUID.randomUUID(),
+            false
+    );
+
+    when(service.findGeneratedAppointmentById(id)).thenReturn(response);
+
+    mockMvc.perform(get(URI + "/today/{id}", id)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(response.id().toString()))
+            .andExpect(jsonPath("$.scheduledDateTime").value(response.scheduledDateTime().toString()))
+            .andExpect(jsonPath("$.overriddenDateTime").isEmpty())
+            .andExpect(jsonPath("$.performed").value(response.performed()))
+            .andExpect(jsonPath("$.cancelled").value(response.cancelled()))
+            .andExpect(jsonPath("$.cancellationReason").isEmpty())
+            .andExpect(jsonPath("$.effectiveDateTime").value(response.effectiveDateTime().toString()))
+            .andExpect(jsonPath("$.ruleId").value(response.ruleId().toString()))
+            .andExpect(jsonPath("$.hasAbsence").value(response.hasAbsence()));
+
+    verify(service, times(1)).findGeneratedAppointmentById(id);
+  }
+
+  @Test
+  @WithMockUser(username = "admin", roles = {"ADMIN"})
   void shouldReturnNotFoundWhenGetNonExistentAppointment() throws Exception {
     UUID id = UUID.randomUUID();
 
@@ -590,5 +628,37 @@ class AppointmentControllerImplTest {
             .contentType(MediaType.APPLICATION_JSON)
             .with(csrf()))
         .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser(username = "admin", roles = {"ADMIN"})
+  void shouldReturnNotFoundWhenListingAppointmentsByNonExistentPatient() throws Exception {
+    UUID patientId = UUID.randomUUID();
+    LocalDate start = LocalDate.of(2026, 1, 1);
+    LocalDate end = LocalDate.of(2026, 1, 31);
+
+    when(service.listByPatient(eq(patientId), eq(start), eq(end), any(Pageable.class)))
+            .thenThrow(new AppointmentNotFoundException());
+
+    mockMvc.perform(get(URI + "/patient/{patientId}", patientId)
+                    .param("start", start.toString())
+                    .param("end", end.toString())
+                    .param("page", "0")
+                    .param("size", "10")
+                    .with(csrf()))
+            .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @WithMockUser(username = "admin", roles = {"ADMIN"})
+  void shouldReturnNotFoundWhenGetTodayAppointmentByIdNonExistent() throws Exception {
+    UUID id = UUID.randomUUID();
+
+    when(service.findGeneratedAppointmentById(id))
+            .thenThrow(new AppointmentNotFoundException());
+
+    mockMvc.perform(get(URI + "/today/{id}", id)
+                    .with(csrf()))
+            .andExpect(status().isNotFound());
   }
 }

--- a/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
@@ -439,82 +439,78 @@ class AppointmentControllerImplTest {
             .andExpect(status().isBadRequest());
   }
 
-//  @Test
-//  @WithMockUser(username = "admin", roles = {"ADMIN"})
-//  void shouldReturnBadRequestWhenProfessionalIdIsNull() throws Exception {
-//    var payload = new CreateAppointmentDTO(
-//        null,
-//        UUID.randomUUID(),
-//        UUID.randomUUID(),
-//        7,
-//        LocalDate.now().plusDays(1),
-//        LocalTime.now()
-//    );
-//
-//    mockMvc.perform(post(URI)
-//            .content(objectMapper.writeValueAsString(payload))
-//            .contentType(MediaType.APPLICATION_JSON)
-//            .with(csrf()))
-//        .andExpect(status().isBadRequest());
-//  }
-//
-//  @Test
-//  @WithMockUser(username = "admin", roles = {"ADMIN"})
-//  void shouldReturnBadRequestWhenServiceIdIsNull() throws Exception {
-//    var payload = new CreateAppointmentDTO(
-//        UUID.randomUUID(),
-//        null,
-//        UUID.randomUUID(),
-//        7,
-//        LocalDate.now().plusDays(1),
-//        LocalTime.now()
-//    );
-//
-//    mockMvc.perform(post(URI)
-//            .content(objectMapper.writeValueAsString(payload))
-//            .contentType(MediaType.APPLICATION_JSON)
-//            .with(csrf()))
-//        .andExpect(status().isBadRequest());
-//  }
-//
-//  @Test
-//  @WithMockUser(username = "admin", roles = {"ADMIN"})
-//  void shouldReturnBadRequestWhenPatientIdIsNull() throws Exception {
-//    var payload = new CreateAppointmentDTO(
-//        UUID.randomUUID(),
-//        UUID.randomUUID(),
-//        null,
-//        7,
-//        LocalDate.now().plusDays(1),
-//        LocalTime.now()
-//    );
-//
-//    mockMvc.perform(post(URI)
-//            .content(objectMapper.writeValueAsString(payload))
-//            .contentType(MediaType.APPLICATION_JSON)
-//            .with(csrf()))
-//        .andExpect(status().isBadRequest());
-//  }
-//
-//  @Test
-//  @WithMockUser(username = "admin", roles = {"ADMIN"})
-//  void shouldReturnBadRequestWhenFrequencyDaysIsNull() throws Exception {
-//    var payload = new CreateAppointmentDTO(
-//        UUID.randomUUID(),
-//        UUID.randomUUID(),
-//        UUID.randomUUID(),
-//        null,
-//        LocalDate.now().plusDays(1),
-//        LocalTime.now()
-//    );
-//
-//    mockMvc.perform(post(URI)
-//            .content(objectMapper.writeValueAsString(payload))
-//            .contentType(MediaType.APPLICATION_JSON)
-//            .with(csrf()))
-//        .andExpect(status().isBadRequest());
-//  }
-//
+  @Test
+  @WithMockUser(username = "admin", roles = {"ADMIN"})
+  void shouldReturnBadRequestWhenProfessionalIdIsNull() throws Exception {
+    var payload = new CreateAppointmentDTO(
+        UUID.randomUUID(),
+        null,
+        7,
+        LocalDate.now().plusDays(1),
+        LocalTime.now()
+    );
+
+    mockMvc.perform(post(URI)
+            .content(objectMapper.writeValueAsString(payload))
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(csrf()))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser(username = "admin", roles = {"ADMIN"})
+  void shouldReturnBadRequestWhenServiceIdIsNull() throws Exception {
+    var payload = new CreateAppointmentDTO(
+            UUID.randomUUID(),
+            null,
+            7,
+            LocalDate.now().plusDays(1),
+            LocalTime.now()
+    );
+
+    mockMvc.perform(post(URI)
+            .content(objectMapper.writeValueAsString(payload))
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(csrf()))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser(username = "admin", roles = {"ADMIN"})
+  void shouldReturnBadRequestWhenPatientIdIsNull() throws Exception {
+    var payload = new CreateAppointmentDTO(
+            UUID.randomUUID(),
+            null,
+            7,
+            LocalDate.now().plusDays(1),
+            LocalTime.now()
+    );
+
+    mockMvc.perform(post(URI)
+            .content(objectMapper.writeValueAsString(payload))
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(csrf()))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser(username = "admin", roles = {"ADMIN"})
+  void shouldReturnBadRequestWhenFrequencyDaysIsNull() throws Exception {
+    var payload = new CreateAppointmentDTO(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            null,
+            LocalDate.now().plusDays(1),
+            LocalTime.now()
+    );
+
+    mockMvc.perform(post(URI)
+            .content(objectMapper.writeValueAsString(payload))
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(csrf()))
+        .andExpect(status().isBadRequest());
+  }
+
 //  @Test
 //  @WithMockUser(username = "admin", roles = {"ADMIN"})
 //  void shouldReturnBadRequestWhenFrequencyDaysIsZeroOrNegative() throws Exception {

--- a/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
@@ -3,6 +3,7 @@ import br.org.apae.api.appointment.application.interfaces.AppointmentApplication
 import br.org.apae.api.appointment.application.internal.AppointmentApplicationServiceImpl;
 import br.org.apae.api.appointment.domain.exceptions.AppointmentAlreadyCancelledException;
 import br.org.apae.api.appointment.domain.exceptions.AppointmentNotFoundException;
+import br.org.apae.api.appointment.domain.model.GeneratedAppointment;
 import br.org.apae.api.auth.application.internal.UserService;
 import br.org.apae.api.auth.infrastructure.security.JwtProvider;
 import br.org.apae.api.common.dto.appointment.request.appointment.CancelGeneratedAppointmentDTO;
@@ -78,6 +79,20 @@ class AppointmentControllerImplTest {
     );
   }
 
+  private GeneratedAppointmentResponseDTO createGeneratedAppointmentDTO(UUID id, LocalDateTime scheduledDateTime, LocalDateTime effectiveDateTime) {
+    return new GeneratedAppointmentResponseDTO(
+            id,
+            UUID.randomUUID(),
+            scheduledDateTime,
+            null,
+            false,
+            false,
+            null,
+            UUID.randomUUID(),
+            effectiveDateTime
+    );
+  }
+
   @Test
   @WithMockUser(username = "admin", roles = {"ADMIN"})
   void shouldCreateAppointmentSuccessfully() throws Exception {
@@ -118,85 +133,70 @@ class AppointmentControllerImplTest {
       .andExpect(jsonPath("$.creationDate").value(response.creationDate().toString()));
   }
 
-//  @Test
-//  @WithMockUser(username = "admin", roles = {"ADMIN"})
-//  void shouldDeleteAppointmentSuccessfully() throws Exception {
-//    UUID id = UUID.randomUUID();
-//
-//    mockMvc.perform(delete(URI_WITH_ID, id)
-//            .with(csrf()))
-//        .andExpect(status().isNoContent());
-//
-//    verify(service, times(1)).delete(id);
-//  }
-//
-//  @Test
-//  @WithMockUser(username = "admin", roles = {"ADMIN"})
-//  void shouldRescheduleAppointmentSuccessfully() throws Exception {
-//    UUID id = UUID.randomUUID();
-//    var payload = new RescheduleGeneratedAppointmentDTO(LocalDateTime.now().withNano(0));
-//
-//    GeneratedAppointmentResponseDTO response = new GeneratedAppointmentResponseDTO(
-//        id,
-//        UUID.randomUUID(),
-//        payload.newDateTime(),
-//        null,
-//        false,
-//        false,
-//        null,
-//        UUID.randomUUID(),
-//        LocalDateTime.now().withNano(0)
-//    );
-//    when(service.reschedule(id, payload.newDateTime())).thenReturn(response);
-//
-//    mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/reschedule", id)
-//        .contentType(MediaType.APPLICATION_JSON)
-//        .content(objectMapper.writeValueAsString(payload))
-//        .with(csrf()))
-//      .andExpect(status().isOk())
-//      .andExpect(jsonPath("$.id").value(response.id().toString()))
-//      .andExpect(jsonPath("$.appointmentId").value(response.appointmentId().toString()))
-//      .andExpect(jsonPath("$.scheduledDateTime").value(response.scheduledDateTime().toString()))
-//      .andExpect(jsonPath("$.overriddenDateTime").isEmpty())
-//      .andExpect(jsonPath("$.performed").isBoolean())
-//      .andExpect(jsonPath("$.cancelled").isBoolean())
-//      .andExpect(jsonPath("$.cancellationReason").isEmpty())
-//      .andExpect(jsonPath("$.patientId").value(response.patientId().toString()))
-//      .andExpect(jsonPath("$.effectiveDateTime").value(response.effectiveDateTime().toString()));
-//  }
-//
-//  @Test
-//  @WithMockUser(username = "admin", roles = {"ADMIN"})
-//  void shouldPerformedAppointmentSuccessfully() throws Exception {
-//    UUID id = UUID.randomUUID();
-//    var response = new GeneratedAppointmentResponseDTO(
-//        id,
-//        UUID.randomUUID(),
-//        null,
-//        null,
-//        true,
-//        false,
-//        null,
-//        UUID.randomUUID(),
-//        LocalDateTime.now().withNano(0)
-//    );
-//
-//    when(service.markAsPerformed(id)).thenReturn(response);
-//
-//    mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/performed", id)
-//            .with(csrf()))
-//        .andExpect(status().isOk())
-//        .andExpect(jsonPath("$.id").value(response.id().toString()))
-//        .andExpect(jsonPath("$.appointmentId").value(response.appointmentId().toString()))
-//        .andExpect(jsonPath("$.scheduledDateTime").isEmpty())
-//        .andExpect(jsonPath("$.overriddenDateTime").isEmpty())
-//        .andExpect(jsonPath("$.performed").value(response.performed()))
-//        .andExpect(jsonPath("$.cancelled").value(response.cancelled()))
-//        .andExpect(jsonPath("$.cancellationReason").isEmpty())
-//        .andExpect(jsonPath("$.patientId").value(response.patientId().toString()))
-//        .andExpect(jsonPath("$.effectiveDateTime").value(response.effectiveDateTime().toString()));
-//  }
-//
+  @Test
+  @WithMockUser(username = "admin", roles = {"ADMIN"})
+  void shouldDeleteAppointmentSuccessfully() throws Exception {
+    UUID id = UUID.randomUUID();
+
+    mockMvc.perform(delete(URI_WITH_ID, id)
+            .with(csrf()))
+        .andExpect(status().isNoContent());
+
+    verify(service, times(1)).delete(id);
+  }
+
+  @Test
+  @WithMockUser(username = "admin", roles = {"ADMIN"})
+  void shouldRescheduleAppointmentSuccessfully() throws Exception {
+    UUID id = UUID.randomUUID();
+    LocalDateTime scheduledDateTime = LocalDateTime.now().withNano(0);
+    LocalDateTime effectiveDateTime = LocalDateTime.now().withNano(0);
+    GeneratedAppointmentResponseDTO response = createGeneratedAppointmentDTO(id, scheduledDateTime, effectiveDateTime);
+
+    LocalDateTime localDateTime = LocalDateTime.now().withNano(0);
+    var payload = new RescheduleGeneratedAppointmentDTO(localDateTime);
+
+    when(service.reschedule(id, payload.newDateTime())).thenReturn(response);
+
+    mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/reschedule", id)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(payload))
+        .with(csrf()))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.id").value(response.id().toString()))
+      .andExpect(jsonPath("$.appointmentId").value(response.appointmentId().toString()))
+      .andExpect(jsonPath("$.scheduledDateTime").value(response.scheduledDateTime().toString()))
+      .andExpect(jsonPath("$.overriddenDateTime").isEmpty())
+      .andExpect(jsonPath("$.performed").isBoolean())
+      .andExpect(jsonPath("$.cancelled").isBoolean())
+      .andExpect(jsonPath("$.cancellationReason").isEmpty())
+      .andExpect(jsonPath("$.patientId").value(response.patientId().toString()))
+      .andExpect(jsonPath("$.effectiveDateTime").value(response.effectiveDateTime().toString()));
+  }
+
+  @Test
+  @WithMockUser(username = "admin", roles = {"ADMIN"})
+  void shouldPerformedAppointmentSuccessfully() throws Exception {
+    UUID id = UUID.randomUUID();
+    LocalDateTime effectiveDateTime = LocalDateTime.now().withNano(0);
+    var response = createGeneratedAppointmentDTO(id, null, effectiveDateTime);
+
+    when(service.markAsPerformed(id)).thenReturn(response);
+
+    mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/performed", id)
+            .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(response.id().toString()))
+        .andExpect(jsonPath("$.appointmentId").value(response.appointmentId().toString()))
+        .andExpect(jsonPath("$.scheduledDateTime").isEmpty())
+        .andExpect(jsonPath("$.overriddenDateTime").isEmpty())
+        .andExpect(jsonPath("$.performed").value(response.performed()))
+        .andExpect(jsonPath("$.cancelled").value(response.cancelled()))
+        .andExpect(jsonPath("$.cancellationReason").isEmpty())
+        .andExpect(jsonPath("$.patientId").value(response.patientId().toString()))
+        .andExpect(jsonPath("$.effectiveDateTime").value(response.effectiveDateTime().toString()));
+  }
+
 //  @Test
 //  @WithMockUser(username = "admin", roles = {"ADMIN"})
 //  void shouldCancelAppointmentSuccessfully() throws Exception {


### PR DESCRIPTION
# Resumo

Ajustei a suíte de testes do AppointmentController para refletir o contrato atual da API. Os testes foram atualizados para usar os DTOs vigentes, corrigindo incompatibilidades em AppointmentResponseDTO, TodayAppointmentsResponseDTO, CreateAppointmentDTO e UpdateAppointmentDTO, além de alinhar chamadas do mock com a assinatura atual do AppointmentApplicationService.

Também foram revisados os cenários essenciais da controller, com foco em fluxo feliz e erros mínimos relevantes. Foram adicionados ou ajustados testes para update, listTodayAppointment, getTodayAppointmentById e listByPatient, incluindo cenários de 404 Not Found quando aplicável.

## Importante

Para poder executar esses testes, é necessário comentar as outras classes de testes. Isso permite que o script `./mvnw` compile os testes e os execute com exito.
```bash
./mvnw test -Dtest=AppointmentControllerImplTest
```

<img width="2074" height="699" alt="image" src="https://github.com/user-attachments/assets/cfb5c61c-c269-4881-99c5-8923c20b620f" />
