### PR TITLE
801 test move AbsenceControllerTest para o pacote correto

### DIFF
--- a/apps/api/src/test/java/br/org/apae/api/controllers/absence/AbsenceControllerImplTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/absence/AbsenceControllerImplTest.java
@@ -1,4 +1,4 @@
-package br.org.apae.api.appointment.interfaces.controllers.impl;
+package br.org.apae.api.controllers.absence;
 
 import br.org.apae.api.appointment.application.interfaces.AbsenceApplicationService;
 import br.org.apae.api.auth.application.internal.UserService;
@@ -6,7 +6,6 @@ import br.org.apae.api.auth.infrastructure.security.JwtProvider;
 import br.org.apae.api.common.dto.appointment.request.absence.CreateAbsenceDTO;
 import br.org.apae.api.common.dto.appointment.response.absence.AbsenceResponseDTO;
 import br.org.apae.api.common.dto.appointment.response.absence.JustifyAbsenceDTO;
-import br.org.apae.api.controllers.absence.AbsenceControllerImpl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
# Qual é o objetivo desta PR?
Esta Pull Request corrige a localização do arquivo de teste AbsenceControllerTest. Ele estava posicionado incorretamente no pacote br.org.apae.api.appointment.interfaces.controllers.impl (espelhando um pacote de implementação interna), quando o correto arquiteturalmente é que ele resida no pacote correspondente à camada de controllers exposta.

# O que foi feito?

- Movimentação do Arquivo de Teste: O arquivo AbsenceControllerTest.java foi movido para o pacote br.org.apae.api.controllers.absence.

- Ajuste de Declaração e Imports: A declaração do package foi corrigida na classe de teste.

<img width="567" height="383" alt="image" src="https://github.com/user-attachments/assets/f2ac5dc4-7d54-493a-ba3f-80b4c0cfe030" />

<img width="963" height="316" alt="image" src="https://github.com/user-attachments/assets/5b1930a8-d323-4c62-890c-bc76229c4b9b" />

