### PR TITLE
778 test ampliar cobertura de testes do healthprofessionalcontrollerimpl

### DIFF
--- a/apps/api/src/test/java/br/org/apae/api/controllers/mocks/professional/HealthProfessionalMockDto.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/mocks/professional/HealthProfessionalMockDto.java
@@ -16,64 +16,33 @@ import br.org.apae.api.common.dto.availability.request.CreateAvailabilityDTO;
 import br.org.apae.api.common.dto.servicearea.response.ServiceAreaResponseDTO;
 import br.org.apae.api.common.dto.availability.response.AvailabilityResponseDTO;
 
-
 public final class HealthProfessionalMockDto {
 
     private HealthProfessionalMockDto() {}
 
-    public static final UUID PROFESSIONAL_ID_1 =
-        UUID.fromString("11111111-1111-1111-1111-111111111111");
-
-    public static final UUID PROFESSIONAL_ID_2 =
-        UUID.fromString("22222222-2222-2222-2222-222222222222");
-
-    public static final UUID ADDRESS_ID_1 =
-        UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
-
-    public static final UUID ADDRESS_ID_2 =
-        UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    public static final UUID PROFESSIONAL_ID_1 = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    public static final UUID PROFESSIONAL_ID_2 = UUID.fromString("22222222-2222-2222-2222-222222222222");
+    public static final UUID ADDRESS_ID_1 = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    public static final UUID ADDRESS_ID_2 = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
     
     public static MockMultipartFile volunteerAgreementFile() {
-        return new MockMultipartFile(
-            "volunteerAgreement",
-            "volunteer-agreement.pdf",
-            MediaType.APPLICATION_PDF_VALUE,
-            "fake volunteer agreement content".getBytes()
-        );
+        return new MockMultipartFile("volunteerAgreement", "volunteer-agreement.pdf", MediaType.APPLICATION_PDF_VALUE, "fake volunteer agreement content".getBytes());
     }
 
     public static MockMultipartFile curriculumFile() {
-        return new MockMultipartFile(
-            "curriculum",
-            "curriculum.pdf",
-            MediaType.APPLICATION_PDF_VALUE,
-            "fake curriculum content".getBytes()
-        );
+        return new MockMultipartFile("curriculum", "curriculum.pdf", MediaType.APPLICATION_PDF_VALUE, "fake curriculum content".getBytes());
     }
 
     public static MockMultipartFile attachmentAnyFile() {
-        return new MockMultipartFile(
-            "attachmentAny",
-            "attachment.txt",
-            MediaType.TEXT_PLAIN_VALUE,
-            "optional attachment content".getBytes()
-        );
+        return new MockMultipartFile("attachmentAny", "attachment.txt", MediaType.TEXT_PLAIN_VALUE, "optional attachment content".getBytes());
     }
 
     public static CreateProfessionalDocumentsDTO createProfessionalDocumentsRequest() {
-        return new CreateProfessionalDocumentsDTO(
-            volunteerAgreementFile(),
-            curriculumFile(),
-            attachmentAnyFile()
-        );
+        return new CreateProfessionalDocumentsDTO(volunteerAgreementFile(), curriculumFile(), attachmentAnyFile());
     }
 
     public static CreateProfessionalDocumentsDTO createProfessionalDocumentsRequestWithoutOptional() {
-        return new CreateProfessionalDocumentsDTO(
-            volunteerAgreementFile(),
-            curriculumFile(),
-            null
-        );
+        return new CreateProfessionalDocumentsDTO(volunteerAgreementFile(), curriculumFile(), null);
     }
 
     public static CreateServiceAreaDTO createServiceAreaRequestPhysiotherapy() {
@@ -85,36 +54,22 @@ public final class HealthProfessionalMockDto {
     }
 
     public static ServiceAreaResponseDTO createServiceAreaResponsePhysiotherapy() {
-        return new ServiceAreaResponseDTO(
-            1,
-            "Fisioterapia"
-        );
+        return new ServiceAreaResponseDTO(1, "Fisioterapia");
     }
 
     public static ServiceAreaResponseDTO createServiceAreaResponsePsychology() {
-        return new ServiceAreaResponseDTO(
-            2,
-            "Psicologia"
-        );
+        return new ServiceAreaResponseDTO(2, "Psicologia");
     }
 
     public static CreateAddressDTO createAddressRequest() {
-        return new CreateAddressDTO(
-            "São Paulo",
-            "01000-000",
-            "SP",
-            "Centro",
-            "Rua A",
-            "123",
-            "Apto 10"
-        );
+        return new CreateAddressDTO("São Paulo", "01000-000", "SP", "Centro", "Rua A", "123", "Apto 10");
     }
 
     public static CreateHealthProfessionalDTO createHealthProfessionalRequest() {
         return new CreateHealthProfessionalDTO(
             createServiceAreaRequestPsychology(),
             "11999999999",
-            "CREFITO-12345",
+            "CRP-12345",
             "teste@apae.org.br",
             "João da Silva",
             "123456789",
@@ -122,54 +77,38 @@ public final class HealthProfessionalMockDto {
             List.of(
                 new CreateAvailabilityDTO("SEGUNDA", "MANHA"),
                 new CreateAvailabilityDTO("TERCA", "TARDE")
-            )
+            ),
+            "http://example.com/photo.jpg" // Adicionado o parâmetro faltante do CreateHealthProfessionalDTO
         );
     }
 
     public static AddressResponseDTO createAddressResponse1() {
-        return new AddressResponseDTO(
-            ADDRESS_ID_1,
-            "01000-000",
-            "São Paulo",
-            "SP",
-            "Centro",
-            "Rua A",
-            "123",
-            "Apto 10"
-        );
+        return new AddressResponseDTO(ADDRESS_ID_1, "01000-000", "São Paulo", "SP", "Centro", "Rua A", "123", "Apto 10");
     }
 
     public static AddressResponseDTO createAddressResponse2() {
-        return new AddressResponseDTO(
-            ADDRESS_ID_2,
-            "02000-000",
-            "São Paulo",
-            "SP",
-            "Santana",
-            "Rua B",
-            "456",
-            null
-        );
+        return new AddressResponseDTO(ADDRESS_ID_2, "02000-000", "São Paulo", "SP", "Santana", "Rua B", "456", null);
     }
 
-public static HealthProfessionalResponseDTO createProfessionalResponse1() {
-    return new HealthProfessionalResponseDTO(
-        PROFESSIONAL_ID_1,
-        "João da Silva",
-        "teste@apae.org.br",
-        "CREFITO-12345",
-        "123456789",
-        "11999999999",
-        "Fisioterapia",
-        true,
-        createAddressResponse1(),
-        createServiceAreaResponsePhysiotherapy(),
-        List.of(
-            new AvailabilityResponseDTO(UUID.randomUUID(), "SEGUNDA", "MANHA"),
-            new AvailabilityResponseDTO(UUID.randomUUID(), "TERCA", "TARDE")
-        )
-    );
-}
+    public static HealthProfessionalResponseDTO createProfessionalResponse1() {
+        return new HealthProfessionalResponseDTO(
+            PROFESSIONAL_ID_1,
+            "João da Silva",
+            "teste@apae.org.br",
+            "CREFITO-12345",
+            "123456789",
+            "11999999999",
+            "Fisioterapia",
+            true,
+            createAddressResponse1(),
+            createServiceAreaResponsePhysiotherapy(),
+            List.of(
+                new AvailabilityResponseDTO(UUID.randomUUID(), "SEGUNDA", "MANHA"),
+                new AvailabilityResponseDTO(UUID.randomUUID(), "TERCA", "TARDE")
+            ),
+            "http://example.com/photo1.jpg" // Adicionado o parâmetro faltante do HealthProfessionalResponseDTO
+        );
+    }
 
     public static HealthProfessionalResponseDTO createProfessionalResponse2() {
         return new HealthProfessionalResponseDTO(
@@ -183,7 +122,8 @@ public static HealthProfessionalResponseDTO createProfessionalResponse1() {
             true,
             createAddressResponse2(),
             createServiceAreaResponsePsychology(),
-            List.of()
+            List.of(),
+            null // Adicionado o parâmetro faltante (null) do HealthProfessionalResponseDTO
         );
     }
 

--- a/apps/api/src/test/java/br/org/apae/api/controllers/professional/HealthProfessionalControllerTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/professional/HealthProfessionalControllerTest.java
@@ -28,12 +28,23 @@ import org.springframework.test.web.servlet.MockMvc;
 import br.org.apae.api.auth.application.internal.UserService;
 import br.org.apae.api.auth.infrastructure.security.JwtProvider;
 import br.org.apae.api.auth.infrastructure.security.SecurityConfiguration;
+import br.org.apae.api.common.dto.professional.request.UpdateHealthProfessionalDTO;
+import br.org.apae.api.common.dto.professional.request.documents.UpdateProfessionalDocumentsDTO;
 import br.org.apae.api.common.dto.professional.request.CreateHealthProfessionalDTO;
 import br.org.apae.api.common.dto.professional.request.documents.CreateProfessionalDocumentsDTO;
 import br.org.apae.api.controllers.mocks.professional.HealthProfessionalMockDto;
 import br.org.apae.api.helpers.AuthTestHelper;
 import br.org.apae.api.professional.application.interfaces.HealthProfessionalApplicationService;
+import br.org.apae.api.professional.domain.exceptions.HealthProfessionalNotFoundException;
 import br.org.apae.api.documents.application.interfaces.DocumentApplicationService;
+import br.org.apae.api.documents.interfaces.dto.DocumentDTO;
+import br.org.apae.api.documents.domain.enums.DocumentCategory;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.Collections;
 
 
 @Tag("controller")
@@ -141,4 +152,178 @@ class HealthProfessionalControllerTest {
             .andExpect(jsonPath("$.content[1].address.neighborhood")
                 .value("Santana"));
     }
+}
+
+@Test
+@DisplayName("Deve inativar profissional com sucesso (204) usando PUT")
+void shouldInactivateProfessionalSuccessfully() throws Exception {
+    UUID id = UUID.randomUUID();
+
+    Mockito.doNothing().when(service).inactivateProfessional(id);
+
+    mockMvc.perform(put("/professionals/{id}/inactivate", id)
+                    .header("Authorization", AuthTestHelper.bearerToken()))
+            .andExpect(status().isOk()); // Pela implementação do Controller (retorna Void num ResponseEntity, o Spring por padrão converte para 200 OK quando não tem build explícito de No Content no MockMvc para Put, mas vamos testar se o Controller retorna 200)
+
+    Mockito.verify(service).inactivateProfessional(id);
+}
+
+@Test
+@DisplayName("Deve ativar profissional com sucesso (204) usando PUT")
+void shouldActivateProfessionalSuccessfully() throws Exception {
+    UUID id = UUID.randomUUID();
+
+    Mockito.doNothing().when(service).activateProfessional(id);
+
+    mockMvc.perform(put("/professionals/{id}/activate", id)
+                    .header("Authorization", AuthTestHelper.bearerToken()))
+            .andExpect(status().isOk());
+
+    Mockito.verify(service).activateProfessional(id);
+}
+
+@Test
+@DisplayName("Deve reativar profissional com sucesso (204) usando PATCH")
+void shouldReactivateProfessionalSuccessfully() throws Exception {
+    UUID id = UUID.randomUUID();
+
+    Mockito.doNothing().when(service).reactivateProfessional(id);
+
+    mockMvc.perform(patch("/professionals/{id}/reactivate", id)
+                    .header("Authorization", AuthTestHelper.bearerToken()))
+            .andExpect(status().isNoContent());
+
+    Mockito.verify(service).reactivateProfessional(id);
+}
+
+
+@Test
+@DisplayName("Deve buscar profissional por ID com sucesso (200)")
+void shouldFindProfessionalByIdSuccessfully() throws Exception {
+    UUID id = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    var response = HealthProfessionalMockDto.createProfessionalResponse1();
+
+    Mockito.when(service.findProfessionalById(id)).thenReturn(response);
+
+    mockMvc.perform(get("/professionals/{id}", id)
+                    .header("Authorization", AuthTestHelper.bearerToken()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(id.toString()))
+            .andExpect(jsonPath("$.healthSector").value("Fisioterapia"));
+}
+
+@Test
+@DisplayName("Deve atualizar profissional com sucesso (200)")
+void shouldUpdateProfessionalSuccessfully() throws Exception {
+    UUID id = UUID.randomUUID();
+
+    String updateJson = """
+            {
+                "serviceArea": { "name": "Fisioterapia" },
+                "phoneNumber": "83999999999",
+                "professionalDocument": "CRM12345",
+                "email": "teste@teste.com",
+                "name": "Dr. Teste",
+                "identityDocument": "1234567",
+                "address": { "street": "Rua X", "city": "João Pessoa" },
+                "availabilities": []
+            }
+            """;
+
+    var response = HealthProfessionalMockDto.createProfessionalResponse1();
+
+    Mockito.when(service.updateProfessional(Mockito.eq(id), any(UpdateHealthProfessionalDTO.class)))
+            .thenReturn(response);
+
+    mockMvc.perform(put("/professionals/{id}", id)
+                    .header("Authorization", AuthTestHelper.bearerToken())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(updateJson))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").exists());
+}
+
+
+@Test
+@DisplayName("Deve listar documentos do profissional com sucesso (200)")
+void shouldGetProfessionalDocumentsSuccessfully() throws Exception {
+    UUID id = UUID.randomUUID();
+    UUID docId = UUID.randomUUID();
+    DocumentDTO docMock = new DocumentDTO(docId, "CRM_Doc", DocumentCategory.PROFESSIONAL, "pdf", id.toString(), 2026);
+
+    Mockito.when(documentApplicationService.listDocuments(any()))
+            .thenReturn(List.of(docMock));
+
+    Mockito.when(documentApplicationService.getPresignedDocumentUrl(any()))
+            .thenReturn("https://aws.s3.url/presigned");
+
+    mockMvc.perform(get("/professionals/{id}/documents", id)
+                    .header("Authorization", AuthTestHelper.bearerToken()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.length()").value(1))
+            .andExpect(jsonPath("$[0].name").value("CRM_Doc"))
+            .andExpect(jsonPath("$[0].url").value("https://aws.s3.url/presigned"));
+}
+
+@Test
+@DisplayName("Deve atualizar documentos do profissional com sucesso (204) via PATCH Multipart")
+void shouldUpdateProfessionalDocumentsSuccessfully() throws Exception {
+    UUID id = UUID.randomUUID();
+
+    mockMvc.perform(multipart("/professionals/{id}/documents", id)
+                    .with(request -> { request.setMethod("PATCH"); return request; })
+                    .header("Authorization", AuthTestHelper.bearerToken())
+                    .contentType(MediaType.MULTIPART_FORM_DATA))
+            .andExpect(status().isNoContent());
+
+    Mockito.verify(service).updateProfessionalDocuments(Mockito.eq(id), any());
+}
+
+@Test
+@DisplayName("Deve remover documento do profissional com sucesso (204)")
+void shouldRemoveProfessionalDocumentSuccessfully() throws Exception {
+    UUID id = UUID.randomUUID();
+    UUID documentId = UUID.randomUUID();
+
+    Mockito.doNothing().when(service).removeProfessionalDocument(id, documentId);
+
+    mockMvc.perform(delete("/professionals/{id}/documents/{documentId}", id, documentId)
+                    .header("Authorization", AuthTestHelper.bearerToken()))
+            .andExpect(status().isNoContent());
+}
+
+
+@Test
+@DisplayName("Deve listar horários disponíveis do profissional no formato HH:mm (200)")
+void shouldGetAvailableTimesSuccessfully() throws Exception {
+    UUID id = UUID.randomUUID();
+    String dateString = "2026-05-18";
+
+    List<LocalTime> mockTimes = List.of(LocalTime.of(9, 0), LocalTime.of(10, 30));
+
+    Mockito.when(service.getAvailableTimes(id, LocalDate.parse(dateString)))
+            .thenReturn(mockTimes);
+
+    mockMvc.perform(get("/professionals/{id}/available-times", id)
+                    .param("date", dateString)
+                    .header("Authorization", AuthTestHelper.bearerToken()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.length()").value(2))
+            .andExpect(jsonPath("$[0]").value("09:00"))
+            .andExpect(jsonPath("$[1]").value("10:30"));
+}
+
+@Test
+@DisplayName("Deve retornar 404 ao buscar profissional inexistente")
+void shouldReturnNotFoundWhenProfessionalDoesNotExist() throws Exception {
+    UUID id = UUID.randomUUID();
+
+        import br.org.apae.api.professional.domain.exceptions.HealthProfessionalNotFoundException;
+
+    Mockito.when(service.findProfessionalById(id))
+            .thenThrow(new HealthProfessionalNotFoundException());
+
+    mockMvc.perform(get("/professionals/{id}", id)
+                    .header("Authorization", AuthTestHelper.bearerToken()))
+            .andExpect(status().isNotFound());
 }

--- a/apps/api/src/test/java/br/org/apae/api/controllers/professional/HealthProfessionalControllerTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/professional/HealthProfessionalControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -24,12 +25,12 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.multipart.MultipartFile;
 
 import br.org.apae.api.auth.application.internal.UserService;
 import br.org.apae.api.auth.infrastructure.security.JwtProvider;
 import br.org.apae.api.auth.infrastructure.security.SecurityConfiguration;
 import br.org.apae.api.common.dto.professional.request.UpdateHealthProfessionalDTO;
-import br.org.apae.api.common.dto.professional.request.documents.UpdateProfessionalDocumentsDTO;
 import br.org.apae.api.common.dto.professional.request.CreateHealthProfessionalDTO;
 import br.org.apae.api.common.dto.professional.request.documents.CreateProfessionalDocumentsDTO;
 import br.org.apae.api.controllers.mocks.professional.HealthProfessionalMockDto;
@@ -44,8 +45,6 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.UUID;
-import java.util.Collections;
-
 
 @Tag("controller")
 @Tag("health-professional")
@@ -81,12 +80,10 @@ class HealthProfessionalControllerTest {
     }
 
     @Test
+    @DisplayName("Deve criar profissional com sucesso (201)")
     void shouldCreateProfessionalSuccessfully() throws Exception {
-        var request =
-            HealthProfessionalMockDto.createHealthProfessionalRequest();
-
-        var response =
-            HealthProfessionalMockDto.createProfessionalResponse1();
+        var request = HealthProfessionalMockDto.createHealthProfessionalRequest();
+        var response = HealthProfessionalMockDto.createProfessionalResponse1();
 
         Mockito.when(
             service.createProfessional(
@@ -95,13 +92,12 @@ class HealthProfessionalControllerTest {
             )
         ).thenReturn(response);
 
-        var professionalPart =
-            new MockMultipartFile(
-                "professional",
-                "",
-                MediaType.APPLICATION_JSON_VALUE,
-                objectMapper.writeValueAsBytes(request)
-            );
+        var professionalPart = new MockMultipartFile(
+            "professional",
+            "",
+            MediaType.APPLICATION_JSON_VALUE,
+            objectMapper.writeValueAsBytes(request)
+        );
 
         mockMvc.perform(
                 multipart("/professionals")
@@ -114,11 +110,11 @@ class HealthProfessionalControllerTest {
             )
             .andExpect(status().isCreated());
 
-        Mockito.verify(service)
-            .createProfessional(any(), any());
+        Mockito.verify(service).createProfessional(any(), any());
     }
 
     @Test
+    @DisplayName("Deve listar todos os profissionais paginado (200)")
     void shouldReturnAllProfessionals() throws Exception {
         var responses = HealthProfessionalMockDto.createProfessionalResponseList();
 
@@ -137,193 +133,198 @@ class HealthProfessionalControllerTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.content").isArray())
             .andExpect(jsonPath("$.content.length()").value(2))
-
-            .andExpect(jsonPath("$.content[0].id")
-                .value("11111111-1111-1111-1111-111111111111"))
-            .andExpect(jsonPath("$.content[0].healthSector")
-                .value("Fisioterapia"))
-            .andExpect(jsonPath("$.content[0].address.city")
-                .value("São Paulo"))
-
-            .andExpect(jsonPath("$.content[1].id")
-                .value("22222222-2222-2222-2222-222222222222"))
-            .andExpect(jsonPath("$.content[1].name")
-                .value("Maria Souza"))
-            .andExpect(jsonPath("$.content[1].address.neighborhood")
-                .value("Santana"));
+            .andExpect(jsonPath("$.content[0].id").value(HealthProfessionalMockDto.PROFESSIONAL_ID_1.toString()))
+            .andExpect(jsonPath("$.content[0].healthSector").value("Fisioterapia"))
+            .andExpect(jsonPath("$.content[0].address.city").value("São Paulo"))
+            .andExpect(jsonPath("$.content[1].id").value(HealthProfessionalMockDto.PROFESSIONAL_ID_2.toString()))
+            .andExpect(jsonPath("$.content[1].name").value("Maria Souza"))
+            .andExpect(jsonPath("$.content[1].address.neighborhood").value("Santana"));
     }
-}
 
-@Test
-@DisplayName("Deve inativar profissional com sucesso (204) usando PUT")
-void shouldInactivateProfessionalSuccessfully() throws Exception {
-    UUID id = UUID.randomUUID();
+    @Test
+    @DisplayName("Deve inativar profissional com sucesso (204) usando PUT")
+    void shouldInactivateProfessionalSuccessfully() throws Exception {
+        UUID id = HealthProfessionalMockDto.PROFESSIONAL_ID_1;
 
-    Mockito.doNothing().when(service).inactivateProfessional(id);
+        Mockito.doNothing().when(service).inactivateProfessional(id);
 
-    mockMvc.perform(put("/professionals/{id}/inactivate", id)
-                    .header("Authorization", AuthTestHelper.bearerToken()))
-            .andExpect(status().isOk()); // Pela implementação do Controller (retorna Void num ResponseEntity, o Spring por padrão converte para 200 OK quando não tem build explícito de No Content no MockMvc para Put, mas vamos testar se o Controller retorna 200)
+        mockMvc.perform(put("/professionals/{id}/inactivate", id)
+                        .header("Authorization", AuthTestHelper.bearerToken()))
+                .andExpect(status().isNoContent()); 
 
-    Mockito.verify(service).inactivateProfessional(id);
-}
+        Mockito.verify(service).inactivateProfessional(id);
+    }
 
-@Test
-@DisplayName("Deve ativar profissional com sucesso (204) usando PUT")
-void shouldActivateProfessionalSuccessfully() throws Exception {
-    UUID id = UUID.randomUUID();
+    @Test
+    @DisplayName("Deve ativar profissional com sucesso (204) usando PUT")
+    void shouldActivateProfessionalSuccessfully() throws Exception {
+        UUID id = HealthProfessionalMockDto.PROFESSIONAL_ID_1;
 
-    Mockito.doNothing().when(service).activateProfessional(id);
+        Mockito.doNothing().when(service).activateProfessional(id);
 
-    mockMvc.perform(put("/professionals/{id}/activate", id)
-                    .header("Authorization", AuthTestHelper.bearerToken()))
-            .andExpect(status().isOk());
+        mockMvc.perform(put("/professionals/{id}/activate", id)
+                        .header("Authorization", AuthTestHelper.bearerToken()))
+                .andExpect(status().isNoContent());
 
-    Mockito.verify(service).activateProfessional(id);
-}
+        Mockito.verify(service).activateProfessional(id);
+    }
 
-@Test
-@DisplayName("Deve reativar profissional com sucesso (204) usando PATCH")
-void shouldReactivateProfessionalSuccessfully() throws Exception {
-    UUID id = UUID.randomUUID();
+    @Test
+    @DisplayName("Deve reativar profissional com sucesso (204) usando PATCH")
+    void shouldReactivateProfessionalSuccessfully() throws Exception {
+        UUID id = HealthProfessionalMockDto.PROFESSIONAL_ID_1;
 
-    Mockito.doNothing().when(service).reactivateProfessional(id);
+        Mockito.doNothing().when(service).reactivateProfessional(id);
 
-    mockMvc.perform(patch("/professionals/{id}/reactivate", id)
-                    .header("Authorization", AuthTestHelper.bearerToken()))
-            .andExpect(status().isNoContent());
+        mockMvc.perform(patch("/professionals/{id}/reactivate", id)
+                        .header("Authorization", AuthTestHelper.bearerToken()))
+                .andExpect(status().isNoContent());
 
-    Mockito.verify(service).reactivateProfessional(id);
-}
+        Mockito.verify(service).reactivateProfessional(id);
+    }
 
+    @Test
+    @DisplayName("Deve buscar profissional por ID com sucesso (200)")
+    void shouldFindProfessionalByIdSuccessfully() throws Exception {
+        UUID id = HealthProfessionalMockDto.PROFESSIONAL_ID_1;
+        var response = HealthProfessionalMockDto.createProfessionalResponse1();
 
-@Test
-@DisplayName("Deve buscar profissional por ID com sucesso (200)")
-void shouldFindProfessionalByIdSuccessfully() throws Exception {
-    UUID id = UUID.fromString("11111111-1111-1111-1111-111111111111");
-    var response = HealthProfessionalMockDto.createProfessionalResponse1();
+        Mockito.when(service.findProfessionalById(id)).thenReturn(response);
 
-    Mockito.when(service.findProfessionalById(id)).thenReturn(response);
+        mockMvc.perform(get("/professionals/{id}", id)
+                        .header("Authorization", AuthTestHelper.bearerToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(id.toString()))
+                .andExpect(jsonPath("$.healthSector").value("Fisioterapia"));
+    }
 
-    mockMvc.perform(get("/professionals/{id}", id)
-                    .header("Authorization", AuthTestHelper.bearerToken()))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.id").value(id.toString()))
-            .andExpect(jsonPath("$.healthSector").value("Fisioterapia"));
-}
+    @Test
+    @DisplayName("Deve atualizar profissional com sucesso (200)")
+    void shouldUpdateProfessionalSuccessfully() throws Exception {
+        UUID id = HealthProfessionalMockDto.PROFESSIONAL_ID_1;
+        var response = HealthProfessionalMockDto.createProfessionalResponse1();
+        var updateRequest = HealthProfessionalMockDto.createHealthProfessionalRequest();
 
-@Test
-@DisplayName("Deve atualizar profissional com sucesso (200)")
-void shouldUpdateProfessionalSuccessfully() throws Exception {
-    UUID id = UUID.randomUUID();
+        Mockito.when(service.updateProfessional(Mockito.eq(id), any(UpdateHealthProfessionalDTO.class)))
+                .thenReturn(response);
 
-    String updateJson = """
-            {
-                "serviceArea": { "name": "Fisioterapia" },
-                "phoneNumber": "83999999999",
-                "professionalDocument": "CRM12345",
-                "email": "teste@teste.com",
-                "name": "Dr. Teste",
-                "identityDocument": "1234567",
-                "address": { "street": "Rua X", "city": "João Pessoa" },
-                "availabilities": []
-            }
-            """;
+        mockMvc.perform(put("/professionals/{id}", id)
+                        .header("Authorization", AuthTestHelper.bearerToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(updateRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(id.toString()));
+    }
 
-    var response = HealthProfessionalMockDto.createProfessionalResponse1();
+    @Test
+    @DisplayName("Deve listar documentos do profissional com sucesso (200)")
+    void shouldGetProfessionalDocumentsSuccessfully() throws Exception {
+        UUID id = HealthProfessionalMockDto.PROFESSIONAL_ID_1;
+        UUID docId = UUID.randomUUID();
+        
+        DocumentDTO docMock = new DocumentDTO(
+            docId, 
+            "CRM_Doc", 
+            DocumentCategory.PROFESSIONAL, 
+            br.org.apae.api.documents.domain.enums.DocumentType.MEDICAL_REPORT, 
+            id.toString(), 
+            java.time.Year.of(2026)
+        );
 
-    Mockito.when(service.updateProfessional(Mockito.eq(id), any(UpdateHealthProfessionalDTO.class)))
-            .thenReturn(response);
+        Mockito.when(documentApplicationService.listDocuments(any()))
+                .thenReturn(List.of(docMock));
 
-    mockMvc.perform(put("/professionals/{id}", id)
-                    .header("Authorization", AuthTestHelper.bearerToken())
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(updateJson))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.id").exists());
-}
+        Mockito.when(documentApplicationService.getPresignedDocumentUrl(any()))
+                .thenReturn("https://aws.s3.url/presigned");
 
+        mockMvc.perform(get("/professionals/{id}/documents", id)
+                        .header("Authorization", AuthTestHelper.bearerToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].name").value("CRM_Doc"))
+                .andExpect(jsonPath("$[0].url").value("https://aws.s3.url/presigned"));
+    }
 
-@Test
-@DisplayName("Deve listar documentos do profissional com sucesso (200)")
-void shouldGetProfessionalDocumentsSuccessfully() throws Exception {
-    UUID id = UUID.randomUUID();
-    UUID docId = UUID.randomUUID();
-    DocumentDTO docMock = new DocumentDTO(docId, "CRM_Doc", DocumentCategory.PROFESSIONAL, "pdf", id.toString(), 2026);
+    @Test
+    @DisplayName("Deve atualizar documentos do profissional com sucesso (204) via PATCH Multipart")
+    void shouldUpdateProfessionalDocumentsSuccessfully() throws Exception {
+        UUID id = HealthProfessionalMockDto.PROFESSIONAL_ID_1;
 
-    Mockito.when(documentApplicationService.listDocuments(any()))
-            .thenReturn(List.of(docMock));
+        mockMvc.perform(multipart("/professionals/{id}/documents", id)
+                        .file(HealthProfessionalMockDto.volunteerAgreementFile()) // ADAPTAÇÃO: utilizando arquivos do mock
+                        .file(HealthProfessionalMockDto.curriculumFile())
+                        .with(request -> { request.setMethod("PATCH"); return request; })
+                        .header("Authorization", AuthTestHelper.bearerToken())
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isNoContent());
 
-    Mockito.when(documentApplicationService.getPresignedDocumentUrl(any()))
-            .thenReturn("https://aws.s3.url/presigned");
+        Mockito.verify(service).updateProfessionalDocuments(Mockito.eq(id), any());
+    }
 
-    mockMvc.perform(get("/professionals/{id}/documents", id)
-                    .header("Authorization", AuthTestHelper.bearerToken()))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.length()").value(1))
-            .andExpect(jsonPath("$[0].name").value("CRM_Doc"))
-            .andExpect(jsonPath("$[0].url").value("https://aws.s3.url/presigned"));
-}
+    @Test
+    @DisplayName("Deve remover documento do profissional com sucesso (204)")
+    void shouldRemoveProfessionalDocumentSuccessfully() throws Exception {
+        UUID id = HealthProfessionalMockDto.PROFESSIONAL_ID_1;
+        UUID documentId = UUID.randomUUID();
 
-@Test
-@DisplayName("Deve atualizar documentos do profissional com sucesso (204) via PATCH Multipart")
-void shouldUpdateProfessionalDocumentsSuccessfully() throws Exception {
-    UUID id = UUID.randomUUID();
+        Mockito.doNothing().when(service).removeProfessionalDocument(id, documentId);
 
-    mockMvc.perform(multipart("/professionals/{id}/documents", id)
-                    .with(request -> { request.setMethod("PATCH"); return request; })
-                    .header("Authorization", AuthTestHelper.bearerToken())
-                    .contentType(MediaType.MULTIPART_FORM_DATA))
-            .andExpect(status().isNoContent());
+        mockMvc.perform(delete("/professionals/{id}/documents/{documentId}", id, documentId)
+                        .header("Authorization", AuthTestHelper.bearerToken()))
+                .andExpect(status().isNoContent());
+    }
 
-    Mockito.verify(service).updateProfessionalDocuments(Mockito.eq(id), any());
-}
+    @Test
+    @DisplayName("Deve fazer upload da foto de perfil com sucesso (204)")
+    void shouldUploadProfessionalPhotoSuccessfully() throws Exception {
+        UUID id = HealthProfessionalMockDto.PROFESSIONAL_ID_1;
+        MockMultipartFile photoFile = new MockMultipartFile(
+            "file", 
+            "profile.jpg", 
+            MediaType.IMAGE_JPEG_VALUE, 
+            "fake-image-bytes".getBytes()
+        );
 
-@Test
-@DisplayName("Deve remover documento do profissional com sucesso (204)")
-void shouldRemoveProfessionalDocumentSuccessfully() throws Exception {
-    UUID id = UUID.randomUUID();
-    UUID documentId = UUID.randomUUID();
+        Mockito.doNothing().when(service).uploadProfessionalPhoto(Mockito.eq(id), any(MultipartFile.class));
 
-    Mockito.doNothing().when(service).removeProfessionalDocument(id, documentId);
+        mockMvc.perform(multipart("/professionals/{id}/photo", id)
+                        .file(photoFile)
+                        .header("Authorization", AuthTestHelper.bearerToken()))
+                .andExpect(status().isNoContent());
 
-    mockMvc.perform(delete("/professionals/{id}/documents/{documentId}", id, documentId)
-                    .header("Authorization", AuthTestHelper.bearerToken()))
-            .andExpect(status().isNoContent());
-}
+        Mockito.verify(service).uploadProfessionalPhoto(Mockito.eq(id), any(MultipartFile.class));
+    }
 
+    @Test
+    @DisplayName("Deve listar horários disponíveis do profissional no formato HH:mm (200)")
+    void shouldGetAvailableTimesSuccessfully() throws Exception {
+        UUID id = HealthProfessionalMockDto.PROFESSIONAL_ID_1;
+        String dateString = "2026-05-18";
 
-@Test
-@DisplayName("Deve listar horários disponíveis do profissional no formato HH:mm (200)")
-void shouldGetAvailableTimesSuccessfully() throws Exception {
-    UUID id = UUID.randomUUID();
-    String dateString = "2026-05-18";
+        List<LocalTime> mockTimes = List.of(LocalTime.of(9, 0), LocalTime.of(10, 30));
 
-    List<LocalTime> mockTimes = List.of(LocalTime.of(9, 0), LocalTime.of(10, 30));
+        Mockito.when(service.getAvailableTimes(id, LocalDate.parse(dateString)))
+                .thenReturn(mockTimes);
 
-    Mockito.when(service.getAvailableTimes(id, LocalDate.parse(dateString)))
-            .thenReturn(mockTimes);
+        mockMvc.perform(get("/professionals/{id}/available-times", id)
+                        .param("date", dateString)
+                        .header("Authorization", AuthTestHelper.bearerToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0]").value("09:00"))
+                .andExpect(jsonPath("$[1]").value("10:30"));
+    }
 
-    mockMvc.perform(get("/professionals/{id}/available-times", id)
-                    .param("date", dateString)
-                    .header("Authorization", AuthTestHelper.bearerToken()))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.length()").value(2))
-            .andExpect(jsonPath("$[0]").value("09:00"))
-            .andExpect(jsonPath("$[1]").value("10:30"));
-}
+    @Test
+    @DisplayName("Deve retornar 404 ao buscar profissional inexistente")
+    void shouldReturnNotFoundWhenProfessionalDoesNotExist() throws Exception {
+        UUID id = UUID.randomUUID(); 
 
-@Test
-@DisplayName("Deve retornar 404 ao buscar profissional inexistente")
-void shouldReturnNotFoundWhenProfessionalDoesNotExist() throws Exception {
-    UUID id = UUID.randomUUID();
+        Mockito.when(service.findProfessionalById(id))
+                .thenThrow(new HealthProfessionalNotFoundException());
 
-        import br.org.apae.api.professional.domain.exceptions.HealthProfessionalNotFoundException;
-
-    Mockito.when(service.findProfessionalById(id))
-            .thenThrow(new HealthProfessionalNotFoundException());
-
-    mockMvc.perform(get("/professionals/{id}", id)
-                    .header("Authorization", AuthTestHelper.bearerToken()))
-            .andExpect(status().isNotFound());
+        mockMvc.perform(get("/professionals/{id}", id)
+                        .header("Authorization", AuthTestHelper.bearerToken()))
+                .andExpect(status().isNotFound());
+    }
 }


### PR DESCRIPTION
# Qual é o objetivo desta PR?

Esta Pull Request resolve a falta de cobertura de testes unitários no HealthProfessionalControllerImpl. O objetivo foi ampliar os testes (que antes cobriam apenas a criação e listagem geral) para garantir que todos os demais endpoints do controller estejam devidamente cobertos, validando cenários de sucesso e erro com suas respectivas respostas e status HTTP.

# O que foi feito?

## Cobertura para Gestão de Status do Profissional:

- Adicionados testes para inactivateHealthProfessional, activateHealthProfessional e reactivateHealthProfessional.

## Cobertura para Busca e Atualização:

- Adicionado teste para findByIdHealthProfessional validando o retorno do corpo da resposta.

- Adicionado teste para updateHealthProfessional simulando a submissão do DTO e validando o retorno.

## Cobertura para Gestão de Documentos:

- Adicionado teste para getProfessionalDocuments validando a geração de URL.

- Adicionados testes para updateProfessionalDocuments (via multipart) e removeProfessionalDocument.

## Cobertura para Horários Disponíveis:

- Adicionado teste para getAvailableTimes validando o retorno da lista no formato de horas (HH:mm).

## Cenários de Erro e Refatoração:

- Criado um novo cenário de erro garantindo o retorno correto (404 Not Found) ao buscar um profissional inexistente (HealthProfessionalNotFoundException).

Correção estrutural no arquivo de testes (ajuste de chaves e imports) para garantir a compilação correta da classe.