### PR TITLE
feat: capitalizar primeira letra nos nomes de vacinas (#765)

### DIFF
--- a/apps/apae/src/app/person/register/additional/page.tsx
+++ b/apps/apae/src/app/person/register/additional/page.tsx
@@ -42,8 +42,7 @@ import { CreateVaccine } from "@/schemas/vaccine-schemas";
 import { Button } from "@/components/ui/button";
 import { useDisordersContext } from "@/hooks/use-disorders";
 import { CreateDisorder } from "@/schemas/disorder-schemas";
-import { formatCurrency } from "@/lib/formats";
-import { useCreateServiceArea } from "@/hooks/service-area/use-create-service-area";
+import { formatCurrency, capitalizeFirst } from "@/lib/formats";import { useCreateServiceArea } from "@/hooks/service-area/use-create-service-area";
 import { useFetchServiceAreas } from "@/hooks/service-area/use-fetch-service-areas";
 import { CreateCare } from "@/schemas/care-schemas";
 
@@ -82,7 +81,11 @@ function CreateVaccineDialog({ open, onOpenChange, onSuccess }: DialogProps) {
                 <FormItem>
                   <FormLabel>Nome da Vacina</FormLabel>
                   <FormControl>
-                    <Input placeholder="Ex: Hepatite B" {...field} />
+                    <Input
+                      placeholder="Ex: Hepatite B"
+                      {...field}
+                      onChange={(e) => field.onChange(capitalizeFirst(e.target.value))}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/apps/apae/src/app/vaccines/[id]/edit/page.tsx
+++ b/apps/apae/src/app/vaccines/[id]/edit/page.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Loader2, ArrowLeft } from "lucide-react";
 import { useVaccinesContext, Vaccine } from "@/hooks/use-vaccines";
 import { z } from "zod";
+import { capitalizeFirst } from "@/lib/formats";
 import { UpdateVaccine } from "@/schemas/vaccine-schemas";
 import {
   Form,
@@ -101,8 +102,12 @@ export default function EditVaccinePage() {
                       Nome da Vacina
                     </FormLabel>
                     <FormControl>
-                      <Input placeholder="Ex: Hepatite B" {...field} />
-                    </FormControl>
+                      <Input
+                        placeholder="Ex: Hepatite B"
+                        {...field}
+                        onChange={(e) => field.onChange(capitalizeFirst(e.target.value))}
+                      />                   
+                     </FormControl>
                     <FormMessage />
                   </FormItem>
                 )}

--- a/apps/apae/src/app/vaccines/new/page.tsx
+++ b/apps/apae/src/app/vaccines/new/page.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import { ArrowLeft } from "lucide-react";
 import { useVaccinesContext } from "@/hooks/use-vaccines";
 import { CreateVaccine } from "@/schemas/vaccine-schemas";
+import { capitalizeFirst } from "@/lib/formats";
 import { z } from "zod";
 import {
     Form,
@@ -66,8 +67,9 @@ export default function NewVaccinePage() {
                                         </FormLabel>
                                         <FormControl>
                                             <Input
-                                                placeholder="Ex: Hepatite B"
-                                                {...field}
+                                              placeholder="Ex: Hepatite B"
+                                              {...field}
+                                              onChange={(e) => field.onChange(capitalizeFirst(e.target.value))}
                                             />
                                         </FormControl>
                                         <FormMessage />

--- a/apps/apae/src/lib/formats.ts
+++ b/apps/apae/src/lib/formats.ts
@@ -83,3 +83,8 @@ export function formatCNS(value: string) {
     .replace(/(\d{4})(\d)/, "$1 $2")
     .replace(/(\d{4})(\d)/, "$1 $2");
 }
+
+export function capitalizeFirst(value: string): string {
+  if (!value) return value;
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}


### PR DESCRIPTION
O que foi feito?
Aplicativo de capitalização automática da primeira letra nos campos de nome de vacina no cadastro, edição e no diálogo de criação rápida.

Arquivos alterados:

src/lib/formats.ts— capitalizeFirstfunção
src/app/vaccines/new/page.tsx— campo nome da vacina
src/app/vaccines/[id]/edit/page.tsx— campo nome da vacina
src/app/patients/create/additional/page.tsx— campo nome sem diálogo de criação rápida

Como testar:

Acesse '/vaccines/new' e digite o nome com letra minúscula
Verifique se a primeira letra está maiúscula automaticamente
Repita em '/vaccines/[id]/edit'
Repetir nenhum diálogo de nova vacina dentro do cadastro do paciente