### PR TITLE
779 test corrigir testes com status http incorretos no disordercontrollerimpltest

### DIFF
--- a/apps/api/src/test/java/br/org/apae/api/controllers/disorder/DisorderControllerImplTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/disorder/DisorderControllerImplTest.java
@@ -21,13 +21,9 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.data.web.config.SpringDataWebConfiguration;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.Arrays;
 import java.util.List;
@@ -45,12 +41,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+
 @WebMvcTest(controllers = DisorderControllerImpl.class)
 @AutoConfigureMockMvc(addFilters = true)
 @Import({
         SpringDataWebConfiguration.class,
-        SecurityConfiguration.class,
-        DisorderTestExceptionHandler.class
+        SecurityConfiguration.class
 })
 @Tag("patient")
 @Tag("unit")
@@ -60,6 +56,7 @@ class DisorderControllerImplTest {
     @TestConfiguration
     @EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
     static class ContextConfiguration {
+
     }
 
     @Autowired
@@ -234,19 +231,5 @@ class DisorderControllerImplTest {
 
         mockMvc.perform(delete(BASE_URL + "/{id}", id).header("Authorization", AuthTestHelper.bearerToken()))
                 .andExpect(status().isNotFound());
-    }
-}
-
-@RestControllerAdvice
-class DisorderTestExceptionHandler {
-
-    @ExceptionHandler(DisorderNotFoundException.class)
-    public ResponseEntity<Void> handleNotFound() {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
-    }
-
-    @ExceptionHandler(DisorderConflictException.class)
-    public ResponseEntity<Void> handleConflict() {
-        return ResponseEntity.status(HttpStatus.CONFLICT).build();
     }
 }

--- a/apps/api/src/test/java/br/org/apae/api/controllers/disorder/DisorderControllerImplTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/disorder/DisorderControllerImplTest.java
@@ -6,6 +6,7 @@ import br.org.apae.api.auth.infrastructure.security.SecurityConfiguration;
 import br.org.apae.api.common.dto.patient.request.disorder.CreateDisorderDTO;
 import br.org.apae.api.common.dto.patient.request.disorder.UpdateDisorderDTO;
 import br.org.apae.api.common.dto.patient.response.disorder.DisorderResponseDTO;
+import br.org.apae.api.common.exceptions.handler.GlobalExceptionHandler;
 import br.org.apae.api.helpers.AuthTestHelper;
 import br.org.apae.api.patient.application.interfaces.DisorderApplicationService;
 import br.org.apae.api.patient.domain.exceptions.DisorderConflictException;
@@ -46,7 +47,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc(addFilters = true)
 @Import({
         SpringDataWebConfiguration.class,
-        SecurityConfiguration.class
+        SecurityConfiguration.class,
+        GlobalExceptionHandler.class
 })
 @Tag("patient")
 @Tag("unit")

--- a/apps/api/src/test/java/br/org/apae/api/controllers/disorder/DisorderControllerImplTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/disorder/DisorderControllerImplTest.java
@@ -6,7 +6,6 @@ import br.org.apae.api.auth.infrastructure.security.SecurityConfiguration;
 import br.org.apae.api.common.dto.patient.request.disorder.CreateDisorderDTO;
 import br.org.apae.api.common.dto.patient.request.disorder.UpdateDisorderDTO;
 import br.org.apae.api.common.dto.patient.response.disorder.DisorderResponseDTO;
-import br.org.apae.api.common.exceptions.handler.GlobalExceptionHandler;
 import br.org.apae.api.helpers.AuthTestHelper;
 import br.org.apae.api.patient.application.interfaces.DisorderApplicationService;
 import br.org.apae.api.patient.domain.exceptions.DisorderConflictException;
@@ -22,9 +21,13 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.data.web.config.SpringDataWebConfiguration;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.Arrays;
 import java.util.List;
@@ -42,13 +45,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-
 @WebMvcTest(controllers = DisorderControllerImpl.class)
 @AutoConfigureMockMvc(addFilters = true)
 @Import({
         SpringDataWebConfiguration.class,
         SecurityConfiguration.class,
-        GlobalExceptionHandler.class
+        DisorderTestExceptionHandler.class
 })
 @Tag("patient")
 @Tag("unit")
@@ -58,7 +60,6 @@ class DisorderControllerImplTest {
     @TestConfiguration
     @EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
     static class ContextConfiguration {
-
     }
 
     @Autowired
@@ -233,5 +234,19 @@ class DisorderControllerImplTest {
 
         mockMvc.perform(delete(BASE_URL + "/{id}", id).header("Authorization", AuthTestHelper.bearerToken()))
                 .andExpect(status().isNotFound());
+    }
+}
+
+@RestControllerAdvice
+class DisorderTestExceptionHandler {
+
+    @ExceptionHandler(DisorderNotFoundException.class)
+    public ResponseEntity<Void> handleNotFound() {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+    }
+
+    @ExceptionHandler(DisorderConflictException.class)
+    public ResponseEntity<Void> handleConflict() {
+        return ResponseEntity.status(HttpStatus.CONFLICT).build();
     }
 }

--- a/apps/api/src/test/java/br/org/apae/api/controllers/disorder/DisorderControllerImplTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/disorder/DisorderControllerImplTest.java
@@ -188,7 +188,7 @@ class DisorderControllerImplTest {
         mockMvc.perform(get(BASE_URL + "/{id}", id)
                         .header("Authorization", AuthTestHelper.bearerToken())
                         .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isConflict());
+                .andExpect(status().isNotFound());
     }
 
     @Test
@@ -204,7 +204,7 @@ class DisorderControllerImplTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(updateDto))
                         .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isConflict());
+                .andExpect(status().isNotFound());
     }
 
     @Test
@@ -230,6 +230,6 @@ class DisorderControllerImplTest {
         doThrow(new DisorderNotFoundException()).when(disorderService).deleteDisorder(id);
 
         mockMvc.perform(delete(BASE_URL + "/{id}", id).header("Authorization", AuthTestHelper.bearerToken()))
-                .andExpect(status().isConflict());
+                .andExpect(status().isNotFound());
     }
 }


### PR DESCRIPTION
# Qual é o objetivo desta PR?
Esta Pull Request resolve uma inconsistência crítica na suíte de testes unitários do DisorderControllerImplTest. O objetivo foi corrigir cenários onde exceções de "recurso não encontrado" esperavam incorretamente o status 409 Conflict.

# O que foi feito?

## Correção de Status HTTP (409 para 404):

- O teste shouldReturnNotFoundWhenSearchDisorderByIdNonExistent agora espera adequadamente o status 404 Not Found.

- O teste shouldReturnNotFoundWhenUpdateDisorderNonExistent agora espera adequadamente o status 404 Not Found.

- O teste shouldReturnNotFoundWhenDeleteDisorderNonExistent agora espera adequadamente o status 404 Not Found.

## Manutenção da Suíte:

- Os demais cenários de sucesso e de conflito por duplicidade de nome foram revisados, validados e mantidos intactos.