### PR TITLE
test: atualiza e corrige os testes em AbsenceControllerImplTest

### DIFF
--- a/apps/api/src/test/java/br/org/apae/api/appointment/interfaces/controllers/impl/AbsenceControllerImplTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/appointment/interfaces/controllers/impl/AbsenceControllerImplTest.java
@@ -5,6 +5,8 @@ import br.org.apae.api.auth.application.internal.UserService;
 import br.org.apae.api.auth.infrastructure.security.JwtProvider;
 import br.org.apae.api.common.dto.appointment.request.absence.CreateAbsenceDTO;
 import br.org.apae.api.common.dto.appointment.response.absence.AbsenceResponseDTO;
+import br.org.apae.api.common.dto.appointment.response.absence.JustifyAbsenceDTO;
+import br.org.apae.api.controllers.absence.AbsenceControllerImpl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,14 +23,13 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+
 
 @WebMvcTest(controllers = AbsenceControllerImpl.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -58,38 +59,98 @@ class AbsenceControllerImplTest {
                 LocalDate date = LocalDate.now();
 
                 CreateAbsenceDTO request = new CreateAbsenceDTO(
-                                generatedId,
-                                date,
-                                "Paciente Faltou");
+                        generatedId,
+                        date,
+                        false,
+                        null,
+                        null);
 
                 AbsenceResponseDTO response = new AbsenceResponseDTO(
-                                id,
-                                generatedId,
-                                patientId,
-                                professionalId,
-                                date,
-                                "Paciente Faltou",
-                                false);
+                        id,
+                        generatedId,
+                        patientId,
+                        professionalId,
+                        date,
+                        null,
+                        false,
+                        false,
+                        null);
 
-                when(service.register(any(CreateAbsenceDTO.class)))
-                                .thenReturn(response);
-                
+                when(service.register(any(CreateAbsenceDTO.class))).thenReturn(response);
+
                 var result = mockMvc.perform(post("/absences")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request)))
                         .andReturn();
-                
+
                 assertEquals(201, result.getResponse().getStatus());
                 assertNotNull(result.getResponse().getHeader("Location"));
+                assertTrue(result.getResponse().getHeader("Location").contains(id.toString()));
 
-                AbsenceResponseDTO body =
-                        objectMapper.readValue(result.getResponse().getContentAsString(),
-                                AbsenceResponseDTO.class);
+                AbsenceResponseDTO body = objectMapper.readValue(
+                        result.getResponse().getContentAsString(), AbsenceResponseDTO.class);
 
                 assertEquals(id, body.id());
-                assertEquals("Paciente Faltou", body.justification());
+                assertEquals(generatedId, body.generatedAppointmentId());
                 assertFalse(body.notified());
+                assertFalse(body.isJustified());
         }
+
+        @Test
+        void shouldReturnBadRequestWhenRegisterWithNullGeneratedAppointmentId() throws Exception {
+                CreateAbsenceDTO invalidRequest = new CreateAbsenceDTO(
+                        null,
+                        LocalDate.now(),
+                        false,
+                        null,
+                        null);
+
+                var result = mockMvc.perform(post("/absences")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(invalidRequest)))
+                        .andReturn();
+
+                assertEquals(400, result.getResponse().getStatus());
+        }
+
+        @Test
+        void shouldReturnBadRequestWhenRegisterWithNullAbsenceDate() throws Exception {
+                CreateAbsenceDTO invalidRequest = new CreateAbsenceDTO(
+                        UUID.randomUUID(),
+                        null,
+                        false,
+                        null,
+                        null);
+
+                var result = mockMvc.perform(post("/absences")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(invalidRequest)))
+                        .andReturn();
+
+                assertEquals(400, result.getResponse().getStatus());
+        }
+
+        @Test
+        void shouldReturnBadRequestWhenServiceThrowsExceptionOnRegister() throws Exception {
+                CreateAbsenceDTO request = new CreateAbsenceDTO(
+                        UUID.randomUUID(),
+                        LocalDate.now(),
+                        false,
+                        null,
+                        null);
+
+                when(service.register(any(CreateAbsenceDTO.class)))
+                        .thenThrow(new IllegalArgumentException("Falta já registrada"));
+
+                var result = mockMvc.perform(post("/absences")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andReturn();
+
+                assertEquals(400, result.getResponse().getStatus());
+        }
+
+        // ==================== findAll ====================
 
         @Test
         void searchForAbsencesUsingFiltersAndPagination() throws Exception {
@@ -99,21 +160,22 @@ class AbsenceControllerImplTest {
                 LocalDate date = LocalDate.now();
 
                 AbsenceResponseDTO response = new AbsenceResponseDTO(
-                                UUID.randomUUID(),
-                                generatedId,
-                                patientId,
-                                professionalId,
-                                date,
-                                "Falta justificada",
-                                true);
+                        UUID.randomUUID(),
+                        generatedId,
+                        patientId,
+                        professionalId,
+                        date,
+                        "Falta justificada",
+                        true,
+                        true,
+                        null);
 
                 Page<AbsenceResponseDTO> page = new PageImpl<>(
-                                List.of(response),
-                                PageRequest.of(0, 10),
-                                1);
+                        List.of(response),
+                        PageRequest.of(0, 10),
+                        1);
 
-                when(service.findAllByFilters(any(), any(), any(), any()))
-                                .thenReturn(page);
+                when(service.findAllByFilters(any(), any(), any(), any())).thenReturn(page);
 
                 var result = mockMvc.perform(get("/absences")
                                 .param("generatedId", generatedId.toString())
@@ -122,77 +184,149 @@ class AbsenceControllerImplTest {
                                 .param("page", "0")
                                 .param("size", "10"))
                         .andReturn();
-                
+
                 assertEquals(200, result.getResponse().getStatus());
 
                 String json = result.getResponse().getContentAsString();
-
                 assertTrue(json.contains("\"content\""));
                 assertTrue(json.contains("Falta justificada"));
                 assertTrue(json.contains("\"notified\":true"));
+                assertTrue(json.contains("\"isJustified\":true"));
         }
 
         @Test
-        void shouldReturnBadRequestWhenRegisterAbsenceWithInvalidBody() throws Exception {
-                CreateAbsenceDTO invalidRequest = new CreateAbsenceDTO(
-                                null,
-                                null,
-                                "");
+        void shouldSearchAbsencesWithoutFilters() throws Exception {
+                AbsenceResponseDTO response = new AbsenceResponseDTO(
+                        UUID.randomUUID(),
+                        UUID.randomUUID(),
+                        UUID.randomUUID(),
+                        UUID.randomUUID(),
+                        LocalDate.now(),
+                        null,
+                        false,
+                        false,
+                        null);
 
-                var result = mockMvc.perform(post("/absences")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(invalidRequest)))
-                                .andReturn();
-                assertEquals(400, result.getResponse().getStatus());
+                Page<AbsenceResponseDTO> page = new PageImpl<>(List.of(response));
+
+                when(service.findAllByFilters(isNull(), isNull(), isNull(), any()))
+                        .thenReturn(page);
+
+                var result = mockMvc.perform(get("/absences")
+                                .param("page", "0")
+                                .param("size", "10"))
+                        .andReturn();
+
+                assertEquals(200, result.getResponse().getStatus());
+
+                String json = result.getResponse().getContentAsString();
+                assertTrue(json.contains("\"content\""));
+                assertTrue(json.contains("\"notified\":false"));
         }
 
         @Test
-        void shouldReturnBadRequestWhenServiceThrowsExceptionOnRegister() throws Exception {
-                CreateAbsenceDTO request = new CreateAbsenceDTO(
-                                UUID.randomUUID(),
-                                LocalDate.now(),
-                                "Teste erro");
+        void shouldReturnEmptyPageWhenNoAbsencesFound() throws Exception {
+                when(service.findAllByFilters(isNull(), isNull(), isNull(), any()))
+                        .thenReturn(Page.empty());
 
-                when(service.register(any(CreateAbsenceDTO.class)))
-                                .thenThrow(new IllegalArgumentException("Falta já registrada"));
+                var result = mockMvc.perform(get("/absences")
+                                .param("page", "0")
+                                .param("size", "10"))
+                        .andReturn();
 
-                var result = mockMvc.perform(post("/absences")
+                assertEquals(200, result.getResponse().getStatus());
+
+                String json = result.getResponse().getContentAsString();
+                assertTrue(json.contains("\"content\":[]"));
+        }
+
+        // ==================== justifyAbsence ====================
+
+        @Test
+        void justifyAbsenceSuccessfully() throws Exception {
+                UUID absenceId = UUID.randomUUID();
+                UUID generatedId = UUID.randomUUID();
+                UUID patientId = UUID.randomUUID();
+                UUID professionalId = UUID.randomUUID();
+                LocalDate date = LocalDate.now();
+                String documentId = "doc-123";
+
+                JustifyAbsenceDTO request = new JustifyAbsenceDTO(
+                        "Motivo de saúde urgente",
+                        documentId);
+
+                AbsenceResponseDTO response = new AbsenceResponseDTO(
+                        absenceId,
+                        generatedId,
+                        patientId,
+                        professionalId,
+                        date,
+                        "Motivo de saúde urgente",
+                        false,
+                        true,
+                        documentId);
+
+                when(service.justify(eq(absenceId), any(JustifyAbsenceDTO.class)))
+                        .thenReturn(response);
+
+                var result = mockMvc.perform(patch("/absences/{id}/justify", absenceId)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request)))
+                        .andReturn();
+
+                assertEquals(200, result.getResponse().getStatus());
+
+                AbsenceResponseDTO body = objectMapper.readValue(
+                        result.getResponse().getContentAsString(), AbsenceResponseDTO.class);
+
+                assertEquals(absenceId, body.id());
+                assertEquals("Motivo de saúde urgente", body.justification());
+                assertTrue(body.isJustified());
+                assertEquals(documentId, body.justificationDocumentId());
+        }
+
+        @Test
+        void shouldReturnBadRequestWhenJustifyAbsenceWithBlankJustification() throws Exception {
+                UUID absenceId = UUID.randomUUID();
+
+                JustifyAbsenceDTO invalidRequest = new JustifyAbsenceDTO("", null);
+
+                var result = mockMvc.perform(patch("/absences/{id}/justify", absenceId)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(invalidRequest)))
                         .andReturn();
 
                 assertEquals(400, result.getResponse().getStatus());
         }
 
         @Test
-        void shouldSearchAbsencesWithoutFilters() throws Exception {
-                AbsenceResponseDTO response = new AbsenceResponseDTO(
-                                UUID.randomUUID(),
-                                UUID.randomUUID(),
-                                UUID.randomUUID(),
-                                UUID.randomUUID(),
-                                LocalDate.now(),
-                                "Paciente faltou",
-                                false);
+        void shouldReturnBadRequestWhenJustifyAbsenceWithNullJustification() throws Exception {
+                UUID absenceId = UUID.randomUUID();
 
-                Page<AbsenceResponseDTO> page = new PageImpl<>(List.of(response));
+                JustifyAbsenceDTO invalidRequest = new JustifyAbsenceDTO(null, null);
 
-                when(service.findAllByFilters(
-                                org.mockito.ArgumentMatchers.isNull(),
-                                org.mockito.ArgumentMatchers.isNull(),
-                                org.mockito.ArgumentMatchers.isNull(),
-                                any()))
-                                .thenReturn(page);
+                var result = mockMvc.perform(patch("/absences/{id}/justify", absenceId)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(invalidRequest)))
+                        .andReturn();
 
-                var result = mockMvc.perform(get("/absences")
-                                .param("page", "0")
-                                .param("size", "10"))
-                                .andReturn();
-
-                assertEquals(200, result.getResponse().getStatus());
-
-                String json = result.getResponse().getContentAsString();
-                assertTrue(json.contains("Paciente faltou"));
+                assertEquals(400, result.getResponse().getStatus());
         }
 
+        @Test
+        void shouldReturnBadRequestWhenServiceThrowsExceptionOnJustify() throws Exception {
+                UUID absenceId = UUID.randomUUID();
+
+                JustifyAbsenceDTO request = new JustifyAbsenceDTO("Justificativa válida", null);
+
+                when(service.justify(eq(absenceId), any(JustifyAbsenceDTO.class)))
+                        .thenThrow(new IllegalArgumentException("Falta não encontrada"));
+
+                var result = mockMvc.perform(patch("/absences/{id}/justify", absenceId)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andReturn();
+
+                assertEquals(400, result.getResponse().getStatus());
+        }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,7 @@
         "react-hook-form": "^7.62.0",
         "react-select": "^5.10.2",
         "react-toastify": "^11.0.5",
+        "recharts": "^2.13.3",
         "tailwind-merge": "^3.3.1",
         "use-mask-input": "^3.5.1",
         "zod": "^4.0.17"
@@ -3066,6 +3067,69 @@
         "axios": "*"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -4296,6 +4360,127 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -4382,6 +4567,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -5102,11 +5293,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.1",
@@ -5599,6 +5805,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -6428,6 +6643,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -7171,6 +7392,21 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -7219,6 +7455,44 @@
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -7891,6 +8165,12 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -8236,6 +8516,28 @@
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/which": {


### PR DESCRIPTION
# O que mudou?

Atualização dos testes do `AbsenceControllerImpl` para refletir a implementação atual do controller, corrigindo testes existentes e adicionando cobertura para o endpoint `justifyAbsence` que não tinha nenhum teste.

## Tarefas Relacionadas

* Issue: https://github.com/IFPBEsp/APAE/issues/774

## Mudanças Realizadas

* Corrigidos os testes existentes de `register` e `findAll` para refletir os campos atuais dos DTOs (`isJustified`, `justificationDocumentId`)
* Adicionados testes para o endpoint `PATCH /absences/{id}/justify`, cobrindo sucesso, justificativa nula, justificativa em branco e exceção do service
* Adicionado cenário de página vazia no `findAll`

