### PR TITLE
776 test corrigir testes do annualregistrycontroller

### DIFF
--- a/apps/api/src/test/java/br/org/apae/api/controllers/annual_registry/AnnualRegistryControllerTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/annual_registry/AnnualRegistryControllerTest.java
@@ -5,6 +5,7 @@ import br.org.apae.api.auth.infrastructure.security.JwtProvider;
 import br.org.apae.api.auth.infrastructure.security.SecurityConfiguration;
 import br.org.apae.api.common.dto.patient.request.annual_registry.CreateAnnualRegistryDTO;
 import br.org.apae.api.common.dto.patient.request.annual_registry.ReplaceAnnualRegistryDTO;
+import br.org.apae.api.common.dto.patient.request.annual_registry.UpdateAnnualRegistryDTO;
 import br.org.apae.api.common.dto.patient.response.annual_registry.AnnualRegistryResponseDTO;
 import br.org.apae.api.common.exceptions.handler.GlobalExceptionHandler;
 import br.org.apae.api.helpers.AuthTestHelper;

--- a/apps/api/src/test/java/br/org/apae/api/controllers/annual_registry/AnnualRegistryControllerTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/annual_registry/AnnualRegistryControllerTest.java
@@ -217,7 +217,7 @@ public class AnnualRegistryControllerTest {
 
         mockMvc.perform(get(BASE_URL + "/{year}", patientId, year)
                         .header("Authorization", AuthTestHelper.bearerToken()))
-                .andExpect(status().isInternalServerError());
+                .andExpect(status().isNotFound());
     }
 
     @Test
@@ -233,13 +233,21 @@ public class AnnualRegistryControllerTest {
                         .header("Authorization", AuthTestHelper.bearerToken()))
                 .andExpect(status().isNotFound());
     }
-/*
+
     @Test
     @DisplayName("PATCH - Deve atualizar parcialmente registro com sucesso")
     void shouldUpdateRegistrySuccess() throws Exception {
         UUID patientId = UUID.randomUUID();
         UUID registryId = UUID.randomUUID();
-        UpdateAnnualRegistryDTO updateDto = new UpdateAnnualRegistryDTO(2025);
+
+        UpdateAnnualRegistryDTO updateDto = new UpdateAnnualRegistryDTO(
+                "987654",
+                "Doença Atualizada",
+                BigDecimal.valueOf(2500.00),
+                Year.of(2025),
+                Collections.emptySet()
+        );
+
         AnnualRegistryResponseDTO responseDto = createResponseDTO(patientId, 2025);
 
         when(annualRegistryService.updateRegistry(patientId, registryId, updateDto))
@@ -258,10 +266,17 @@ public class AnnualRegistryControllerTest {
     void shouldReturnConflictOnUpdateWithExistingYear() throws Exception {
         UUID patientId = UUID.randomUUID();
         UUID registryId = UUID.randomUUID();
-        UpdateAnnualRegistryDTO updateDto = new UpdateAnnualRegistryDTO(2025);
+
+        UpdateAnnualRegistryDTO updateDto = new UpdateAnnualRegistryDTO(
+                "987654",
+                "Doença Atualizada",
+                BigDecimal.valueOf(2500.00),
+                Year.of(2025),
+                Collections.emptySet()
+        );
 
         when(annualRegistryService.updateRegistry(patientId, registryId, updateDto))
-                .thenThrow(new AnnualRegistryConflictException(2025));
+                .thenThrow(new AnnualRegistryConflictException(Year.of(2025)));
 
         mockMvc.perform(patch(BASE_URL + "/{registryId}", patientId, registryId)
                         .header("Authorization", AuthTestHelper.bearerToken())
@@ -269,7 +284,31 @@ public class AnnualRegistryControllerTest {
                         .content(objectMapper.writeValueAsString(updateDto)))
                 .andExpect(status().isConflict());
     }
-*/
+
+    @Test
+    @DisplayName("PATCH - Deve retornar NotFound (404) ao tentar atualizar registro inexistente")
+    void shouldReturnNotFoundOnUpdateWhenRegistryDoesNotExist() throws Exception {
+        UUID patientId = UUID.randomUUID();
+        UUID registryId = UUID.randomUUID();
+
+        UpdateAnnualRegistryDTO updateDto = new UpdateAnnualRegistryDTO(
+                "987654",
+                "Doença Atualizada",
+                BigDecimal.valueOf(2500.00),
+                Year.of(2025),
+                Collections.emptySet()
+        );
+
+        when(annualRegistryService.updateRegistry(patientId, registryId, updateDto))
+                .thenThrow(new RegistryNotFoundException(registryId));
+
+        mockMvc.perform(patch(BASE_URL + "/{registryId}", patientId, registryId)
+                        .header("Authorization", AuthTestHelper.bearerToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateDto)))
+                .andExpect(status().isNotFound());
+    }
+
     @Test
     @DisplayName("PUT - Deve substituir registro totalmente com sucesso")
     void shouldReplaceRegistrySuccess() throws Exception {
@@ -302,7 +341,7 @@ public class AnnualRegistryControllerTest {
                         .header("Authorization", AuthTestHelper.bearerToken())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(replaceDto)))
-                .andExpect(status().isInternalServerError());
+                .andExpect(status().isNotFound());
     }
 
     @Test
@@ -331,7 +370,7 @@ public class AnnualRegistryControllerTest {
 
         mockMvc.perform(delete(BASE_URL + "/{registryId}", patientId, registryId)
                         .header("Authorization", AuthTestHelper.bearerToken()))
-                .andExpect(status().isInternalServerError());
+                .andExpect(status().isNotFound());
     }
 
     @Test


### PR DESCRIPTION
# Qual é o objetivo desta PR?

Esta Pull Request resolve inconsistências nos testes unitários do AnnualRegistryControllerImpl. O objetivo foi corrigir o mapeamento de exceções de domínio que estavam esperando erro 500 ao invés do correto (404), e garantir a cobertura de testes do endpoint updateRegistry que estava desativada.

# O que foi feito?

## Correção de Status HTTP (500 para 404) nos seguintes cenários:

- shouldReturnNotFoundWhenRegistryByYearDoesNotExist

- shouldReturnNotFoundWhenRegistryOwnershipFail

- shouldReturnNotFoundWhenDeleteNonExistent

## Reativação e Atualização dos Testes do updateRegistry:

- Testes comentados foram reativados.

- O mock do DTO foi atualizado para refletir a assinatura atual do UpdateAnnualRegistryDTO (com os atributos bpc, diseases, familyIncome, year e disorders).

- Adicionado teste cobrindo o cenário de sucesso (200 OK).

- Adicionado teste cobrindo o cenário de conflito de datas (409 Conflict).

- Criado um novo cenário de erro garantindo o retorno correto quando o registro não existe (404 Not Found).
