### PR TITLE
798 chore padronizar uso de displayname nos testes

### DIFF
--- a/apps/api/src/test/java/br/org/apae/api/appointment/interfaces/controllers/impl/AbsenceControllerImplTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/appointment/interfaces/controllers/impl/AbsenceControllerImplTest.java
@@ -8,6 +8,7 @@ import br.org.apae.api.common.dto.appointment.response.absence.AbsenceResponseDT
 import br.org.apae.api.common.dto.appointment.response.absence.JustifyAbsenceDTO;
 import br.org.apae.api.controllers.absence.AbsenceControllerImpl;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -35,298 +36,309 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 @AutoConfigureMockMvc(addFilters = false)
 class AbsenceControllerImplTest {
 
-        @Autowired
-        private MockMvc mockMvc;
+    @Autowired
+    private MockMvc mockMvc;
 
-        @MockitoBean
-        private AbsenceApplicationService service;
+    @MockitoBean
+    private AbsenceApplicationService service;
 
-        @MockitoBean
-        private JwtProvider jwtProvider;
+    @MockitoBean
+    private JwtProvider jwtProvider;
 
-        @MockitoBean
-        private UserService userService;
+    @MockitoBean
+    private UserService userService;
 
-        @Autowired
-        private ObjectMapper objectMapper;
+    @Autowired
+    private ObjectMapper objectMapper;
 
-        @Test
-        void registerAbsenceSuccessfully() throws Exception {
-                UUID id = UUID.randomUUID();
-                UUID generatedId = UUID.randomUUID();
-                UUID patientId = UUID.randomUUID();
-                UUID professionalId = UUID.randomUUID();
-                LocalDate date = LocalDate.now();
+    @Test
+    @DisplayName("Deve registrar falta com sucesso (201)")
+    void registerAbsenceSuccessfully() throws Exception {
+        UUID id = UUID.randomUUID();
+        UUID generatedId = UUID.randomUUID();
+        UUID patientId = UUID.randomUUID();
+        UUID professionalId = UUID.randomUUID();
+        LocalDate date = LocalDate.now();
 
-                CreateAbsenceDTO request = new CreateAbsenceDTO(
-                        generatedId,
-                        date,
-                        false,
-                        null,
-                        null);
+        CreateAbsenceDTO request = new CreateAbsenceDTO(
+                generatedId,
+                date,
+                false,
+                null,
+                null);
 
-                AbsenceResponseDTO response = new AbsenceResponseDTO(
-                        id,
-                        generatedId,
-                        patientId,
-                        professionalId,
-                        date,
-                        null,
-                        false,
-                        false,
-                        null);
+        AbsenceResponseDTO response = new AbsenceResponseDTO(
+                id,
+                generatedId,
+                patientId,
+                professionalId,
+                date,
+                null,
+                false,
+                false,
+                null);
 
-                when(service.register(any(CreateAbsenceDTO.class))).thenReturn(response);
+        when(service.register(any(CreateAbsenceDTO.class))).thenReturn(response);
 
-                var result = mockMvc.perform(post("/absences")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(request)))
-                        .andReturn();
+        var result = mockMvc.perform(post("/absences")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andReturn();
 
-                assertEquals(201, result.getResponse().getStatus());
-                assertNotNull(result.getResponse().getHeader("Location"));
-                assertTrue(result.getResponse().getHeader("Location").contains(id.toString()));
+        assertEquals(201, result.getResponse().getStatus());
+        assertNotNull(result.getResponse().getHeader("Location"));
+        assertTrue(result.getResponse().getHeader("Location").contains(id.toString()));
 
-                AbsenceResponseDTO body = objectMapper.readValue(
-                        result.getResponse().getContentAsString(), AbsenceResponseDTO.class);
+        AbsenceResponseDTO body = objectMapper.readValue(
+                result.getResponse().getContentAsString(), AbsenceResponseDTO.class);
 
-                assertEquals(id, body.id());
-                assertEquals(generatedId, body.generatedAppointmentId());
-                assertFalse(body.notified());
-                assertFalse(body.isJustified());
-        }
+        assertEquals(id, body.id());
+        assertEquals(generatedId, body.generatedAppointmentId());
+        assertFalse(body.notified());
+        assertFalse(body.isJustified());
+    }
 
-        @Test
-        void shouldReturnBadRequestWhenRegisterWithNullGeneratedAppointmentId() throws Exception {
-                CreateAbsenceDTO invalidRequest = new CreateAbsenceDTO(
-                        null,
-                        LocalDate.now(),
-                        false,
-                        null,
-                        null);
+    @Test
+    @DisplayName("Deve retornar BadRequest (400) ao tentar registrar falta com ID de agendamento nulo")
+    void shouldReturnBadRequestWhenRegisterWithNullGeneratedAppointmentId() throws Exception {
+        CreateAbsenceDTO invalidRequest = new CreateAbsenceDTO(
+                null,
+                LocalDate.now(),
+                false,
+                null,
+                null);
 
-                var result = mockMvc.perform(post("/absences")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(invalidRequest)))
-                        .andReturn();
+        var result = mockMvc.perform(post("/absences")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequest)))
+                .andReturn();
 
-                assertEquals(400, result.getResponse().getStatus());
-        }
+        assertEquals(400, result.getResponse().getStatus());
+    }
 
-        @Test
-        void shouldReturnBadRequestWhenRegisterWithNullAbsenceDate() throws Exception {
-                CreateAbsenceDTO invalidRequest = new CreateAbsenceDTO(
-                        UUID.randomUUID(),
-                        null,
-                        false,
-                        null,
-                        null);
+    @Test
+    @DisplayName("Deve retornar BadRequest (400) ao tentar registrar falta com data nula")
+    void shouldReturnBadRequestWhenRegisterWithNullAbsenceDate() throws Exception {
+        CreateAbsenceDTO invalidRequest = new CreateAbsenceDTO(
+                UUID.randomUUID(),
+                null,
+                false,
+                null,
+                null);
 
-                var result = mockMvc.perform(post("/absences")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(invalidRequest)))
-                        .andReturn();
+        var result = mockMvc.perform(post("/absences")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequest)))
+                .andReturn();
 
-                assertEquals(400, result.getResponse().getStatus());
-        }
+        assertEquals(400, result.getResponse().getStatus());
+    }
 
-        @Test
-        void shouldReturnBadRequestWhenServiceThrowsExceptionOnRegister() throws Exception {
-                CreateAbsenceDTO request = new CreateAbsenceDTO(
-                        UUID.randomUUID(),
-                        LocalDate.now(),
-                        false,
-                        null,
-                        null);
+    @Test
+    @DisplayName("Deve retornar BadRequest (400) quando o serviço lançar exceção ao registrar falta")
+    void shouldReturnBadRequestWhenServiceThrowsExceptionOnRegister() throws Exception {
+        CreateAbsenceDTO request = new CreateAbsenceDTO(
+                UUID.randomUUID(),
+                LocalDate.now(),
+                false,
+                null,
+                null);
 
-                when(service.register(any(CreateAbsenceDTO.class)))
-                        .thenThrow(new IllegalArgumentException("Falta já registrada"));
+        when(service.register(any(CreateAbsenceDTO.class)))
+                .thenThrow(new IllegalArgumentException("Falta já registrada"));
 
-                var result = mockMvc.perform(post("/absences")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(request)))
-                        .andReturn();
+        var result = mockMvc.perform(post("/absences")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andReturn();
 
-                assertEquals(400, result.getResponse().getStatus());
-        }
+        assertEquals(400, result.getResponse().getStatus());
+    }
 
-        // ==================== findAll ====================
+    // ==================== findAll ====================
 
-        @Test
-        void searchForAbsencesUsingFiltersAndPagination() throws Exception {
-                UUID generatedId = UUID.randomUUID();
-                UUID patientId = UUID.randomUUID();
-                UUID professionalId = UUID.randomUUID();
-                LocalDate date = LocalDate.now();
+    @Test
+    @DisplayName("Deve buscar faltas utilizando filtros e paginação com sucesso (200)")
+    void searchForAbsencesUsingFiltersAndPagination() throws Exception {
+        UUID generatedId = UUID.randomUUID();
+        UUID patientId = UUID.randomUUID();
+        UUID professionalId = UUID.randomUUID();
+        LocalDate date = LocalDate.now();
 
-                AbsenceResponseDTO response = new AbsenceResponseDTO(
-                        UUID.randomUUID(),
-                        generatedId,
-                        patientId,
-                        professionalId,
-                        date,
-                        "Falta justificada",
-                        true,
-                        true,
-                        null);
+        AbsenceResponseDTO response = new AbsenceResponseDTO(
+                UUID.randomUUID(),
+                generatedId,
+                patientId,
+                professionalId,
+                date,
+                "Falta justificada",
+                true,
+                true,
+                null);
 
-                Page<AbsenceResponseDTO> page = new PageImpl<>(
-                        List.of(response),
-                        PageRequest.of(0, 10),
-                        1);
+        Page<AbsenceResponseDTO> page = new PageImpl<>(
+                List.of(response),
+                PageRequest.of(0, 10),
+                1);
 
-                when(service.findAllByFilters(any(), any(), any(), any())).thenReturn(page);
+        when(service.findAllByFilters(any(), any(), any(), any())).thenReturn(page);
 
-                var result = mockMvc.perform(get("/absences")
-                                .param("generatedId", generatedId.toString())
-                                .param("patientId", patientId.toString())
-                                .param("professionalId", professionalId.toString())
-                                .param("page", "0")
-                                .param("size", "10"))
-                        .andReturn();
+        var result = mockMvc.perform(get("/absences")
+                        .param("generatedId", generatedId.toString())
+                        .param("patientId", patientId.toString())
+                        .param("professionalId", professionalId.toString())
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andReturn();
 
-                assertEquals(200, result.getResponse().getStatus());
+        assertEquals(200, result.getResponse().getStatus());
 
-                String json = result.getResponse().getContentAsString();
-                assertTrue(json.contains("\"content\""));
-                assertTrue(json.contains("Falta justificada"));
-                assertTrue(json.contains("\"notified\":true"));
-                assertTrue(json.contains("\"isJustified\":true"));
-        }
+        String json = result.getResponse().getContentAsString();
+        assertTrue(json.contains("\"content\""));
+        assertTrue(json.contains("Falta justificada"));
+        assertTrue(json.contains("\"notified\":true"));
+        assertTrue(json.contains("\"isJustified\":true"));
+    }
 
-        @Test
-        void shouldSearchAbsencesWithoutFilters() throws Exception {
-                AbsenceResponseDTO response = new AbsenceResponseDTO(
-                        UUID.randomUUID(),
-                        UUID.randomUUID(),
-                        UUID.randomUUID(),
-                        UUID.randomUUID(),
-                        LocalDate.now(),
-                        null,
-                        false,
-                        false,
-                        null);
+    @Test
+    @DisplayName("Deve buscar faltas sem utilizar filtros com sucesso (200)")
+    void shouldSearchAbsencesWithoutFilters() throws Exception {
+        AbsenceResponseDTO response = new AbsenceResponseDTO(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                LocalDate.now(),
+                null,
+                false,
+                false,
+                null);
 
-                Page<AbsenceResponseDTO> page = new PageImpl<>(List.of(response));
+        Page<AbsenceResponseDTO> page = new PageImpl<>(List.of(response));
 
-                when(service.findAllByFilters(isNull(), isNull(), isNull(), any()))
-                        .thenReturn(page);
+        when(service.findAllByFilters(isNull(), isNull(), isNull(), any()))
+                .thenReturn(page);
 
-                var result = mockMvc.perform(get("/absences")
-                                .param("page", "0")
-                                .param("size", "10"))
-                        .andReturn();
+        var result = mockMvc.perform(get("/absences")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andReturn();
 
-                assertEquals(200, result.getResponse().getStatus());
+        assertEquals(200, result.getResponse().getStatus());
 
-                String json = result.getResponse().getContentAsString();
-                assertTrue(json.contains("\"content\""));
-                assertTrue(json.contains("\"notified\":false"));
-        }
+        String json = result.getResponse().getContentAsString();
+        assertTrue(json.contains("\"content\""));
+        assertTrue(json.contains("\"notified\":false"));
+    }
 
-        @Test
-        void shouldReturnEmptyPageWhenNoAbsencesFound() throws Exception {
-                when(service.findAllByFilters(isNull(), isNull(), isNull(), any()))
-                        .thenReturn(Page.empty());
+    @Test
+    @DisplayName("Deve retornar página vazia quando nenhuma falta for encontrada (200)")
+    void shouldReturnEmptyPageWhenNoAbsencesFound() throws Exception {
+        when(service.findAllByFilters(isNull(), isNull(), isNull(), any()))
+                .thenReturn(Page.empty());
 
-                var result = mockMvc.perform(get("/absences")
-                                .param("page", "0")
-                                .param("size", "10"))
-                        .andReturn();
+        var result = mockMvc.perform(get("/absences")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andReturn();
 
-                assertEquals(200, result.getResponse().getStatus());
+        assertEquals(200, result.getResponse().getStatus());
 
-                String json = result.getResponse().getContentAsString();
-                assertTrue(json.contains("\"content\":[]"));
-        }
+        String json = result.getResponse().getContentAsString();
+        assertTrue(json.contains("\"content\":[]"));
+    }
 
-        // ==================== justifyAbsence ====================
+    // ==================== justifyAbsence ====================
 
-        @Test
-        void justifyAbsenceSuccessfully() throws Exception {
-                UUID absenceId = UUID.randomUUID();
-                UUID generatedId = UUID.randomUUID();
-                UUID patientId = UUID.randomUUID();
-                UUID professionalId = UUID.randomUUID();
-                LocalDate date = LocalDate.now();
-                String documentId = "doc-123";
+    @Test
+    @DisplayName("Deve justificar falta com sucesso (200)")
+    void justifyAbsenceSuccessfully() throws Exception {
+        UUID absenceId = UUID.randomUUID();
+        UUID generatedId = UUID.randomUUID();
+        UUID patientId = UUID.randomUUID();
+        UUID professionalId = UUID.randomUUID();
+        LocalDate date = LocalDate.now();
+        String documentId = "doc-123";
 
-                JustifyAbsenceDTO request = new JustifyAbsenceDTO(
-                        "Motivo de saúde urgente",
-                        documentId);
+        JustifyAbsenceDTO request = new JustifyAbsenceDTO(
+                "Motivo de saúde urgente",
+                documentId);
 
-                AbsenceResponseDTO response = new AbsenceResponseDTO(
-                        absenceId,
-                        generatedId,
-                        patientId,
-                        professionalId,
-                        date,
-                        "Motivo de saúde urgente",
-                        false,
-                        true,
-                        documentId);
+        AbsenceResponseDTO response = new AbsenceResponseDTO(
+                absenceId,
+                generatedId,
+                patientId,
+                professionalId,
+                date,
+                "Motivo de saúde urgente",
+                false,
+                true,
+                documentId);
 
-                when(service.justify(eq(absenceId), any(JustifyAbsenceDTO.class)))
-                        .thenReturn(response);
+        when(service.justify(eq(absenceId), any(JustifyAbsenceDTO.class)))
+                .thenReturn(response);
 
-                var result = mockMvc.perform(patch("/absences/{id}/justify", absenceId)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(request)))
-                        .andReturn();
+        var result = mockMvc.perform(patch("/absences/{id}/justify", absenceId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andReturn();
 
-                assertEquals(200, result.getResponse().getStatus());
+        assertEquals(200, result.getResponse().getStatus());
 
-                AbsenceResponseDTO body = objectMapper.readValue(
-                        result.getResponse().getContentAsString(), AbsenceResponseDTO.class);
+        AbsenceResponseDTO body = objectMapper.readValue(
+                result.getResponse().getContentAsString(), AbsenceResponseDTO.class);
 
-                assertEquals(absenceId, body.id());
-                assertEquals("Motivo de saúde urgente", body.justification());
-                assertTrue(body.isJustified());
-                assertEquals(documentId, body.justificationDocumentId());
-        }
+        assertEquals(absenceId, body.id());
+        assertEquals("Motivo de saúde urgente", body.justification());
+        assertTrue(body.isJustified());
+        assertEquals(documentId, body.justificationDocumentId());
+    }
 
-        @Test
-        void shouldReturnBadRequestWhenJustifyAbsenceWithBlankJustification() throws Exception {
-                UUID absenceId = UUID.randomUUID();
+    @Test
+    @DisplayName("Deve retornar BadRequest (400) ao tentar justificar falta com texto em branco")
+    void shouldReturnBadRequestWhenJustifyAbsenceWithBlankJustification() throws Exception {
+        UUID absenceId = UUID.randomUUID();
 
-                JustifyAbsenceDTO invalidRequest = new JustifyAbsenceDTO("", null);
+        JustifyAbsenceDTO invalidRequest = new JustifyAbsenceDTO("", null);
 
-                var result = mockMvc.perform(patch("/absences/{id}/justify", absenceId)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(invalidRequest)))
-                        .andReturn();
+        var result = mockMvc.perform(patch("/absences/{id}/justify", absenceId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequest)))
+                .andReturn();
 
-                assertEquals(400, result.getResponse().getStatus());
-        }
+        assertEquals(400, result.getResponse().getStatus());
+    }
 
-        @Test
-        void shouldReturnBadRequestWhenJustifyAbsenceWithNullJustification() throws Exception {
-                UUID absenceId = UUID.randomUUID();
+    @Test
+    @DisplayName("Deve retornar BadRequest (400) ao tentar justificar falta com texto nulo")
+    void shouldReturnBadRequestWhenJustifyAbsenceWithNullJustification() throws Exception {
+        UUID absenceId = UUID.randomUUID();
 
-                JustifyAbsenceDTO invalidRequest = new JustifyAbsenceDTO(null, null);
+        JustifyAbsenceDTO invalidRequest = new JustifyAbsenceDTO(null, null);
 
-                var result = mockMvc.perform(patch("/absences/{id}/justify", absenceId)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(invalidRequest)))
-                        .andReturn();
+        var result = mockMvc.perform(patch("/absences/{id}/justify", absenceId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequest)))
+                .andReturn();
 
-                assertEquals(400, result.getResponse().getStatus());
-        }
+        assertEquals(400, result.getResponse().getStatus());
+    }
 
-        @Test
-        void shouldReturnBadRequestWhenServiceThrowsExceptionOnJustify() throws Exception {
-                UUID absenceId = UUID.randomUUID();
+    @Test
+    @DisplayName("Deve retornar BadRequest (400) quando o serviço lançar exceção ao justificar falta")
+    void shouldReturnBadRequestWhenServiceThrowsExceptionOnJustify() throws Exception {
+        UUID absenceId = UUID.randomUUID();
 
-                JustifyAbsenceDTO request = new JustifyAbsenceDTO("Justificativa válida", null);
+        JustifyAbsenceDTO request = new JustifyAbsenceDTO("Justificativa válida", null);
 
-                when(service.justify(eq(absenceId), any(JustifyAbsenceDTO.class)))
-                        .thenThrow(new IllegalArgumentException("Falta não encontrada"));
+        when(service.justify(eq(absenceId), any(JustifyAbsenceDTO.class)))
+                .thenThrow(new IllegalArgumentException("Falta não encontrada"));
 
-                var result = mockMvc.perform(patch("/absences/{id}/justify", absenceId)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(request)))
-                        .andReturn();
+        var result = mockMvc.perform(patch("/absences/{id}/justify", absenceId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andReturn();
 
-                assertEquals(400, result.getResponse().getStatus());
-        }
+        assertEquals(400, result.getResponse().getStatus());
+    }
 }

--- a/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerImplTest.java
@@ -15,6 +15,7 @@ import br.org.apae.api.common.dto.appointment.response.appointment.TodayAppointm
 import br.org.apae.api.common.dto.patient.response.patient.PatientResponseDTO;
 import br.org.apae.api.common.dto.professional.response.HealthProfessionalResponseDTO;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -46,620 +47,645 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest({ AppointmentControllerImpl.class })
 class AppointmentControllerImplTest {
 
-  @Autowired
-  private MockMvc mockMvc;
-  @MockitoBean
-  private AppointmentApplicationService service;
-  @Autowired
-  private ObjectMapper objectMapper;
-  @MockitoBean
-  private JwtProvider jwtProvider;
-  @MockitoBean
-  private UserService userService;
-  private static final String URI = "/appointments";
-  private static final String URI_WITH_ID = URI + "/{id}";
-  private static final String GENERATED_URI_WITH_ID = URI + "/generated/{id}";
-
-  private AppointmentResponseDTO createAppointmentDTO(UUID id) {
-    return new AppointmentResponseDTO(
-            id,
-            mock(HealthProfessionalResponseDTO.class),
-            mock(AnnualRegistryResponseDTO.class),
-            7,
-            LocalDate.now(),
-            LocalDate.of(2026, 12, 31),
-            LocalTime.now().withNano(0),
-            true,
-            LocalDateTime.now().withNano(0),
-            null,
-            null
-    );
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldCreateAppointmentSuccessfully() throws Exception {
-    var payload = new CreateAppointmentDTO(
-        UUID.randomUUID(),
-        UUID.randomUUID(),
-        2,
-        LocalDate.now(),
-        LocalTime.now()
-    );
-
-    mockMvc.perform(post(URI)
-            .content(objectMapper.writeValueAsString(payload))
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(csrf()))
-        .andExpect(status().isCreated());
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldGetAppointmentByIdSuccessfully() throws Exception {
-    UUID id = UUID.randomUUID();
-
-    AppointmentResponseDTO response = createAppointmentDTO(id);
-
-    when(service.findById(id)).thenReturn(response);
-
-    mockMvc.perform(get(URI_WITH_ID, id)
-        .contentType(MediaType.APPLICATION_JSON)
-        .with(csrf()))
-      .andExpect(status().isOk())
-      .andExpect(jsonPath("$.id").value(response.id().toString()))
-      .andExpect(jsonPath("$.frequencyDays").value(response.frequencyDays()))
-      .andExpect(jsonPath("$.initialDate").value(response.initialDate().toString()))
-      .andExpect(jsonPath("$.endDate").value(response.endDate().toString()))
-      .andExpect(jsonPath("$.hour").value(response.hour().toString()))
-      .andExpect(jsonPath("$.isActive").value(response.isActive()))
-      .andExpect(jsonPath("$.creationDate").value(response.creationDate().toString()));
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldDeleteAppointmentSuccessfully() throws Exception {
-    UUID id = UUID.randomUUID();
-
-    mockMvc.perform(delete(URI_WITH_ID, id)
-            .with(csrf()))
-        .andExpect(status().isNoContent());
-
-    verify(service, times(1)).delete(id);
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldRescheduleAppointmentSuccessfully() throws Exception {
-    UUID id = UUID.randomUUID();
-    var response = new GeneratedAppointmentResponseDTO(
-            id,
-            UUID.randomUUID(),
-            LocalDateTime.now().withNano(0),
-            null,
-            false,
-            false,
-            null,
-            UUID.randomUUID(),
-            LocalDateTime.now().withNano(0)
-    );
-
-    LocalDateTime localDateTime = LocalDateTime.now().withNano(0);
-    var payload = new RescheduleGeneratedAppointmentDTO(localDateTime);
-
-    when(service.reschedule(id, payload.newDateTime())).thenReturn(response);
-
-    mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/reschedule", id)
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(objectMapper.writeValueAsString(payload))
-        .with(csrf()))
-      .andExpect(status().isOk())
-      .andExpect(jsonPath("$.id").value(response.id().toString()))
-      .andExpect(jsonPath("$.appointmentId").value(response.appointmentId().toString()))
-      .andExpect(jsonPath("$.scheduledDateTime").value(response.scheduledDateTime().toString()))
-      .andExpect(jsonPath("$.overriddenDateTime").isEmpty())
-      .andExpect(jsonPath("$.performed").isBoolean())
-      .andExpect(jsonPath("$.cancelled").isBoolean())
-      .andExpect(jsonPath("$.cancellationReason").isEmpty())
-      .andExpect(jsonPath("$.patientId").value(response.patientId().toString()))
-      .andExpect(jsonPath("$.effectiveDateTime").value(response.effectiveDateTime().toString()));
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldPerformedAppointmentSuccessfully() throws Exception {
-    UUID id = UUID.randomUUID();
-    var response = new GeneratedAppointmentResponseDTO(
-            id,
-            UUID.randomUUID(),
-            null,
-            null,
-            false,
-            false,
-            null,
-            UUID.randomUUID(),
-            LocalDateTime.now().withNano(0)
-    );
-
-    when(service.markAsPerformed(id)).thenReturn(response);
-
-    mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/performed", id)
-            .with(csrf()))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.id").value(response.id().toString()))
-        .andExpect(jsonPath("$.appointmentId").value(response.appointmentId().toString()))
-        .andExpect(jsonPath("$.scheduledDateTime").isEmpty())
-        .andExpect(jsonPath("$.overriddenDateTime").isEmpty())
-        .andExpect(jsonPath("$.performed").value(response.performed()))
-        .andExpect(jsonPath("$.cancelled").value(response.cancelled()))
-        .andExpect(jsonPath("$.cancellationReason").isEmpty())
-        .andExpect(jsonPath("$.patientId").value(response.patientId().toString()))
-        .andExpect(jsonPath("$.effectiveDateTime").value(response.effectiveDateTime().toString()));
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldCancelAppointmentSuccessfully() throws Exception {
-    UUID id = UUID.randomUUID();
-    var payload = new CancelGeneratedAppointmentDTO("cancel reason");
-
-    var response = new GeneratedAppointmentResponseDTO(
-        id,
-        UUID.randomUUID(),
-        null,
-        null,
-        false,
-        true,
-        payload.reason(),
-        UUID.randomUUID(),
-        LocalDateTime.now().withNano(0)
-    );
-
-    when(service.cancel(id, payload.reason())).thenReturn(response);
-
-    mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/cancel", id)
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(payload))
-            .with(csrf()))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.id").value(response.id().toString()))
-        .andExpect(jsonPath("$.appointmentId").value(response.appointmentId().toString()))
-        .andExpect(jsonPath("$.scheduledDateTime").isEmpty())
-        .andExpect(jsonPath("$.overriddenDateTime").isEmpty())
-        .andExpect(jsonPath("$.performed").value(response.performed()))
-        .andExpect(jsonPath("$.cancelled").value(response.cancelled()))
-        .andExpect(jsonPath("$.cancellationReason").value(response.cancellationReason()))
-        .andExpect(jsonPath("$.patientId").value(response.patientId().toString()))
-        .andExpect(jsonPath("$.effectiveDateTime").value(response.effectiveDateTime().toString()));
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldUpdateAppointmentRuleSuccessfully() throws Exception {
-    UUID id = UUID.randomUUID();
-
-    var payload = new UpdateAppointmentDTO(
-            UUID.randomUUID(),
-            UUID.randomUUID(),
-            UUID.randomUUID(),
-            14,
-            LocalDate.now().plusDays(1),
-            LocalTime.of(10, 30, 0),
-            LocalDate.now().plusDays(30)
-    );
-
-    var response = new AppointmentResponseDTO(
-            id,
-            mock(HealthProfessionalResponseDTO.class),
-            mock(AnnualRegistryResponseDTO.class),
-            payload.frequencyDays(),
-            payload.initialDate(),
-            payload.endDate(),
-            payload.hour(),
-            true,
-            LocalDateTime.now().withNano(0),
-            null,
-            null
-    );
-
-    when(service.update(id, payload)).thenReturn(response);
-
-    mockMvc.perform(patch(URI_WITH_ID, id)
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(payload))
-            .with(csrf()))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.id").value(response.id().toString()))
-        .andExpect(jsonPath("$.frequencyDays").value(response.frequencyDays()))
-        .andExpect(jsonPath("$.hour").value(response.hour().format(DateTimeFormatter.ISO_LOCAL_TIME)))
-        .andExpect(jsonPath("$.isActive").value(response.isActive()))
-        .andExpect(jsonPath("$.creationDate").value(response.creationDate().toString()));
-
-    verify(service, times(1)).update(eq(id), any(UpdateAppointmentDTO.class));
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldListGeneratedAppointmentsByPatientSuccessfully() throws Exception {
-    UUID patientId = UUID.randomUUID();
-
-    LocalDate start = LocalDate.of(2026, 1, 1);
-    LocalDate end = LocalDate.of(2026, 1, 31);
-
-    var response = new GeneratedAppointmentResponseDTO(
-        UUID.randomUUID(),
-        UUID.randomUUID(),
-        LocalDateTime.now().withNano(0),
-        null,
-        false,
-        false,
-        null,
-        patientId,
-        null
-    );
-
-    Page<GeneratedAppointmentResponseDTO> page =
-        new PageImpl<>(List.of(response), PageRequest.of(0, 10), 1);
-
-    when(service.listByPatient(eq(patientId), eq(start), eq(end), any(Pageable.class)))
-        .thenReturn(page);
-
-    mockMvc.perform(get(URI + "/patient/{patientId}", patientId)
-            .param("start", start.toString())
-            .param("end", end.toString())
-            .param("page", "0")
-            .param("size", "10")
-            .with(csrf()))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.content").isArray())
-        .andExpect(jsonPath("$.content.length()").value(1))
-        .andExpect(jsonPath("$.content[0].id").value(response.id().toString()))
-        .andExpect(jsonPath("$.content[0].appointmentId").value(response.appointmentId().toString()))
-        .andExpect(jsonPath("$.content[0].scheduledDateTime").value(response.scheduledDateTime().toString()))
-        .andExpect(jsonPath("$.content[0].performed").value(response.performed()))
-        .andExpect(jsonPath("$.content[0].cancelled").value(response.cancelled()))
-        .andExpect(jsonPath("$.content[0].patientId").value(response.patientId().toString()));
-
-    verify(service, times(1))
-        .listByPatient(eq(patientId), eq(start), eq(end), any(Pageable.class));
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldListTodayAppointmentsSuccessfully() throws Exception {
-    LocalDate date = LocalDate.now();
-
-    var response = new TodayAppointmentsResponseDTO(
-        UUID.randomUUID(),
-        mock(PatientResponseDTO.class),
-        mock(HealthProfessionalResponseDTO.class),
-        LocalDateTime.now().withNano(0),
-        null,
-        false,
-        false,
-        null,
-        null,
-        UUID.randomUUID(),
-        false
-    );
-
-    Page<TodayAppointmentsResponseDTO> page =
-        new PageImpl<>(List.of(response), PageRequest.of(0, 10), 1);
-
-    when(service.listAppointmentForToday(eq(date), any(Pageable.class)))
-        .thenReturn(page);
-
-    mockMvc.perform(get(URI + "/today")
-            .param("date", date.toString())
-            .param("page", "0")
-            .param("size", "10")
-            .with(csrf()))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.content").isArray())
-        .andExpect(jsonPath("$.content.length()").value(1))
-        .andExpect(jsonPath("$.content[0].id").value(response.id().toString()))
-        .andExpect(jsonPath("$.content[0].performed").value(response.performed()))
-        .andExpect(jsonPath("$.content[0].cancelled").value(response.cancelled()))
-        .andExpect(jsonPath("$.content[0].ruleId").value(response.ruleId().toString()));
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldGetAllAppointmentsSuccessfully() throws Exception {
-    LocalDate date = LocalDate.of(2026, 1, 21);
-    LocalTime time = LocalTime.of(10, 30);
-
-    AppointmentResponseDTO response1 = createAppointmentDTO(UUID.randomUUID()) ;
-
-    AppointmentResponseDTO response2 = createAppointmentDTO(UUID.randomUUID());
-    Page<AppointmentResponseDTO> page =
-        new PageImpl<>(List.of(response1, response2), PageRequest.of(0, 10), 2);
-
-    when(service.findAll(eq(date), eq(time), any(Pageable.class)))
-        .thenReturn(page);
-
-    mockMvc.perform(get(URI)
-            .param("date", date.toString())
-            .param("time", time.format(DateTimeFormatter.ISO_LOCAL_TIME))
-            .param("page", "0")
-            .param("size", "10")
-            .with(csrf()))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.content").isArray())
-        .andExpect(jsonPath("$.content.length()").value(2))
-        .andExpect(jsonPath("$.content[0].id").value(response1.id().toString()))
-        .andExpect(jsonPath("$.content[0].frequencyDays").value(response1.frequencyDays()))
-        .andExpect(jsonPath("$.content[0].hour").value(
-            response1.hour().format(DateTimeFormatter.ISO_LOCAL_TIME)))
-        .andExpect(jsonPath("$.content[1].id").value(response2.id().toString()))
-        .andExpect(jsonPath("$.content[1].frequencyDays").value(response2.frequencyDays()))
-        .andExpect(jsonPath("$.content[1].hour").value(
-            response2.hour().format(DateTimeFormatter.ISO_LOCAL_TIME)));
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldGetTodayAppointmentByIdSuccessfully() throws Exception {
-    UUID id = UUID.randomUUID();
-
-    var response = new TodayAppointmentsResponseDTO(
-            id,
-            mock(PatientResponseDTO.class),
-            mock(HealthProfessionalResponseDTO.class),
-            LocalDateTime.now().withNano(0),
-            null,
-            false,
-            false,
-            null,
-            LocalDateTime.now().withNano(0),
-            UUID.randomUUID(),
-            false
-    );
-
-    when(service.findGeneratedAppointmentById(id)).thenReturn(response);
-
-    mockMvc.perform(get(URI + "/today/{id}", id)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .with(csrf()))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.id").value(response.id().toString()))
-            .andExpect(jsonPath("$.scheduledDateTime").value(response.scheduledDateTime().toString()))
-            .andExpect(jsonPath("$.overriddenDateTime").isEmpty())
-            .andExpect(jsonPath("$.performed").value(response.performed()))
-            .andExpect(jsonPath("$.cancelled").value(response.cancelled()))
-            .andExpect(jsonPath("$.cancellationReason").isEmpty())
-            .andExpect(jsonPath("$.effectiveDateTime").value(response.effectiveDateTime().toString()))
-            .andExpect(jsonPath("$.ruleId").value(response.ruleId().toString()))
-            .andExpect(jsonPath("$.hasAbsence").value(response.hasAbsence()));
-
-    verify(service, times(1)).findGeneratedAppointmentById(id);
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldReturnNotFoundWhenGetNonExistentAppointment() throws Exception {
-    UUID id = UUID.randomUUID();
-
-    when(service.findById(id)).thenThrow(new AppointmentNotFoundException());
-
-    mockMvc.perform(get(URI_WITH_ID, id)
-                    .with(csrf()))
-            .andExpect(status().isNotFound());
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldReturnNotFoundWhenReschedulingNonExistentAppointment() throws Exception {
-    UUID id = UUID.randomUUID();
-    var payload = new RescheduleGeneratedAppointmentDTO(LocalDateTime.now().plusDays(1));
-
-    when(service.reschedule(any(), any())).thenThrow(new AppointmentNotFoundException());
-
-    mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/reschedule", id)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(payload))
-                    .with(csrf()))
-            .andExpect(status().isNotFound());
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldReturnBadRequestWhenCancellingAlreadyCancelledAppointment() throws Exception {
-    UUID id = UUID.randomUUID();
-    var payload = new CancelGeneratedAppointmentDTO("Motivo qualquer");
-
-    when(service.cancel(eq(id), anyString())).thenThrow(new AppointmentAlreadyCancelledException());
-
-    mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/cancel", id)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(payload))
-                    .with(csrf()))
-            .andExpect(status().isBadRequest());
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldReturnBadRequestWhenProfessionalIdIsNull() throws Exception {
-    var payload = new CreateAppointmentDTO(
-        UUID.randomUUID(),
-        null,
-        7,
-        LocalDate.now().plusDays(1),
-        LocalTime.now()
-    );
-
-    mockMvc.perform(post(URI)
-            .content(objectMapper.writeValueAsString(payload))
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(csrf()))
-        .andExpect(status().isBadRequest());
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldReturnBadRequestWhenPatientIdIsNull() throws Exception {
-    var payload = new CreateAppointmentDTO(
-            UUID.randomUUID(),
-            null,
-            7,
-            LocalDate.now().plusDays(1),
-            LocalTime.now()
-    );
-
-    mockMvc.perform(post(URI)
-            .content(objectMapper.writeValueAsString(payload))
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(csrf()))
-        .andExpect(status().isBadRequest());
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldReturnBadRequestWhenFrequencyDaysIsNull() throws Exception {
-    var payload = new CreateAppointmentDTO(
-            UUID.randomUUID(),
-            UUID.randomUUID(),
-            null,
-            LocalDate.now().plusDays(1),
-            LocalTime.now()
-    );
-
-    mockMvc.perform(post(URI)
-            .content(objectMapper.writeValueAsString(payload))
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(csrf()))
-        .andExpect(status().isBadRequest());
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldReturnBadRequestWhenFrequencyDaysIsZero() throws Exception {
-    var payload = new CreateAppointmentDTO(
-            UUID.randomUUID(),
-            UUID.randomUUID(),
-            0,
-            LocalDate.now().plusDays(1),
-            LocalTime.now()
-    );
-
-    mockMvc.perform(post(URI)
-            .content(objectMapper.writeValueAsString(payload))
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(csrf()))
-        .andExpect(status().isBadRequest());
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldReturnBadRequestWhenFrequencyDaysIsNegative() throws Exception {
-    var payload = new CreateAppointmentDTO(
-            UUID.randomUUID(),
-            UUID.randomUUID(),
-            -5,
-            LocalDate.now().plusDays(1),
-            LocalTime.now()
-    );
-
-    mockMvc.perform(post(URI)
-            .content(objectMapper.writeValueAsString(payload))
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(csrf()))
-        .andExpect(status().isBadRequest());
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldReturnBadRequestWhenInitialDateIsNull() throws Exception {
-    var payload = new CreateAppointmentDTO(
-            UUID.randomUUID(),
-            UUID.randomUUID(),
-            7,
-            null,
-            LocalTime.now()
-    );
-
-    mockMvc.perform(post(URI)
-            .content(objectMapper.writeValueAsString(payload))
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(csrf()))
-        .andExpect(status().isBadRequest());
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldReturnBadRequestWhenInitialDateIsInThePast() throws Exception {
-    var payload = new CreateAppointmentDTO(
-            UUID.randomUUID(),
-            UUID.randomUUID(),
-            7,
-            LocalDate.now().minusDays(1),
-            LocalTime.now()
-    );
-
-    mockMvc.perform(post(URI)
-            .content(objectMapper.writeValueAsString(payload))
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(csrf()))
-        .andExpect(status().isBadRequest());
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldReturnBadRequestWhenHourIsNull() throws Exception {
-    var payload = new CreateAppointmentDTO(
-            UUID.randomUUID(),
-            UUID.randomUUID(),
-            7,
-            LocalDate.now().minusDays(1),
-            null
-    );
-
-    mockMvc.perform(post(URI)
-            .content(objectMapper.writeValueAsString(payload))
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(csrf()))
-        .andExpect(status().isBadRequest());
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldReturnBadRequestWhenCreateBodyIsMissing() throws Exception {
-    mockMvc.perform(post(URI)
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(csrf()))
-        .andExpect(status().isBadRequest());
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldReturnNotFoundWhenListingAppointmentsByNonExistentPatient() throws Exception {
-    UUID patientId = UUID.randomUUID();
-    LocalDate start = LocalDate.of(2026, 1, 1);
-    LocalDate end = LocalDate.of(2026, 1, 31);
-
-    when(service.listByPatient(eq(patientId), eq(start), eq(end), any(Pageable.class)))
-            .thenThrow(new AppointmentNotFoundException());
-
-    mockMvc.perform(get(URI + "/patient/{patientId}", patientId)
-                    .param("start", start.toString())
-                    .param("end", end.toString())
-                    .param("page", "0")
-                    .param("size", "10")
-                    .with(csrf()))
-            .andExpect(status().isNotFound())
-            .andExpect(jsonPath("$.message").value("Agendamento não encontrado."));
-  }
-
-  @Test
-  @WithMockUser(username = "admin", roles = {"ADMIN"})
-  void shouldReturnNotFoundWhenGetTodayAppointmentByIdNonExistent() throws Exception {
-    UUID id = UUID.randomUUID();
-
-    when(service.findGeneratedAppointmentById(id))
-            .thenThrow(new AppointmentNotFoundException());
-
-    mockMvc.perform(get(URI + "/today/{id}", id)
-                    .with(csrf()))
-            .andExpect(status().isNotFound());
-  }
+    @Autowired
+    private MockMvc mockMvc;
+    @MockitoBean
+    private AppointmentApplicationService service;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @MockitoBean
+    private JwtProvider jwtProvider;
+    @MockitoBean
+    private UserService userService;
+    private static final String URI = "/appointments";
+    private static final String URI_WITH_ID = URI + "/{id}";
+    private static final String GENERATED_URI_WITH_ID = URI + "/generated/{id}";
+
+    private AppointmentResponseDTO createAppointmentDTO(UUID id) {
+        return new AppointmentResponseDTO(
+                id,
+                mock(HealthProfessionalResponseDTO.class),
+                mock(AnnualRegistryResponseDTO.class),
+                7,
+                LocalDate.now(),
+                LocalDate.of(2026, 12, 31),
+                LocalTime.now().withNano(0),
+                true,
+                LocalDateTime.now().withNano(0),
+                null,
+                null
+        );
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @DisplayName("Deve criar agendamento com sucesso (201)")
+    void shouldCreateAppointmentSuccessfully() throws Exception {
+        var payload = new CreateAppointmentDTO(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                2,
+                LocalDate.now(),
+                LocalTime.now()
+        );
+
+        mockMvc.perform(post(URI)
+                        .content(objectMapper.writeValueAsString(payload))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @DisplayName("Deve buscar agendamento por ID com sucesso (200)")
+    void shouldGetAppointmentByIdSuccessfully() throws Exception {
+        UUID id = UUID.randomUUID();
+
+        AppointmentResponseDTO response = createAppointmentDTO(id);
+
+        when(service.findById(id)).thenReturn(response);
+
+        mockMvc.perform(get(URI_WITH_ID, id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(response.id().toString()))
+                .andExpect(jsonPath("$.frequencyDays").value(response.frequencyDays()))
+                .andExpect(jsonPath("$.initialDate").value(response.initialDate().toString()))
+                .andExpect(jsonPath("$.endDate").value(response.endDate().toString()))
+                .andExpect(jsonPath("$.hour").value(response.hour().toString()))
+                .andExpect(jsonPath("$.isActive").value(response.isActive()))
+                .andExpect(jsonPath("$.creationDate").value(response.creationDate().toString()));
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @DisplayName("Deve deletar agendamento com sucesso (204)")
+    void shouldDeleteAppointmentSuccessfully() throws Exception {
+        UUID id = UUID.randomUUID();
+
+        mockMvc.perform(delete(URI_WITH_ID, id)
+                        .with(csrf()))
+                .andExpect(status().isNoContent());
+
+        verify(service, times(1)).delete(id);
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @DisplayName("Deve reagendar agendamento gerado com sucesso (200)")
+    void shouldRescheduleAppointmentSuccessfully() throws Exception {
+        UUID id = UUID.randomUUID();
+        var response = new GeneratedAppointmentResponseDTO(
+                id,
+                UUID.randomUUID(),
+                LocalDateTime.now().withNano(0),
+                null,
+                false,
+                false,
+                null,
+                UUID.randomUUID(),
+                LocalDateTime.now().withNano(0)
+        );
+
+        LocalDateTime localDateTime = LocalDateTime.now().withNano(0);
+        var payload = new RescheduleGeneratedAppointmentDTO(localDateTime);
+
+        when(service.reschedule(id, payload.newDateTime())).thenReturn(response);
+
+        mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/reschedule", id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(response.id().toString()))
+                .andExpect(jsonPath("$.appointmentId").value(response.appointmentId().toString()))
+                .andExpect(jsonPath("$.scheduledDateTime").value(response.scheduledDateTime().toString()))
+                .andExpect(jsonPath("$.overriddenDateTime").isEmpty())
+                .andExpect(jsonPath("$.performed").isBoolean())
+                .andExpect(jsonPath("$.cancelled").isBoolean())
+                .andExpect(jsonPath("$.cancellationReason").isEmpty())
+                .andExpect(jsonPath("$.patientId").value(response.patientId().toString()))
+                .andExpect(jsonPath("$.effectiveDateTime").value(response.effectiveDateTime().toString()));
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @DisplayName("Deve marcar agendamento como realizado com sucesso (200)")
+    void shouldPerformedAppointmentSuccessfully() throws Exception {
+        UUID id = UUID.randomUUID();
+        var response = new GeneratedAppointmentResponseDTO(
+                id,
+                UUID.randomUUID(),
+                null,
+                null,
+                false,
+                false,
+                null,
+                UUID.randomUUID(),
+                LocalDateTime.now().withNano(0)
+        );
+
+        when(service.markAsPerformed(id)).thenReturn(response);
+
+        mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/performed", id)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(response.id().toString()))
+                .andExpect(jsonPath("$.appointmentId").value(response.appointmentId().toString()))
+                .andExpect(jsonPath("$.scheduledDateTime").isEmpty())
+                .andExpect(jsonPath("$.overriddenDateTime").isEmpty())
+                .andExpect(jsonPath("$.performed").value(response.performed()))
+                .andExpect(jsonPath("$.cancelled").value(response.cancelled()))
+                .andExpect(jsonPath("$.cancellationReason").isEmpty())
+                .andExpect(jsonPath("$.patientId").value(response.patientId().toString()))
+                .andExpect(jsonPath("$.effectiveDateTime").value(response.effectiveDateTime().toString()));
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @DisplayName("Deve cancelar agendamento com sucesso (200)")
+    void shouldCancelAppointmentSuccessfully() throws Exception {
+        UUID id = UUID.randomUUID();
+        var payload = new CancelGeneratedAppointmentDTO("cancel reason");
+
+        var response = new GeneratedAppointmentResponseDTO(
+                id,
+                UUID.randomUUID(),
+                null,
+                null,
+                false,
+                true,
+                payload.reason(),
+                UUID.randomUUID(),
+                LocalDateTime.now().withNano(0)
+        );
+
+        when(service.cancel(id, payload.reason())).thenReturn(response);
+
+        mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/cancel", id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(response.id().toString()))
+                .andExpect(jsonPath("$.appointmentId").value(response.appointmentId().toString()))
+                .andExpect(jsonPath("$.scheduledDateTime").isEmpty())
+                .andExpect(jsonPath("$.overriddenDateTime").isEmpty())
+                .andExpect(jsonPath("$.performed").value(response.performed()))
+                .andExpect(jsonPath("$.cancelled").value(response.cancelled()))
+                .andExpect(jsonPath("$.cancellationReason").value(response.cancellationReason()))
+                .andExpect(jsonPath("$.patientId").value(response.patientId().toString()))
+                .andExpect(jsonPath("$.effectiveDateTime").value(response.effectiveDateTime().toString()));
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @DisplayName("Deve atualizar regra de agendamento com sucesso (200)")
+    void shouldUpdateAppointmentRuleSuccessfully() throws Exception {
+        UUID id = UUID.randomUUID();
+
+        var payload = new UpdateAppointmentDTO(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                14,
+                LocalDate.now().plusDays(1),
+                LocalTime.of(10, 30, 0),
+                LocalDate.now().plusDays(30)
+        );
+
+        var response = new AppointmentResponseDTO(
+                id,
+                mock(HealthProfessionalResponseDTO.class),
+                mock(AnnualRegistryResponseDTO.class),
+                payload.frequencyDays(),
+                payload.initialDate(),
+                payload.endDate(),
+                payload.hour(),
+                true,
+                LocalDateTime.now().withNano(0),
+                null,
+                null
+        );
+
+        when(service.update(id, payload)).thenReturn(response);
+
+        mockMvc.perform(patch(URI_WITH_ID, id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(response.id().toString()))
+                .andExpect(jsonPath("$.frequencyDays").value(response.frequencyDays()))
+                .andExpect(jsonPath("$.hour").value(response.hour().format(DateTimeFormatter.ISO_LOCAL_TIME)))
+                .andExpect(jsonPath("$.isActive").value(response.isActive()))
+                .andExpect(jsonPath("$.creationDate").value(response.creationDate().toString()));
+
+        verify(service, times(1)).update(eq(id), any(UpdateAppointmentDTO.class));
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @DisplayName("Deve listar agendamentos gerados por paciente com sucesso (200)")
+    void shouldListGeneratedAppointmentsByPatientSuccessfully() throws Exception {
+        UUID patientId = UUID.randomUUID();
+
+        LocalDate start = LocalDate.of(2026, 1, 1);
+        LocalDate end = LocalDate.of(2026, 1, 31);
+
+        var response = new GeneratedAppointmentResponseDTO(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                LocalDateTime.now().withNano(0),
+                null,
+                false,
+                false,
+                null,
+                patientId,
+                null
+        );
+
+        Page<GeneratedAppointmentResponseDTO> page =
+                new PageImpl<>(List.of(response), PageRequest.of(0, 10), 1);
+
+        when(service.listByPatient(eq(patientId), eq(start), eq(end), any(Pageable.class)))
+                .thenReturn(page);
+
+        mockMvc.perform(get(URI + "/patient/{patientId}", patientId)
+                        .param("start", start.toString())
+                        .param("end", end.toString())
+                        .param("page", "0")
+                        .param("size", "10")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content.length()").value(1))
+                .andExpect(jsonPath("$.content[0].id").value(response.id().toString()))
+                .andExpect(jsonPath("$.content[0].appointmentId").value(response.appointmentId().toString()))
+                .andExpect(jsonPath("$.content[0].scheduledDateTime").value(response.scheduledDateTime().toString()))
+                .andExpect(jsonPath("$.content[0].performed").value(response.performed()))
+                .andExpect(jsonPath("$.content[0].cancelled").value(response.cancelled()))
+                .andExpect(jsonPath("$.content[0].patientId").value(response.patientId().toString()));
+
+        verify(service, times(1))
+                .listByPatient(eq(patientId), eq(start), eq(end), any(Pageable.class));
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @DisplayName("Deve listar agendamentos do dia atual com sucesso (200)")
+    void shouldListTodayAppointmentsSuccessfully() throws Exception {
+        LocalDate date = LocalDate.now();
+
+        var response = new TodayAppointmentsResponseDTO(
+                UUID.randomUUID(),
+                mock(PatientResponseDTO.class),
+                mock(HealthProfessionalResponseDTO.class),
+                LocalDateTime.now().withNano(0),
+                null,
+                false,
+                false,
+                null,
+                null,
+                UUID.randomUUID(),
+                false
+        );
+
+        Page<TodayAppointmentsResponseDTO> page =
+                new PageImpl<>(List.of(response), PageRequest.of(0, 10), 1);
+
+        when(service.listAppointmentForToday(eq(date), any(Pageable.class)))
+                .thenReturn(page);
+
+        mockMvc.perform(get(URI + "/today")
+                        .param("date", date.toString())
+                        .param("page", "0")
+                        .param("size", "10")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content.length()").value(1))
+                .andExpect(jsonPath("$.content[0].id").value(response.id().toString()))
+                .andExpect(jsonPath("$.content[0].performed").value(response.performed()))
+                .andExpect(jsonPath("$.content[0].cancelled").value(response.cancelled()))
+                .andExpect(jsonPath("$.content[0].ruleId").value(response.ruleId().toString()));
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @DisplayName("Deve listar todos os agendamentos paginados com sucesso (200)")
+    void shouldGetAllAppointmentsSuccessfully() throws Exception {
+        LocalDate date = LocalDate.of(2026, 1, 21);
+        LocalTime time = LocalTime.of(10, 30);
+
+        AppointmentResponseDTO response1 = createAppointmentDTO(UUID.randomUUID()) ;
+
+        AppointmentResponseDTO response2 = createAppointmentDTO(UUID.randomUUID());
+        Page<AppointmentResponseDTO> page =
+                new PageImpl<>(List.of(response1, response2), PageRequest.of(0, 10), 2);
+
+        when(service.findAll(eq(date), eq(time), any(Pageable.class)))
+                .thenReturn(page);
+
+        mockMvc.perform(get(URI)
+                        .param("date", date.toString())
+                        .param("time", time.format(DateTimeFormatter.ISO_LOCAL_TIME))
+                        .param("page", "0")
+                        .param("size", "10")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content.length()").value(2))
+                .andExpect(jsonPath("$.content[0].id").value(response1.id().toString()))
+                .andExpect(jsonPath("$.content[0].frequencyDays").value(response1.frequencyDays()))
+                .andExpect(jsonPath("$.content[0].hour").value(
+                        response1.hour().format(DateTimeFormatter.ISO_LOCAL_TIME)))
+                .andExpect(jsonPath("$.content[1].id").value(response2.id().toString()))
+                .andExpect(jsonPath("$.content[1].frequencyDays").value(response2.frequencyDays()))
+                .andExpect(jsonPath("$.content[1].hour").value(
+                        response2.hour().format(DateTimeFormatter.ISO_LOCAL_TIME)));
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @DisplayName("Deve buscar agendamento do dia por ID com sucesso (200)")
+    void shouldGetTodayAppointmentByIdSuccessfully() throws Exception {
+        UUID id = UUID.randomUUID();
+
+        var response = new TodayAppointmentsResponseDTO(
+                id,
+                mock(PatientResponseDTO.class),
+                mock(HealthProfessionalResponseDTO.class),
+                LocalDateTime.now().withNano(0),
+                null,
+                false,
+                false,
+                null,
+                LocalDateTime.now().withNano(0),
+                UUID.randomUUID(),
+                false
+        );
+
+        when(service.findGeneratedAppointmentById(id)).thenReturn(response);
+
+        mockMvc.perform(get(URI + "/today/{id}", id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(response.id().toString()))
+                .andExpect(jsonPath("$.scheduledDateTime").value(response.scheduledDateTime().toString()))
+                .andExpect(jsonPath("$.overriddenDateTime").isEmpty())
+                .andExpect(jsonPath("$.performed").value(response.performed()))
+                .andExpect(jsonPath("$.cancelled").value(response.cancelled()))
+                .andExpect(jsonPath("$.cancellationReason").isEmpty())
+                .andExpect(jsonPath("$.effectiveDateTime").value(response.effectiveDateTime().toString()))
+                .andExpect(jsonPath("$.ruleId").value(response.ruleId().toString()))
+                .andExpect(jsonPath("$.hasAbsence").value(response.hasAbsence()));
+
+        verify(service, times(1)).findGeneratedAppointmentById(id);
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @DisplayName("Deve retornar NotFound (404) ao buscar agendamento inexistente")
+    void shouldReturnNotFoundWhenGetNonExistentAppointment() throws Exception {
+        UUID id = UUID.randomUUID();
+
+        when(service.findById(id)).thenThrow(new AppointmentNotFoundException());
+
+        mockMvc.perform(get(URI_WITH_ID, id)
+                        .with(csrf()))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @DisplayName("Deve retornar NotFound (404) ao tentar reagendar agendamento inexistente")
+    void shouldReturnNotFoundWhenReschedulingNonExistentAppointment() throws Exception {
+        UUID id = UUID.randomUUID();
+        var payload = new RescheduleGeneratedAppointmentDTO(LocalDateTime.now().plusDays(1));
+
+        when(service.reschedule(any(), any())).thenThrow(new AppointmentNotFoundException());
+
+        mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/reschedule", id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload))
+                        .with(csrf()))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @DisplayName("Deve retornar BadRequest (400) ao tentar cancelar um agendamento já cancelado")
+    void shouldReturnBadRequestWhenCancellingAlreadyCancelledAppointment() throws Exception {
+        UUID id = UUID.randomUUID();
+        var payload = new CancelGeneratedAppointmentDTO("Motivo qualquer");
+
+        when(service.cancel(eq(id), anyString())).thenThrow(new AppointmentAlreadyCancelledException());
+
+        mockMvc.perform(patch(GENERATED_URI_WITH_ID + "/cancel", id)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload))
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @DisplayName("Deve retornar BadRequest (400) ao tentar criar agendamento sem ID do profissional")
+    void shouldReturnBadRequestWhenProfessionalIdIsNull() throws Exception {
+        var payload = new CreateAppointmentDTO(
+                UUID.randomUUID(),
+                null,
+                7,
+                LocalDate.now().plusDays(1),
+                LocalTime.now()
+        );
+
+        mockMvc.perform(post(URI)
+                        .content(objectMapper.writeValueAsString(payload))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @DisplayName("Deve retornar BadRequest (400) ao tentar criar agendamento sem ID do paciente")
+    void shouldReturnBadRequestWhenPatientIdIsNull() throws Exception {
+        var payload = new CreateAppointmentDTO(
+                UUID.randomUUID(),
+                null,
+                7,
+                LocalDate.now().plusDays(1),
+                LocalTime.now()
+        );
+
+        mockMvc.perform(post(URI)
+                        .content(objectMapper.writeValueAsString(payload))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @DisplayName("Deve retornar BadRequest (400) ao tentar criar agendamento com frequência nula")
+    void shouldReturnBadRequestWhenFrequencyDaysIsNull() throws Exception {
+        var payload = new CreateAppointmentDTO(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                null,
+                LocalDate.now().plusDays(1),
+                LocalTime.now()
+        );
+
+        mockMvc.perform(post(URI)
+                        .content(objectMapper.writeValueAsString(payload))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @DisplayName("Deve retornar BadRequest (400) ao tentar criar agendamento com frequência igual a zero")
+    void shouldReturnBadRequestWhenFrequencyDaysIsZero() throws Exception {
+        var payload = new CreateAppointmentDTO(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                0,
+                LocalDate.now().plusDays(1),
+                LocalTime.now()
+        );
+
+        mockMvc.perform(post(URI)
+                        .content(objectMapper.writeValueAsString(payload))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @DisplayName("Deve retornar BadRequest (400) ao tentar criar agendamento com frequência negativa")
+    void shouldReturnBadRequestWhenFrequencyDaysIsNegative() throws Exception {
+        var payload = new CreateAppointmentDTO(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                -5,
+                LocalDate.now().plusDays(1),
+                LocalTime.now()
+        );
+
+        mockMvc.perform(post(URI)
+                        .content(objectMapper.writeValueAsString(payload))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @DisplayName("Deve retornar BadRequest (400) ao tentar criar agendamento com data inicial nula")
+    void shouldReturnBadRequestWhenInitialDateIsNull() throws Exception {
+        var payload = new CreateAppointmentDTO(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                7,
+                null,
+                LocalTime.now()
+        );
+
+        mockMvc.perform(post(URI)
+                        .content(objectMapper.writeValueAsString(payload))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @DisplayName("Deve retornar BadRequest (400) ao tentar criar agendamento com data inicial no passado")
+    void shouldReturnBadRequestWhenInitialDateIsInThePast() throws Exception {
+        var payload = new CreateAppointmentDTO(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                7,
+                LocalDate.now().minusDays(1),
+                LocalTime.now()
+        );
+
+        mockMvc.perform(post(URI)
+                        .content(objectMapper.writeValueAsString(payload))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @DisplayName("Deve retornar BadRequest (400) ao tentar criar agendamento com horário nulo")
+    void shouldReturnBadRequestWhenHourIsNull() throws Exception {
+        var payload = new CreateAppointmentDTO(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                7,
+                LocalDate.now().minusDays(1),
+                null
+        );
+
+        mockMvc.perform(post(URI)
+                        .content(objectMapper.writeValueAsString(payload))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @DisplayName("Deve retornar BadRequest (400) ao tentar criar agendamento sem corpo na requisição")
+    void shouldReturnBadRequestWhenCreateBodyIsMissing() throws Exception {
+        mockMvc.perform(post(URI)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @DisplayName("Deve retornar NotFound (404) ao listar agendamentos de um paciente inexistente")
+    void shouldReturnNotFoundWhenListingAppointmentsByNonExistentPatient() throws Exception {
+        UUID patientId = UUID.randomUUID();
+        LocalDate start = LocalDate.of(2026, 1, 1);
+        LocalDate end = LocalDate.of(2026, 1, 31);
+
+        when(service.listByPatient(eq(patientId), eq(start), eq(end), any(Pageable.class)))
+                .thenThrow(new AppointmentNotFoundException());
+
+        mockMvc.perform(get(URI + "/patient/{patientId}", patientId)
+                        .param("start", start.toString())
+                        .param("end", end.toString())
+                        .param("page", "0")
+                        .param("size", "10")
+                        .with(csrf()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("Agendamento não encontrado."));
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @DisplayName("Deve retornar NotFound (404) ao buscar agendamento do dia inexistente")
+    void shouldReturnNotFoundWhenGetTodayAppointmentByIdNonExistent() throws Exception {
+        UUID id = UUID.randomUUID();
+
+        when(service.findGeneratedAppointmentById(id))
+                .thenThrow(new AppointmentNotFoundException());
+
+        mockMvc.perform(get(URI + "/today/{id}", id)
+                        .with(csrf()))
+                .andExpect(status().isNotFound());
+    }
 }

--- a/apps/api/src/test/java/br/org/apae/api/controllers/disorder/DisorderControllerImplTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/disorder/DisorderControllerImplTest.java
@@ -12,6 +12,7 @@ import br.org.apae.api.patient.domain.exceptions.DisorderConflictException;
 import br.org.apae.api.patient.domain.exceptions.DisorderNotFoundException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -82,6 +83,7 @@ class DisorderControllerImplTest {
     }
 
     @Test
+    @DisplayName("Deve criar transtorno com sucesso (201)")
     void shouldCreateDisordSucess() throws Exception {
         CreateDisorderDTO requestDto = new CreateDisorderDTO("Transtorno Ansioso");
         UUID idGerado = UUID.randomUUID();
@@ -102,6 +104,7 @@ class DisorderControllerImplTest {
     }
 
     @Test
+    @DisplayName("Deve buscar todos os transtornos com sucesso (200)")
     void shouldGetAllDisordersSucess() throws Exception {
         DisorderResponseDTO d1 = new DisorderResponseDTO(UUID.randomUUID(), "Transtorno A", false);
         DisorderResponseDTO d2 = new DisorderResponseDTO(UUID.randomUUID(), "Transtorno B", false);
@@ -120,6 +123,7 @@ class DisorderControllerImplTest {
     }
 
     @Test
+    @DisplayName("Deve buscar transtorno por ID com sucesso (200)")
     void shouldSearchDisordsByIdSucess() throws Exception {
         UUID id = UUID.randomUUID();
         DisorderResponseDTO responseDto = new DisorderResponseDTO(id, "Transtorno Específico", false);
@@ -136,6 +140,7 @@ class DisorderControllerImplTest {
     }
 
     @Test
+    @DisplayName("Deve atualizar transtorno com sucesso (200)")
     void SouldUpdateDisorderSucess() throws Exception {
         UUID id = UUID.randomUUID();
         UpdateDisorderDTO updateDto = new UpdateDisorderDTO("Transtorno Atualizado");
@@ -154,6 +159,7 @@ class DisorderControllerImplTest {
     }
 
     @Test
+    @DisplayName("Deve deletar transtorno com sucesso (204)")
     void shouldRemoveDisorderSucess() throws Exception {
         UUID id = UUID.randomUUID();
 
@@ -164,6 +170,7 @@ class DisorderControllerImplTest {
     }
 
     @Test
+    @DisplayName("Deve retornar Conflict (409) ao tentar criar transtorno com nome duplicado")
     void shouldReturnConflictWhenCreateDisorderWithDuplicateName() throws Exception {
         CreateDisorderDTO requestDto = new CreateDisorderDTO("Transtorno Duplicado");
 
@@ -179,6 +186,7 @@ class DisorderControllerImplTest {
     }
 
     @Test
+    @DisplayName("Deve retornar NotFound (404) ao buscar transtorno inexistente")
     void shouldReturnNotFoundWhenSearchDisorderByIdNonExistent() throws Exception {
         UUID id = UUID.randomUUID();
 
@@ -192,6 +200,7 @@ class DisorderControllerImplTest {
     }
 
     @Test
+    @DisplayName("Deve retornar NotFound (404) ao tentar atualizar transtorno inexistente")
     void shouldReturnNotFoundWhenUpdateDisorderNonExistent() throws Exception {
         UUID id = UUID.randomUUID();
         UpdateDisorderDTO updateDto = new UpdateDisorderDTO("Nome qualquer");
@@ -208,6 +217,7 @@ class DisorderControllerImplTest {
     }
 
     @Test
+    @DisplayName("Deve retornar Conflict (409) ao tentar atualizar transtorno gerando nome duplicado")
     void shouldReturnConflictWhenUpdateDisorderWithDuplicateName() throws Exception {
         UUID id = UUID.randomUUID();
         UpdateDisorderDTO updateDto = new UpdateDisorderDTO("Nome Já Existe");
@@ -224,6 +234,7 @@ class DisorderControllerImplTest {
     }
 
     @Test
+    @DisplayName("Deve retornar NotFound (404) ao tentar deletar transtorno inexistente")
     void shouldReturnNotFoundWhenDeleteDisorderNonExistent() throws Exception {
         UUID id = UUID.randomUUID();
 

--- a/apps/api/src/test/java/br/org/apae/api/controllers/patient/PatientDocumentsTests.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/patient/PatientDocumentsTests.java
@@ -1,4 +1,3 @@
-
 package br.org.apae.api.controllers.patient;
 
 import br.org.apae.api.auth.application.internal.UserService;
@@ -37,146 +36,146 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 @Tags({
-    @Tag("controller"),
-    @Tag("patient"),
-    @Tag("documents")
+        @Tag("controller"),
+        @Tag("patient"),
+        @Tag("documents")
 })
 @WebMvcTest(PatientDocumentsControllerImpl.class)
 class PatientDocumentsTests {
 
-  @Autowired
-  private MockMvc mockMvc;
+    @Autowired
+    private MockMvc mockMvc;
 
-  @MockitoBean
-  private DocumentApplicationService documentService;
+    @MockitoBean
+    private DocumentApplicationService documentService;
 
-  @MockitoBean
-  private JwtProvider jwtProvider;
+    @MockitoBean
+    private JwtProvider jwtProvider;
 
-  @MockitoBean
-  private UserService userService;
+    @MockitoBean
+    private UserService userService;
 
-  private UUID patientId() {
-    return UUID.randomUUID();
-  }
+    private UUID patientId() {
+        return UUID.randomUUID();
+    }
 
-  private DocumentDTO document(DocumentCategory category) {
-    return new DocumentDTO(
-        UUID.randomUUID(),
-        "document.pdf",
-        category,
-        DocumentType.REFERRAL,
-        patientId().toString(),
-        Year.now());
-  }
+    private DocumentDTO document(DocumentCategory category) {
+        return new DocumentDTO(
+                UUID.randomUUID(),
+                "document.pdf",
+                category,
+                DocumentType.REFERRAL,
+                patientId().toString(),
+                Year.now());
+    }
 
-  static Stream<Arguments> documentsEndpoints() {
-    return Stream.of(
-        Arguments.of("/patients/{id}/documents/medicals", DocumentCategory.MEDICAL),
-        Arguments.of("/patients/{id}/documents/personals", DocumentCategory.PERSONAL),
-        Arguments.of("/patients/{id}/documents/schools", DocumentCategory.SCHOOL));
-  }
+    static Stream<Arguments> documentsEndpoints() {
+        return Stream.of(
+                Arguments.of("/patients/{id}/documents/medicals", DocumentCategory.MEDICAL),
+                Arguments.of("/patients/{id}/documents/personals", DocumentCategory.PERSONAL),
+                Arguments.of("/patients/{id}/documents/schools", DocumentCategory.SCHOOL));
+    }
 
-  @Test
-  @DisplayName("Should upload document successfully (201)")
-  @WithMockUser
-  void shouldUploadDocumentSuccessfully() throws Exception {
-    MockMultipartFile file = new MockMultipartFile(
-        "file",
-        "document.pdf",
-        "application/pdf",
-        "content".getBytes());
+    @Test
+    @DisplayName("Deve fazer upload do documento com sucesso (201)")
+    @WithMockUser
+    void shouldUploadDocumentSuccessfully() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "document.pdf",
+                "application/pdf",
+                "content".getBytes());
 
-    mockMvc.perform(
-        multipart("/patients/{id}/documents", patientId())
-            .file(file)
-            .param("category", "MEDICAL")
-            .param("type", "REFERRAL")
-            .with(csrf()))
-        .andExpect(status().isCreated());
-  }
+        mockMvc.perform(
+                        multipart("/patients/{id}/documents", patientId())
+                                .file(file)
+                                .param("category", "MEDICAL")
+                                .param("type", "REFERRAL")
+                                .with(csrf()))
+                .andExpect(status().isCreated());
+    }
 
-  @Test
-  @DisplayName("Should fail when category is invalid")
-  @WithMockUser
-  void shouldFailWhenCategoryIsInvalid() throws Exception {
-    MockMultipartFile file = new MockMultipartFile(
-        "file",
-        "document.pdf",
-        "application/pdf",
-        "content".getBytes());
+    @Test
+    @DisplayName("Deve falhar ao tentar fazer upload com categoria inválida")
+    @WithMockUser
+    void shouldFailWhenCategoryIsInvalid() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "document.pdf",
+                "application/pdf",
+                "content".getBytes());
 
-    mockMvc.perform(
-        multipart("/patients/{id}/documents", patientId())
-            .file(file)
-            .param("category", "INVALID")
-            .param("type", "REFERRAL")
-            .with(csrf()))
-        .andExpect(status().isInternalServerError());
-  }
+        mockMvc.perform(
+                        multipart("/patients/{id}/documents", patientId())
+                                .file(file)
+                                .param("category", "INVALID")
+                                .param("type", "REFERRAL")
+                                .with(csrf()))
+                .andExpect(status().isInternalServerError());
+    }
 
-  @Test
-  @DisplayName("Should return error when service fails during upload")
-  @WithMockUser
-  void shouldReturnErrorWhenServiceFails() throws Exception {
-    MockMultipartFile file = new MockMultipartFile(
-        "file",
-        "document.pdf",
-        "application/pdf",
-        "content".getBytes());
+    @Test
+    @DisplayName("Deve retornar erro quando o serviço falhar durante o upload")
+    @WithMockUser
+    void shouldReturnErrorWhenServiceFails() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "document.pdf",
+                "application/pdf",
+                "content".getBytes());
 
-    doThrow(new RuntimeException("Service error"))
-        .when(documentService)
-        .putDocument(any());
+        doThrow(new RuntimeException("Service error"))
+                .when(documentService)
+                .putDocument(any());
 
-    mockMvc.perform(
-        multipart("/patients/{id}/documents", patientId())
-            .file(file)
-            .param("category", "MEDICAL")
-            .param("type", "REFERRAL")
-            .with(csrf()))
-        .andExpect(status().isInternalServerError());
-  }
+        mockMvc.perform(
+                        multipart("/patients/{id}/documents", patientId())
+                                .file(file)
+                                .param("category", "MEDICAL")
+                                .param("type", "REFERRAL")
+                                .with(csrf()))
+                .andExpect(status().isInternalServerError());
+    }
 
-  @ParameterizedTest(name = "Should return documents successfully for endpoint {0}")
-  @MethodSource("documentsEndpoints")
-  @WithMockUser
-  void shouldReturnDocumentsSuccessfully(String endpoint, DocumentCategory category) throws Exception {
-    when(documentService.listDocuments(any()))
-        .thenReturn(List.of(document(category)));
+    @ParameterizedTest(name = "Deve retornar documentos com sucesso para o endpoint {0}")
+    @MethodSource("documentsEndpoints")
+    @WithMockUser
+    void shouldReturnDocumentsSuccessfully(String endpoint, DocumentCategory category) throws Exception {
+        when(documentService.listDocuments(any()))
+                .thenReturn(List.of(document(category)));
 
-    when(documentService.getPresignedDocumentUrl(any()))
-        .thenReturn("http://presigned-url");
+        when(documentService.getPresignedDocumentUrl(any()))
+                .thenReturn("http://presigned-url");
 
-    mockMvc.perform(get(endpoint, patientId()))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$", hasSize(1)))
-        .andExpect(jsonPath("$[0].url").value("http://presigned-url"));
-  }
+        mockMvc.perform(get(endpoint, patientId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].url").value("http://presigned-url"));
+    }
 
-  @ParameterizedTest(name = "Should return error when patient not found for endpoint {0}")
-  @MethodSource("documentsEndpoints")
-  @WithMockUser
-  void shouldReturnErrorWhenPatientNotFound(String endpoint, DocumentCategory category) throws Exception {
-    when(documentService.listDocuments(any()))
-        .thenThrow(new RuntimeException("Patient not found"));
+    @ParameterizedTest(name = "Deve retornar erro quando o paciente não for encontrado para o endpoint {0}")
+    @MethodSource("documentsEndpoints")
+    @WithMockUser
+    void shouldReturnErrorWhenPatientNotFound(String endpoint, DocumentCategory category) throws Exception {
+        when(documentService.listDocuments(any()))
+                .thenThrow(new RuntimeException("Patient not found"));
 
-    mockMvc.perform(get(endpoint, patientId()))
-        .andExpect(status().isInternalServerError());
-  }
+        mockMvc.perform(get(endpoint, patientId()))
+                .andExpect(status().isInternalServerError());
+    }
 
-  @ParameterizedTest(name = "Should handle presigned url failure for endpoint {0}")
-  @MethodSource("documentsEndpoints")
-  @WithMockUser
-  void shouldCoverCatchWhenPresignedUrlFails(String endpoint, DocumentCategory category) throws Exception {
-    when(documentService.listDocuments(any()))
-        .thenReturn(List.of(document(category)));
+    @ParameterizedTest(name = "Deve cobrir a exceção quando a geração da URL pre-assinada falhar para o endpoint {0}")
+    @MethodSource("documentsEndpoints")
+    @WithMockUser
+    void shouldCoverCatchWhenPresignedUrlFails(String endpoint, DocumentCategory category) throws Exception {
+        when(documentService.listDocuments(any()))
+                .thenReturn(List.of(document(category)));
 
-    when(documentService.getPresignedDocumentUrl(any()))
-        .thenThrow(new RuntimeException("MinIO unavailable"));
+        when(documentService.getPresignedDocumentUrl(any()))
+                .thenThrow(new RuntimeException("MinIO unavailable"));
 
-    mockMvc.perform(get(endpoint, patientId()))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$", hasSize(0)));
-  }
+        mockMvc.perform(get(endpoint, patientId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
+    }
 }

--- a/apps/api/src/test/java/br/org/apae/api/controllers/patient/PatientModificationTests.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/patient/PatientModificationTests.java
@@ -62,7 +62,7 @@ public class PatientModificationTests {
     private UserService userService;
 
     @Test
-    @DisplayName("Should update a patient successfully (Returns 200)")
+    @DisplayName("Deve atualizar o paciente com sucesso (200)")
     @WithMockUser(username = "admin", roles = {"ADMIN"})
     void shouldUpdatePatientSuccessfully() throws Exception {
         UUID patientId = UUID.randomUUID();
@@ -120,7 +120,7 @@ public class PatientModificationTests {
     }
 
     @Test
-    @DisplayName("Should return 400 Bad Request when providing invalid data for update")
+    @DisplayName("Deve retornar BadRequest (400) ao tentar atualizar com dados inválidos")
     @WithMockUser(username = "admin", roles = {"ADMIN"})
     void shouldReturnBadRequestWhenDataIsInvalid() throws Exception {
         UpdatePatientDTO invalidDTO = PatientCreator.createInvalidUpdateRequest();
@@ -133,7 +133,7 @@ public class PatientModificationTests {
     }
 
     @Test
-    @DisplayName("Should throw PatientNotFoundException when trying to update a non-existent patient")
+    @DisplayName("Deve lançar PatientNotFoundException ao tentar atualizar um paciente inexistente")
     @WithMockUser(username = "admin", roles = {"ADMIN"})
     void shouldThrowNotFoundWhenUpdatingNonExistentPatient() throws Exception {
         UUID randomId = UUID.randomUUID();
@@ -149,4 +149,3 @@ public class PatientModificationTests {
                 .andExpect(status().isBadRequest());
     }
 }
-

--- a/apps/api/src/test/java/br/org/apae/api/controllers/patient/PatientRemovalTests.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/patient/PatientRemovalTests.java
@@ -54,13 +54,12 @@ public class PatientRemovalTests {
     private UserService userService;
 
     @Test
-    @DisplayName("Should perform logical deletion (deactivate) successfully (Returns 204)")
+    @DisplayName("Deve realizar a deleção lógica (inativar) com sucesso (204)")
     @WithMockUser(username = "admin", roles = {"ADMIN"})
     void shouldPerformLogicalDeletionSuccessfully() throws Exception {
         UUID id = UUID.randomUUID();
 
         doNothing().when(patientService).deletePatient(id);
-
 
         mockMvc.perform(patch("/patients/{id}", id)
                         .with(csrf()))
@@ -68,7 +67,7 @@ public class PatientRemovalTests {
     }
 
     @Test
-    @DisplayName("Should return 404 Not Found when trying to deactivate non-existent ID")
+    @DisplayName("Deve retornar NotFound (404) ao tentar inativar um ID inexistente")
     @WithMockUser(username = "admin", roles = {"ADMIN"})
     void shouldReturnNotFoundWhenIdDoesNotExist() throws Exception {
         UUID id = UUID.randomUUID();


### PR DESCRIPTION
# Qual é o objetivo desta PR?

Esta Pull Request atende à necessidade de padronização da documentação dos testes unitários do sistema. O objetivo foi uniformizar o uso da anotação @DisplayName em todos os testes afetados, garantindo que a descrição das funcionalidades esteja clara, concisa e no idioma português, facilitando a leitura de relatórios de execução e a compreensão do comportamento esperado pelo time de desenvolvimento.

# O que foi feito?

# - Padronização de DisplayName:

## Adição ou correção das anotações @DisplayName para todos os métodos de teste nos arquivos:
* DisorderControllerImplTest

* AbsenceControllerImplTest

* PatientDocumentsTests

* PatientModificationTests

* PatientRemovalTests

# - Tradução: 
Todas as descrições foram traduzidas para o português, incluindo descrições de testes parametrizados (@ParameterizedTest), mantendo a especificação do status HTTP esperado (ex: "com sucesso (200)", "retornar NotFound (404)").

# - Ajustes de Imports:
 Inclusão do import org.junit.jupiter.api.DisplayName; em todas as classes onde a anotação não estava presente.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected HTTP status codes for various error scenarios (returning 404 Not Found instead of 409 Conflict for non-existent resource cases).

* **Tests**
  * Expanded test coverage for absence justification workflows.
  * Enhanced test suite with improved descriptive labels and assertions.
  * Updated test expectations to align with corrected API behavior and request/response formats.
  * Enabled previously inactive test suite for patient retrieval endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IFPBEsp/APAE/pull/808?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->