### PR TITLE
807 test mover healthprofessionalmockdto para o pacote correto

### DIFF
--- a/apps/api/src/test/java/br/org/apae/api/controllers/professional/HealthProfessionalControllerTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/professional/HealthProfessionalControllerTest.java
@@ -33,7 +33,7 @@ import br.org.apae.api.auth.infrastructure.security.SecurityConfiguration;
 import br.org.apae.api.common.dto.professional.request.UpdateHealthProfessionalDTO;
 import br.org.apae.api.common.dto.professional.request.CreateHealthProfessionalDTO;
 import br.org.apae.api.common.dto.professional.request.documents.CreateProfessionalDocumentsDTO;
-import br.org.apae.api.controllers.mocks.professional.HealthProfessionalMockDto;
+import br.org.apae.api.mocks.professional.HealthProfessionalMockDto;
 import br.org.apae.api.helpers.AuthTestHelper;
 import br.org.apae.api.professional.application.interfaces.HealthProfessionalApplicationService;
 import br.org.apae.api.professional.domain.exceptions.HealthProfessionalNotFoundException;

--- a/apps/api/src/test/java/br/org/apae/api/mocks/professional/HealthProfessionalMockDto.java
+++ b/apps/api/src/test/java/br/org/apae/api/mocks/professional/HealthProfessionalMockDto.java
@@ -1,4 +1,4 @@
-package br.org.apae.api.controllers.mocks.professional;
+package br.org.apae.api.mocks.professional;
 
 import java.util.List;
 import java.util.UUID;


### PR DESCRIPTION
# Qual é o objetivo desta PR?

Esta Pull Request resolve um problema de organização arquitetural no projeto. A classe HealthProfessionalMockDto, que contém os métodos estáticos de fábrica para os testes, estava alocada incorretamente no pacote de controllers. O objetivo foi movê-la para o diretório correto destinado aos mocks, mantendo a coesão estrutural da aplicação e evitando a exposição de classes de teste junto à camada de implementação web.

# O que foi feito?

## Movimentação de Diretório: 

- O arquivo HealthProfessionalMockDto.java foi movido do pacote br.org.apae.api.controllers.professional.mocks para o pacote definitivo br.org.apae.api.mocks.professional.

## Ajuste de Referências:

- Atualização automática do package dentro da classe movida.

- Atualização da importação (import) na classe de teste HealthProfessionalControllerTest que possuia dependência desta classe de mock.

<img width="578" height="318" alt="image" src="https://github.com/user-attachments/assets/f2bc3ff7-74fb-472b-8c7f-8792c1f92360" />

<img width="924" height="191" alt="image" src="https://github.com/user-attachments/assets/73574d01-8881-4a72-9415-2f5c1b528585" />

<img width="918" height="338" alt="image" src="https://github.com/user-attachments/assets/dcc06690-dad3-4e04-9d2c-bdb5ced60b60" />
