### PR TITLE
[TEST] Reativar e atualizar testes do PatientRetrievalTests #781

### DIFF
--- a/apps/api/src/main/java/br/org/apae/api/patient/application/exceptions/PatientExceptionHandler.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/application/exceptions/PatientExceptionHandler.java
@@ -1,11 +1,5 @@
 package br.org.apae.api.patient.application.exceptions;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.annotation.ControllerAdvice;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-
 import br.org.apae.api.common.exceptions.types.ErrorResponse;
 import br.org.apae.api.patient.domain.exceptions.AnnualRegistryConflictException;
 import br.org.apae.api.patient.domain.exceptions.DisorderConflictException;
@@ -21,153 +15,225 @@ import br.org.apae.api.patient.domain.exceptions.VaccineConflictException;
 import br.org.apae.api.patient.domain.exceptions.VaccineMismatchException;
 import br.org.apae.api.patient.domain.exceptions.VaccineNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 
 @ControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
 public class PatientExceptionHandler {
+
   @ExceptionHandler(InvalidDataException.class)
-  public ResponseEntity<ErrorResponse> handleInvalidData(InvalidDataException ex, HttpServletRequest request) {
-    ErrorResponse error = new ErrorResponse(
-        HttpStatus.BAD_REQUEST.value(),
-        HttpStatus.BAD_REQUEST.getReasonPhrase(),
-        ex.getMessage(),
-        request.getRequestURI());
-    return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
-  }
-
-  @ExceptionHandler(PatientNotFoundException.class)
-  public ResponseEntity<ErrorResponse> handlePatientNotFound(PatientNotFoundException ex, HttpServletRequest request) {
-    ErrorResponse error = new ErrorResponse(
-        HttpStatus.NOT_FOUND.value(),
-        HttpStatus.NOT_FOUND.getReasonPhrase(),
-        ex.getMessage(),
-        request.getRequestURI());
-    return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
-  }
-
-  @ExceptionHandler(PatientConflictException.class)
-  public ResponseEntity<ErrorResponse> handlePatientConflict(PatientConflictException ex, HttpServletRequest request) {
-    ErrorResponse error = new ErrorResponse(
-        HttpStatus.CONFLICT.value(),
-        HttpStatus.CONFLICT.getReasonPhrase(),
-        ex.getMessage(),
-        request.getRequestURI());
-    return new ResponseEntity<>(error, HttpStatus.CONFLICT);
-  }
-
-  @ExceptionHandler(GuardianNotFoundException.class)
-  public ResponseEntity<ErrorResponse> handleGuardianNotFound(GuardianNotFoundException ex,
-      HttpServletRequest request) {
-    ErrorResponse error = new ErrorResponse(
-        HttpStatus.NOT_FOUND.value(),
-        HttpStatus.NOT_FOUND.getReasonPhrase(),
-        ex.getMessage(),
-        request.getRequestURI());
-    return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
-  }
-
-  @ExceptionHandler(ParentNotFoundException.class)
-  public ResponseEntity<ErrorResponse> handleParentNotFound(ParentNotFoundException ex, HttpServletRequest request) {
-    ErrorResponse error = new ErrorResponse(
-        HttpStatus.NOT_FOUND.value(),
-        HttpStatus.NOT_FOUND.getReasonPhrase(),
-        ex.getMessage(),
-        request.getRequestURI());
-    return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
-  }
-
-  @ExceptionHandler(ParentMismatchException.class)
-  public ResponseEntity<ErrorResponse> handleParentMismatch(ParentMismatchException ex, HttpServletRequest request) {
-    ErrorResponse error = new ErrorResponse(
-        HttpStatus.NOT_FOUND.value(),
-        HttpStatus.NOT_FOUND.getReasonPhrase(),
-        ex.getMessage(),
-        request.getRequestURI());
-    return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
-  }
-
-  @ExceptionHandler(VaccineNotFoundException.class)
-  public ResponseEntity<ErrorResponse> handleVaccineNotFound(VaccineNotFoundException ex, HttpServletRequest request) {
-    ErrorResponse error = new ErrorResponse(
-        HttpStatus.NOT_FOUND.value(),
-        HttpStatus.NOT_FOUND.getReasonPhrase(),
-        ex.getMessage(),
-        request.getRequestURI());
-    return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
-  }
-
-  @ExceptionHandler(VaccineMismatchException.class)
-  public ResponseEntity<ErrorResponse> handleVaccineMismatch(VaccineMismatchException ex, HttpServletRequest request) {
-    ErrorResponse error = new ErrorResponse(
-        HttpStatus.NOT_FOUND.value(),
-        HttpStatus.NOT_FOUND.getReasonPhrase(),
-        ex.getMessage(),
-        request.getRequestURI());
-    return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
-  }
-
-  @ExceptionHandler(VaccineConflictException.class)
-  public ResponseEntity<ErrorResponse> handleVaccineConflict(VaccineConflictException ex, HttpServletRequest request) {
-    ErrorResponse error = new ErrorResponse(
-        HttpStatus.CONFLICT.value(),
-        HttpStatus.CONFLICT.getReasonPhrase(),
-        ex.getMessage(),
-        request.getRequestURI());
-    return new ResponseEntity<>(error, HttpStatus.CONFLICT);
-  }
-
-  @ExceptionHandler(DisorderConflictException.class)
-  public ResponseEntity<ErrorResponse> handleDisorderConflict(DisorderConflictException ex,
-      HttpServletRequest request) {
-    ErrorResponse error = new ErrorResponse(
-        HttpStatus.CONFLICT.value(),
-        HttpStatus.CONFLICT.getReasonPhrase(),
-        ex.getMessage(),
-        request.getRequestURI());
-    return new ResponseEntity<>(error, HttpStatus.CONFLICT);
-  }
-
-  @ExceptionHandler(DisorderNotFoundException.class)
-  public ResponseEntity<ErrorResponse> handleDisorderNotFound(DisorderNotFoundException ex,
-      HttpServletRequest request) {
-    ErrorResponse error = new ErrorResponse(
-        HttpStatus.CONFLICT.value(),
-        HttpStatus.CONFLICT.getReasonPhrase(),
-        ex.getMessage(),
-        request.getRequestURI());
-    return new ResponseEntity<>(error, HttpStatus.CONFLICT);
-  }
-
-  @ExceptionHandler(DisorderMismatchException.class)
-  public ResponseEntity<ErrorResponse> handleDisorderMismatch(DisorderMismatchException ex,
-      HttpServletRequest request) {
-    ErrorResponse error = new ErrorResponse(
-        HttpStatus.NOT_FOUND.value(),
-        HttpStatus.NOT_FOUND.getReasonPhrase(),
-        ex.getMessage(),
-        request.getRequestURI());
-    return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
-  }
-
-  @ExceptionHandler(AnnualRegistryConflictException.class)
-  public ResponseEntity<ErrorResponse> handleDisorderMismatch(AnnualRegistryConflictException ex,
-      HttpServletRequest request) {
-    ErrorResponse error = new ErrorResponse(
-        HttpStatus.CONFLICT.value(),
-        HttpStatus.CONFLICT.getReasonPhrase(),
-        ex.getMessage(),
-        request.getRequestURI());
-    return new ResponseEntity<>(error, HttpStatus.CONFLICT);
-  }
-
-  @ExceptionHandler(MethodArgumentNotValidException.class)
-  public ResponseEntity<ErrorResponse> handleArgumentNotValidException(MethodArgumentNotValidException ex,
-                                                                       HttpServletRequest request) {
+  public ResponseEntity<ErrorResponse> handleInvalidData(
+          InvalidDataException ex,
+          HttpServletRequest request
+  ) {
     ErrorResponse error = new ErrorResponse(
             HttpStatus.BAD_REQUEST.value(),
             HttpStatus.BAD_REQUEST.getReasonPhrase(),
             ex.getMessage(),
             request.getRequestURI()
     );
+
+    return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler(PatientNotFoundException.class)
+  public ResponseEntity<ErrorResponse> handlePatientNotFound(
+          PatientNotFoundException ex,
+          HttpServletRequest request
+  ) {
+    ErrorResponse error = new ErrorResponse(
+            HttpStatus.NOT_FOUND.value(),
+            HttpStatus.NOT_FOUND.getReasonPhrase(),
+            ex.getMessage(),
+            request.getRequestURI()
+    );
+
+    return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(PatientConflictException.class)
+  public ResponseEntity<ErrorResponse> handlePatientConflict(
+          PatientConflictException ex,
+          HttpServletRequest request
+  ) {
+    ErrorResponse error = new ErrorResponse(
+            HttpStatus.CONFLICT.value(),
+            HttpStatus.CONFLICT.getReasonPhrase(),
+            ex.getMessage(),
+            request.getRequestURI()
+    );
+
+    return new ResponseEntity<>(error, HttpStatus.CONFLICT);
+  }
+
+  @ExceptionHandler(GuardianNotFoundException.class)
+  public ResponseEntity<ErrorResponse> handleGuardianNotFound(
+          GuardianNotFoundException ex,
+          HttpServletRequest request
+  ) {
+    ErrorResponse error = new ErrorResponse(
+            HttpStatus.NOT_FOUND.value(),
+            HttpStatus.NOT_FOUND.getReasonPhrase(),
+            ex.getMessage(),
+            request.getRequestURI()
+    );
+
+    return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(ParentNotFoundException.class)
+  public ResponseEntity<ErrorResponse> handleParentNotFound(
+          ParentNotFoundException ex,
+          HttpServletRequest request
+  ) {
+    ErrorResponse error = new ErrorResponse(
+            HttpStatus.NOT_FOUND.value(),
+            HttpStatus.NOT_FOUND.getReasonPhrase(),
+            ex.getMessage(),
+            request.getRequestURI()
+    );
+
+    return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(ParentMismatchException.class)
+  public ResponseEntity<ErrorResponse> handleParentMismatch(
+          ParentMismatchException ex,
+          HttpServletRequest request
+  ) {
+    ErrorResponse error = new ErrorResponse(
+            HttpStatus.NOT_FOUND.value(),
+            HttpStatus.NOT_FOUND.getReasonPhrase(),
+            ex.getMessage(),
+            request.getRequestURI()
+    );
+
+    return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(VaccineNotFoundException.class)
+  public ResponseEntity<ErrorResponse> handleVaccineNotFound(
+          VaccineNotFoundException ex,
+          HttpServletRequest request
+  ) {
+    ErrorResponse error = new ErrorResponse(
+            HttpStatus.NOT_FOUND.value(),
+            HttpStatus.NOT_FOUND.getReasonPhrase(),
+            ex.getMessage(),
+            request.getRequestURI()
+    );
+
+    return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(VaccineMismatchException.class)
+  public ResponseEntity<ErrorResponse> handleVaccineMismatch(
+          VaccineMismatchException ex,
+          HttpServletRequest request
+  ) {
+    ErrorResponse error = new ErrorResponse(
+            HttpStatus.NOT_FOUND.value(),
+            HttpStatus.NOT_FOUND.getReasonPhrase(),
+            ex.getMessage(),
+            request.getRequestURI()
+    );
+
+    return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(VaccineConflictException.class)
+  public ResponseEntity<ErrorResponse> handleVaccineConflict(
+          VaccineConflictException ex,
+          HttpServletRequest request
+  ) {
+    ErrorResponse error = new ErrorResponse(
+            HttpStatus.CONFLICT.value(),
+            HttpStatus.CONFLICT.getReasonPhrase(),
+            ex.getMessage(),
+            request.getRequestURI()
+    );
+
+    return new ResponseEntity<>(error, HttpStatus.CONFLICT);
+  }
+
+  @ExceptionHandler(DisorderConflictException.class)
+  public ResponseEntity<ErrorResponse> handleDisorderConflict(
+          DisorderConflictException ex,
+          HttpServletRequest request
+  ) {
+    ErrorResponse error = new ErrorResponse(
+            HttpStatus.CONFLICT.value(),
+            HttpStatus.CONFLICT.getReasonPhrase(),
+            ex.getMessage(),
+            request.getRequestURI()
+    );
+
+    return new ResponseEntity<>(error, HttpStatus.CONFLICT);
+  }
+
+  @ExceptionHandler(DisorderNotFoundException.class)
+  public ResponseEntity<ErrorResponse> handleDisorderNotFound(
+          DisorderNotFoundException ex,
+          HttpServletRequest request
+  ) {
+    ErrorResponse error = new ErrorResponse(
+            HttpStatus.NOT_FOUND.value(),
+            HttpStatus.NOT_FOUND.getReasonPhrase(),
+            ex.getMessage(),
+            request.getRequestURI()
+    );
+
+    return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(DisorderMismatchException.class)
+  public ResponseEntity<ErrorResponse> handleDisorderMismatch(
+          DisorderMismatchException ex,
+          HttpServletRequest request
+  ) {
+    ErrorResponse error = new ErrorResponse(
+            HttpStatus.NOT_FOUND.value(),
+            HttpStatus.NOT_FOUND.getReasonPhrase(),
+            ex.getMessage(),
+            request.getRequestURI()
+    );
+
+    return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(AnnualRegistryConflictException.class)
+  public ResponseEntity<ErrorResponse> handleAnnualRegistryConflict(
+          AnnualRegistryConflictException ex,
+          HttpServletRequest request
+  ) {
+    ErrorResponse error = new ErrorResponse(
+            HttpStatus.CONFLICT.value(),
+            HttpStatus.CONFLICT.getReasonPhrase(),
+            ex.getMessage(),
+            request.getRequestURI()
+    );
+
+    return new ResponseEntity<>(error, HttpStatus.CONFLICT);
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ErrorResponse> handleArgumentNotValidException(
+          MethodArgumentNotValidException ex,
+          HttpServletRequest request
+  ) {
+    ErrorResponse error = new ErrorResponse(
+            HttpStatus.BAD_REQUEST.value(),
+            HttpStatus.BAD_REQUEST.getReasonPhrase(),
+            ex.getMessage(),
+            request.getRequestURI()
+    );
+
     return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
   }
 }

--- a/apps/api/src/test/java/br/org/apae/api/controllers/patient/PatientRetrievalTests.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/patient/PatientRetrievalTests.java
@@ -1,4 +1,4 @@
-/*package br.org.apae.api.controllers.patient;
+package br.org.apae.api.controllers.patient;
 
 import br.org.apae.api.auth.application.internal.UserService;
 import br.org.apae.api.auth.infrastructure.security.JwtProvider;
@@ -6,12 +6,13 @@ import br.org.apae.api.common.dto.patient.response.disorder.DisorderResponseDTO;
 import br.org.apae.api.common.dto.patient.response.patient.PatientResponseDTO;
 import br.org.apae.api.common.dto.patient.response.patient.PatientSummaryResponseDTO;
 import br.org.apae.api.common.dto.servicearea.response.ServiceAreaResponseDTO;
+import br.org.apae.api.controllers.patient.mocks.patient.PatientCreator;
+import br.org.apae.api.patient.application.exceptions.PatientExceptionHandler;
 import br.org.apae.api.patient.application.interfaces.AnnualRegistryApplicationService;
 import br.org.apae.api.patient.application.interfaces.DisorderApplicationService;
 import br.org.apae.api.patient.application.interfaces.PatientApplicationService;
 import br.org.apae.api.patient.domain.exceptions.PatientNotFoundException;
 import br.org.apae.api.servicearea.application.interfaces.ServiceAreaApplicationService;
-import br.org.apae.api.controllers.patient.mocks.patient.PatientCreator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Tags;
@@ -20,10 +21,15 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
 import java.util.List;
 import java.util.Map;
@@ -31,7 +37,8 @@ import java.util.UUID;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -43,7 +50,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         @Tag("patient")
 })
 @WebMvcTest(PatientControllerImpl.class)
+@Import(PatientExceptionHandler.class)
 public class PatientRetrievalTests {
+
     @Autowired
     private MockMvc mockMvc;
 
@@ -130,7 +139,11 @@ public class PatientRetrievalTests {
         UUID randomId = UUID.randomUUID();
 
         when(patientService.findPatientById(randomId))
-                .thenThrow(PatientNotFoundException.class);
+                .thenThrow(new PatientNotFoundException());
+        mockMvc.perform(get("/patients/{id}", randomId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isNotFound());
 
         mockMvc.perform(get("/patients/{id}", randomId)
                         .contentType(MediaType.APPLICATION_JSON))
@@ -138,42 +151,51 @@ public class PatientRetrievalTests {
     }
 
     @Test
-    @DisplayName("Should return all patients (no filters provided)")
+    @DisplayName("Should return all patients when no filter provided")
     @WithMockUser(username = "admin", roles = {"ADMIN"})
     void shouldReturnAllPatientsWhenNoFilterProvided() throws Exception {
-        List<PatientSummaryResponseDTO> list = List.of(PatientCreator.createSummaryResponse());
-        when(patientService.findPatientByFilter(anyMap())).thenReturn(list);
+        PatientSummaryResponseDTO patient = PatientCreator.createSummaryResponse();
+
+        Page<PatientSummaryResponseDTO> page = new PageImpl<>(
+                List.of(patient),
+                PageRequest.of(0, 10),
+                1
+        );
+
+        when(patientService.findPatientByFilter(anyMap(), any()))
+                .thenReturn(page);
 
         mockMvc.perform(get("/patients")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].id").value(list.getFirst().id().toString()))
-                .andExpect(jsonPath("$[0].fullName").value("João da Silva"))
-                .andExpect(jsonPath("$[0].birthplace").value("Campina Grande"))
-                .andExpect(jsonPath("$[0].birthDate").value("2010-01-01"))
-                .andExpect(jsonPath("$[0].contact").value("8399999999"))
-                .andExpect(jsonPath("$[0].birthCertificateNumber").value("123456"))
-                .andExpect(jsonPath("$[0].registryOffice").value("Cartório X"))
-                .andExpect(jsonPath("$[0].fls").value("10"))
-                .andExpect(jsonPath("$[0].book").value("A"))
-                .andExpect(jsonPath("$[0].rg").value("123456"))
-                .andExpect(jsonPath("$[0].issueDate").value("2015-01-01"))
-                .andExpect(jsonPath("$[0].issuingAgency").value("SSP/PB"))
-                .andExpect(jsonPath("$[0].cpf").value("000.000.000-00"))
-                .andExpect(jsonPath("$[0].cns").value("123456789"))
-                .andExpect(jsonPath("$[0].nis").value("12345"))
-                .andExpect(jsonPath("$[0].registrationDate").value(list.getFirst().registrationDate().toString()))
-                .andExpect(jsonPath("$[0].allergies").value("Nenhuma"))
-                .andExpect(jsonPath("$[0].isStudent").value(true))
-                .andExpect(jsonPath("$[0].isDeleted").value(false))
-                .andExpect(jsonPath("$[0].photoUrl").value("http://url-foto.com"))
-                .andExpect(jsonPath("$[0].address.cep").value("58000-000"))
-                .andExpect(jsonPath("$[0].address.city").value("Campina Grande"))
-                .andExpect(jsonPath("$[0].address.state").value("PB"))
-                .andExpect(jsonPath("$[0].address.neighborhood").value("Centro"))
-                .andExpect(jsonPath("$[0].address.street").value("Rua X"))
-                .andExpect(jsonPath("$[0].address.number").value("123"))
-                .andExpect(jsonPath("$[0].address.complement").value("Apt 1"));
+                .andExpect(jsonPath("$.content", hasSize(1)))
+                .andExpect(jsonPath("$.content[0].id").value(patient.id().toString()))
+                .andExpect(jsonPath("$.content[0].fullName").value("João da Silva"))
+                .andExpect(jsonPath("$.content[0].birthplace").value("Campina Grande"))
+                .andExpect(jsonPath("$.content[0].birthDate").value("2010-01-01"))
+                .andExpect(jsonPath("$.content[0].contact").value("8399999999"))
+                .andExpect(jsonPath("$.content[0].birthCertificateNumber").value("123456"))
+                .andExpect(jsonPath("$.content[0].registryOffice").value("Cartório X"))
+                .andExpect(jsonPath("$.content[0].fls").value("10"))
+                .andExpect(jsonPath("$.content[0].book").value("A"))
+                .andExpect(jsonPath("$.content[0].rg").value("123456"))
+                .andExpect(jsonPath("$.content[0].issueDate").value("2015-01-01"))
+                .andExpect(jsonPath("$.content[0].issuingAgency").value("SSP/PB"))
+                .andExpect(jsonPath("$.content[0].cpf").value("000.000.000-00"))
+                .andExpect(jsonPath("$.content[0].cns").value("123456789"))
+                .andExpect(jsonPath("$.content[0].nis").value("12345"))
+                .andExpect(jsonPath("$.content[0].registrationDate").value(patient.registrationDate().toString()))
+                .andExpect(jsonPath("$.content[0].allergies").value("Nenhuma"))
+                .andExpect(jsonPath("$.content[0].isStudent").value(true))
+                .andExpect(jsonPath("$.content[0].isDeleted").value(false))
+                .andExpect(jsonPath("$.content[0].photoUrl").value("http://url-foto.com"))
+                .andExpect(jsonPath("$.content[0].address.cep").value("58000-000"))
+                .andExpect(jsonPath("$.content[0].address.city").value("Campina Grande"))
+                .andExpect(jsonPath("$.content[0].address.state").value("PB"))
+                .andExpect(jsonPath("$.content[0].address.neighborhood").value("Centro"))
+                .andExpect(jsonPath("$.content[0].address.street").value("Rua X"))
+                .andExpect(jsonPath("$.content[0].address.number").value("123"))
+                .andExpect(jsonPath("$.content[0].address.complement").value("Apt 1"));
     }
 
     @Test
@@ -181,17 +203,18 @@ public class PatientRetrievalTests {
     @WithMockUser(username = "admin", roles = {"ADMIN"})
     void shouldPassNameFilterToService() throws Exception {
         String nomeBusca = "João";
-        when(patientService.findPatientByFilter(anyMap())).thenReturn(List.of());
+
+        when(patientService.findPatientByFilter(anyMap(), any()))
+                .thenReturn(Page.empty());
 
         mockMvc.perform(get("/patients")
                         .param("name", nomeBusca)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
 
-        verify(patientService).findPatientByFilter(filtersCaptor.capture());
-        Map<String, String> filtrosCapturados = filtersCaptor.getValue();
+        verify(patientService).findPatientByFilter(filtersCaptor.capture(), any());
 
-        assertEquals(nomeBusca, filtrosCapturados.get("name"));
+        assertEquals(nomeBusca, filtersCaptor.getValue().get("name"));
     }
 
     @Test
@@ -199,14 +222,17 @@ public class PatientRetrievalTests {
     @WithMockUser(username = "admin", roles = {"ADMIN"})
     void shouldPassCityFilterToService() throws Exception {
         String cidade = "Campina";
-        when(patientService.findPatientByFilter(anyMap())).thenReturn(List.of());
+
+        when(patientService.findPatientByFilter(anyMap(), any()))
+                .thenReturn(Page.empty());
 
         mockMvc.perform(get("/patients")
                         .param("city", cidade)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
 
-        verify(patientService).findPatientByFilter(filtersCaptor.capture());
+        verify(patientService).findPatientByFilter(filtersCaptor.capture(), any());
+
         assertEquals(cidade, filtersCaptor.getValue().get("city"));
     }
 
@@ -215,14 +241,17 @@ public class PatientRetrievalTests {
     @WithMockUser(username = "admin", roles = {"ADMIN"})
     void shouldPassDisorderFilterToService() throws Exception {
         String transtorno = "Autista";
-        when(patientService.findPatientByFilter(anyMap())).thenReturn(List.of());
+
+        when(patientService.findPatientByFilter(anyMap(), any()))
+                .thenReturn(Page.empty());
 
         mockMvc.perform(get("/patients")
                         .param("disorder", transtorno)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
 
-        verify(patientService).findPatientByFilter(filtersCaptor.capture());
+        verify(patientService).findPatientByFilter(filtersCaptor.capture(), any());
+
         assertEquals(transtorno, filtersCaptor.getValue().get("disorder"));
     }
 
@@ -231,14 +260,17 @@ public class PatientRetrievalTests {
     @WithMockUser(username = "admin", roles = {"ADMIN"})
     void shouldPassYearFilterToService() throws Exception {
         String ano = "2024";
-        when(patientService.findPatientByFilter(anyMap())).thenReturn(List.of());
+
+        when(patientService.findPatientByFilter(anyMap(), any()))
+                .thenReturn(Page.empty());
 
         mockMvc.perform(get("/patients")
                         .param("year", ano)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
 
-        verify(patientService).findPatientByFilter(filtersCaptor.capture());
+        verify(patientService).findPatientByFilter(filtersCaptor.capture(), any());
+
         assertEquals(ano, filtersCaptor.getValue().get("year"));
     }
 
@@ -247,14 +279,17 @@ public class PatientRetrievalTests {
     @WithMockUser(username = "admin", roles = {"ADMIN"})
     void shouldPassTreatmentTypeFilterToService() throws Exception {
         String tipo = "Fisioterapia";
-        when(patientService.findPatientByFilter(anyMap())).thenReturn(List.of());
+
+        when(patientService.findPatientByFilter(anyMap(), any()))
+                .thenReturn(Page.empty());
 
         mockMvc.perform(get("/patients")
                         .param("treatmentType", tipo)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
 
-        verify(patientService).findPatientByFilter(filtersCaptor.capture());
+        verify(patientService).findPatientByFilter(filtersCaptor.capture(), any());
+
         assertEquals(tipo, filtersCaptor.getValue().get("treatmentType"));
     }
 
@@ -262,12 +297,20 @@ public class PatientRetrievalTests {
     @DisplayName("Should list available disorder names for filtering")
     @WithMockUser(username = "admin", roles = {"ADMIN"})
     void shouldListAvailableDisordersForFilter() throws Exception {
-        DisorderResponseDTO tea = new DisorderResponseDTO(UUID.randomUUID(), "TEA");
-        DisorderResponseDTO tdah = new DisorderResponseDTO(UUID.randomUUID(), "TDAH");
+        DisorderResponseDTO tea = new DisorderResponseDTO(
+                UUID.randomUUID(),
+                "TEA",
+                true
+        );
 
-        List<DisorderResponseDTO> listaDoService = List.of(tea, tdah);
+        DisorderResponseDTO tdah = new DisorderResponseDTO(
+                UUID.randomUUID(),
+                "TDAH",
+                true
+        );
 
-        when(disorderApplicationService.findAllDisorders()).thenReturn(listaDoService);
+        when(disorderApplicationService.findAllDisorders())
+                .thenReturn(List.of(tea, tdah));
 
         mockMvc.perform(get("/patients/filtros/transtornos")
                         .contentType(MediaType.APPLICATION_JSON))
@@ -281,8 +324,8 @@ public class PatientRetrievalTests {
     @DisplayName("Should list available years for filtering")
     @WithMockUser(username = "admin", roles = {"ADMIN"})
     void shouldListAvailableYearsForFilter() throws Exception {
-        List<String> mockData = List.of("2024", "2025");
-        when(annualRegistryApplicationService.findAllRegistryYears()).thenReturn(mockData);
+        when(annualRegistryApplicationService.findAllRegistryYears())
+                .thenReturn(List.of("2024", "2025"));
 
         mockMvc.perform(get("/patients/filtros/anos"))
                 .andExpect(status().isOk())
@@ -295,8 +338,8 @@ public class PatientRetrievalTests {
     @DisplayName("Should list available cities for filtering")
     @WithMockUser(username = "admin", roles = {"ADMIN"})
     void shouldListAvailableCitiesForFilter() throws Exception {
-        List<String> mockData = List.of("Campina Grande", "Esperança");
-        when(patientService.findAllPatientCities()).thenReturn(mockData);
+        when(patientService.findAllPatientCities())
+                .thenReturn(List.of("Campina Grande", "Esperança"));
 
         mockMvc.perform(get("/patients/filtros/cidades"))
                 .andExpect(status().isOk())
@@ -306,11 +349,16 @@ public class PatientRetrievalTests {
     }
 
     @Test
-    @DisplayName("Should list available service areas ")
+    @DisplayName("Should list available service areas")
     @WithMockUser(username = "admin", roles = {"ADMIN"})
     void shouldListAvailableAllServiceArea() throws Exception {
-        List<ServiceAreaResponseDTO> mockData = List.of(new ServiceAreaResponseDTO(1, "Fisioterapia"), new ServiceAreaResponseDTO(2, "Nutrição"));
-        when(serviceAreaApplicationService.findAllServiceAreas()).thenReturn(mockData);
+        List<ServiceAreaResponseDTO> mockData = List.of(
+                new ServiceAreaResponseDTO(1, "Fisioterapia"),
+                new ServiceAreaResponseDTO(2, "Nutrição")
+        );
+
+        when(serviceAreaApplicationService.findAllServiceAreas())
+                .thenReturn(mockData);
 
         mockMvc.perform(get("/patients/filtros/tipos-atendimento"))
                 .andExpect(status().isOk())
@@ -323,8 +371,8 @@ public class PatientRetrievalTests {
     @DisplayName("Should remove blank filters before passing to service")
     @WithMockUser(username = "admin", roles = {"ADMIN"})
     void shouldRemoveBlankFilters() throws Exception {
-        when(patientService.findPatientByFilter(anyMap()))
-                .thenReturn(List.of());
+        when(patientService.findPatientByFilter(anyMap(), any()))
+                .thenReturn(Page.empty());
 
         mockMvc.perform(get("/patients")
                         .param("name", "   ")
@@ -332,11 +380,8 @@ public class PatientRetrievalTests {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
 
-        verify(patientService).findPatientByFilter(filtersCaptor.capture());
+        verify(patientService).findPatientByFilter(filtersCaptor.capture(), any());
 
-        Map<String, String> filtrosCapturados = filtersCaptor.getValue();
-
-        assertEquals(0, filtrosCapturados.size());
+        assertEquals(0, filtersCaptor.getValue().size());
     }
 }
-    */


### PR DESCRIPTION
# O que esse PR fornece?

* **Reativação do `PatientRetrievalTests`**: os testes anteriormente comentados foram descomentados e ajustados para voltar a compilar e executar corretamente com a implementação atual do controller.

* **Adequação à paginação (`Pageable`)**: atualização dos testes do método `findWithFilters` para refletir a nova assinatura baseada em `Page<PatientSummaryResponseDTO>`, incluindo o envio correto do parâmetro `Pageable` nas chamadas e mocks.

* **Correção dos mocks e validações**: substituição das validações antigas baseadas em `List` por verificações compatíveis com retorno paginado (`Page`), garantindo aderência ao comportamento atual da API.

* **Revisão dos testes de busca de pacientes**: manutenção e validação dos cenários relacionados à busca por ID e filtros de listagem, assegurando compatibilidade com as mudanças recentes do módulo de pacientes.

* **Padronização do tratamento de exceções**: integração das adaptações dos testes com o novo fluxo de tratamento de exceções do módulo de pacientes, mantendo consistência entre implementação e cobertura de testes.

---

# Coleta de evidências

Imagem anexada demonstrando sucesso na execução de todos os testes:

<img width="1920" height="1080" alt="Captura de tela de 2026-05-16 17-35-20" src="https://github.com/user-attachments/assets/a00f4019-3fb5-410d-a391-823d78b36857" />

---

# Critérios de Aceite

* [x] Os testes devem ser descomentados e compilar sem erros
* [x] Os testes de `findWithFilters` devem ser atualizados para refletir o retorno paginado (`Page`) e o parâmetro `Pageable`
* [x] Os demais testes de busca por ID e filtros de listagem devem ser revisados e mantidos caso estejam corretos
