### PR TITLE
805 Remove sufixo 'Impl' das classes de teste de Controllers

### DIFF
--- a/apps/api/src/test/java/br/org/apae/api/appointment/interfaces/controllers/impl/AbsenceControllerTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/appointment/interfaces/controllers/impl/AbsenceControllerTest.java
@@ -34,7 +34,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 
 @WebMvcTest(controllers = AbsenceControllerImpl.class)
 @AutoConfigureMockMvc(addFilters = false)
-class AbsenceControllerImplTest {
+class AbsenceControllerTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/appointment/AppointmentControllerTest.java
@@ -45,7 +45,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest({ AppointmentControllerImpl.class })
-class AppointmentControllerImplTest {
+class AppointmentControllerTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/apps/api/src/test/java/br/org/apae/api/controllers/disorder/DisorderControllerTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/disorder/DisorderControllerTest.java
@@ -52,7 +52,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Tag("patient")
 @Tag("unit")
 @Tag("controller")
-class DisorderControllerImplTest {
+class DisorderControllerTest {
 
     @TestConfiguration
     @EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)


### PR DESCRIPTION
# Qual é o objetivo desta PR?

Esta Pull Request realiza uma melhoria arquitetural nas classes de teste unitário dos Controllers. O objetivo é remover o sufixo Impl da nomenclatura das classes de teste, garantindo que o nome do teste reflita o contrato/interface do Controller (AbsenceController, AppointmentController, DisorderController) e não o seu detalhe de implementação, seguindo as boas práticas de Clean Code.

# O que foi feito?

## Renomeação de Arquivos e Classes:

- O arquivo AbsenceControllerImplTest.java foi renomeado para AbsenceControllerTest.java.

- O arquivo AppointmentControllerImplTest.java foi renomeado para AppointmentControllerTest.java.

- O arquivo DisorderControllerImplTest.java foi renomeado para DisorderControllerTest.java.

- A injeção interna do contexto do Spring (@WebMvcTest) foi mantida corretamente apontando para as implementações, garantindo que a execução da suíte não fosse afetada.

<img width="586" height="415" alt="image" src="https://github.com/user-attachments/assets/db309b95-d081-43ce-922b-88e90412aa9a" />
