### PR TITLE
826-test-renomear-pacote-annual_registry

### DIFF
--- a/apps/api/src/main/java/br/org/apae/api/common/dto/patient/request/annualregistry/CreateAnnualRegistryDTO.java
+++ b/apps/api/src/main/java/br/org/apae/api/common/dto/patient/request/annualregistry/CreateAnnualRegistryDTO.java
@@ -1,4 +1,4 @@
-package br.org.apae.api.common.dto.patient.request.annual_registry;
+package br.org.apae.api.common.dto.patient.request.annualregistry;
 
 import java.math.BigDecimal;
 import java.time.Year;

--- a/apps/api/src/main/java/br/org/apae/api/common/dto/patient/request/annualregistry/ReplaceAnnualRegistryDTO.java
+++ b/apps/api/src/main/java/br/org/apae/api/common/dto/patient/request/annualregistry/ReplaceAnnualRegistryDTO.java
@@ -1,4 +1,4 @@
-package br.org.apae.api.common.dto.patient.request.annual_registry;
+package br.org.apae.api.common.dto.patient.request.annualregistry;
 
 import br.org.apae.api.common.dto.patient.request.disorder.CreateDisorderDTO;
 import br.org.apae.api.common.dto.servicearea.request.CreateServiceAreaDTO;

--- a/apps/api/src/main/java/br/org/apae/api/common/dto/patient/request/annualregistry/UpdateAnnualRegistryDTO.java
+++ b/apps/api/src/main/java/br/org/apae/api/common/dto/patient/request/annualregistry/UpdateAnnualRegistryDTO.java
@@ -1,4 +1,4 @@
-package br.org.apae.api.common.dto.patient.request.annual_registry;
+package br.org.apae.api.common.dto.patient.request.annualregistry;
 
 import java.math.BigDecimal;
 import java.time.Year;

--- a/apps/api/src/main/java/br/org/apae/api/common/dto/patient/request/patient/CreatePatientDTO.java
+++ b/apps/api/src/main/java/br/org/apae/api/common/dto/patient/request/patient/CreatePatientDTO.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Set;
 
 import br.org.apae.api.common.dto.address.CreateAddressDTO;
-import br.org.apae.api.common.dto.patient.request.annual_registry.CreateAnnualRegistryDTO;
+import br.org.apae.api.common.dto.patient.request.annualregistry.CreateAnnualRegistryDTO;
 import br.org.apae.api.common.dto.patient.request.guardian.CreateGuardianDTO;
 import br.org.apae.api.common.dto.patient.request.parent.CreateParentDTO;
 import br.org.apae.api.common.dto.patient.request.vaccine.CreateVaccineDTO;

--- a/apps/api/src/main/java/br/org/apae/api/common/dto/patient/response/annualregistry/AnnualRegistryResponseDTO.java
+++ b/apps/api/src/main/java/br/org/apae/api/common/dto/patient/response/annualregistry/AnnualRegistryResponseDTO.java
@@ -1,4 +1,4 @@
-package br.org.apae.api.common.dto.patient.response.annual_registry;
+package br.org.apae.api.common.dto.patient.response.annualregistry;
 
 import java.math.BigDecimal;
 import java.util.Set;

--- a/apps/api/src/main/java/br/org/apae/api/controllers/annual_registry/AnnualRegistryControllerImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/controllers/annual_registry/AnnualRegistryControllerImpl.java
@@ -10,10 +10,10 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
-import br.org.apae.api.common.dto.patient.request.annual_registry.CreateAnnualRegistryDTO;
-import br.org.apae.api.common.dto.patient.request.annual_registry.ReplaceAnnualRegistryDTO;
-import br.org.apae.api.common.dto.patient.request.annual_registry.UpdateAnnualRegistryDTO;
-import br.org.apae.api.common.dto.patient.response.annual_registry.AnnualRegistryResponseDTO;
+import br.org.apae.api.common.dto.patient.request.annualregistry.CreateAnnualRegistryDTO;
+import br.org.apae.api.common.dto.patient.request.annualregistry.ReplaceAnnualRegistryDTO;
+import br.org.apae.api.common.dto.patient.request.annualregistry.UpdateAnnualRegistryDTO;
+import br.org.apae.api.common.dto.patient.response.annualregistry.AnnualRegistryResponseDTO;
 import br.org.apae.api.patient.application.interfaces.AnnualRegistryApplicationService;
 import br.org.apae.api.patient.interfaces.controllers.AnnualRegistryController;
 import jakarta.validation.Valid;

--- a/apps/api/src/main/java/br/org/apae/api/patient/application/interfaces/AnnualRegistryApplicationService.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/application/interfaces/AnnualRegistryApplicationService.java
@@ -3,10 +3,10 @@ package br.org.apae.api.patient.application.interfaces;
 import java.time.Year;
 import java.util.List;
 import java.util.UUID;
-import br.org.apae.api.common.dto.patient.request.annual_registry.CreateAnnualRegistryDTO;
-import br.org.apae.api.common.dto.patient.request.annual_registry.ReplaceAnnualRegistryDTO;
-import br.org.apae.api.common.dto.patient.request.annual_registry.UpdateAnnualRegistryDTO;
-import br.org.apae.api.common.dto.patient.response.annual_registry.AnnualRegistryResponseDTO;
+import br.org.apae.api.common.dto.patient.request.annualregistry.CreateAnnualRegistryDTO;
+import br.org.apae.api.common.dto.patient.request.annualregistry.ReplaceAnnualRegistryDTO;
+import br.org.apae.api.common.dto.patient.request.annualregistry.UpdateAnnualRegistryDTO;
+import br.org.apae.api.common.dto.patient.response.annualregistry.AnnualRegistryResponseDTO;
 
 public interface AnnualRegistryApplicationService {
 

--- a/apps/api/src/main/java/br/org/apae/api/patient/application/internal/AnnualRegistryApplicationServiceImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/application/internal/AnnualRegistryApplicationServiceImpl.java
@@ -13,10 +13,10 @@ import br.org.apae.api.professional.domain.exceptions.ServiceAreaNotFoundExcepti
 import br.org.apae.api.servicearea.application.interfaces.ServiceAreaApplicationService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import br.org.apae.api.common.dto.patient.request.annual_registry.CreateAnnualRegistryDTO;
-import br.org.apae.api.common.dto.patient.request.annual_registry.UpdateAnnualRegistryDTO;
-import br.org.apae.api.common.dto.patient.request.annual_registry.ReplaceAnnualRegistryDTO;
-import br.org.apae.api.common.dto.patient.response.annual_registry.AnnualRegistryResponseDTO;
+import br.org.apae.api.common.dto.patient.request.annualregistry.CreateAnnualRegistryDTO;
+import br.org.apae.api.common.dto.patient.request.annualregistry.UpdateAnnualRegistryDTO;
+import br.org.apae.api.common.dto.patient.request.annualregistry.ReplaceAnnualRegistryDTO;
+import br.org.apae.api.common.dto.patient.response.annualregistry.AnnualRegistryResponseDTO;
 import br.org.apae.api.common.dto.patient.response.disorder.DisorderResponseDTO;
 import br.org.apae.api.patient.application.interfaces.AnnualRegistryApplicationService;
 import br.org.apae.api.patient.application.interfaces.DisorderApplicationService;

--- a/apps/api/src/main/java/br/org/apae/api/patient/application/mappers/AnnualRegistryMapper.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/application/mappers/AnnualRegistryMapper.java
@@ -10,10 +10,10 @@ import br.org.apae.api.servicearea.domain.model.ServiceArea;
 import org.jspecify.annotations.NonNull;
 import org.springframework.stereotype.Component;
 
-import br.org.apae.api.common.dto.patient.request.annual_registry.CreateAnnualRegistryDTO;
-import br.org.apae.api.common.dto.patient.request.annual_registry.ReplaceAnnualRegistryDTO;
-import br.org.apae.api.common.dto.patient.request.annual_registry.UpdateAnnualRegistryDTO;
-import br.org.apae.api.common.dto.patient.response.annual_registry.AnnualRegistryResponseDTO;
+import br.org.apae.api.common.dto.patient.request.annualregistry.CreateAnnualRegistryDTO;
+import br.org.apae.api.common.dto.patient.request.annualregistry.ReplaceAnnualRegistryDTO;
+import br.org.apae.api.common.dto.patient.request.annualregistry.UpdateAnnualRegistryDTO;
+import br.org.apae.api.common.dto.patient.response.annualregistry.AnnualRegistryResponseDTO;
 import br.org.apae.api.common.dto.patient.response.disorder.DisorderResponseDTO;
 import br.org.apae.api.patient.domain.model.AnnualRegistry;
 import br.org.apae.api.patient.domain.model.Disorder;

--- a/apps/api/src/main/java/br/org/apae/api/patient/interfaces/controllers/AnnualRegistryController.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/interfaces/controllers/AnnualRegistryController.java
@@ -6,10 +6,10 @@ import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import br.org.apae.api.common.dto.patient.request.annual_registry.CreateAnnualRegistryDTO;
-import br.org.apae.api.common.dto.patient.request.annual_registry.ReplaceAnnualRegistryDTO;
-import br.org.apae.api.common.dto.patient.request.annual_registry.UpdateAnnualRegistryDTO;
-import br.org.apae.api.common.dto.patient.response.annual_registry.AnnualRegistryResponseDTO;
+import br.org.apae.api.common.dto.patient.request.annualregistry.CreateAnnualRegistryDTO;
+import br.org.apae.api.common.dto.patient.request.annualregistry.ReplaceAnnualRegistryDTO;
+import br.org.apae.api.common.dto.patient.request.annualregistry.UpdateAnnualRegistryDTO;
+import br.org.apae.api.common.dto.patient.response.annualregistry.AnnualRegistryResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;

--- a/apps/api/src/test/java/br/org/apae/api/controllers/annualregistry/AnnualRegistryControllerTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/annualregistry/AnnualRegistryControllerTest.java
@@ -8,6 +8,7 @@ import br.org.apae.api.common.dto.patient.request.annualregistry.ReplaceAnnualRe
 import br.org.apae.api.common.dto.patient.request.annualregistry.UpdateAnnualRegistryDTO;
 import br.org.apae.api.common.dto.patient.response.annualregistry.AnnualRegistryResponseDTO;
 import br.org.apae.api.common.exceptions.handler.GlobalExceptionHandler;
+import br.org.apae.api.controllers.annual_registry.AnnualRegistryControllerImpl;
 import br.org.apae.api.helpers.AuthTestHelper;
 import br.org.apae.api.patient.application.interfaces.AnnualRegistryApplicationService;
 import br.org.apae.api.patient.domain.exceptions.AnnualRegistryConflictException;

--- a/apps/api/src/test/java/br/org/apae/api/controllers/annualregistry/AnnualRegistryControllerTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/annualregistry/AnnualRegistryControllerTest.java
@@ -1,12 +1,12 @@
-package br.org.apae.api.controllers.annual_registry;
+package br.org.apae.api.controllers.annualregistry;
 
 import br.org.apae.api.auth.application.internal.UserService;
 import br.org.apae.api.auth.infrastructure.security.JwtProvider;
 import br.org.apae.api.auth.infrastructure.security.SecurityConfiguration;
-import br.org.apae.api.common.dto.patient.request.annual_registry.CreateAnnualRegistryDTO;
-import br.org.apae.api.common.dto.patient.request.annual_registry.ReplaceAnnualRegistryDTO;
-import br.org.apae.api.common.dto.patient.request.annual_registry.UpdateAnnualRegistryDTO;
-import br.org.apae.api.common.dto.patient.response.annual_registry.AnnualRegistryResponseDTO;
+import br.org.apae.api.common.dto.patient.request.annualregistry.CreateAnnualRegistryDTO;
+import br.org.apae.api.common.dto.patient.request.annualregistry.ReplaceAnnualRegistryDTO;
+import br.org.apae.api.common.dto.patient.request.annualregistry.UpdateAnnualRegistryDTO;
+import br.org.apae.api.common.dto.patient.response.annualregistry.AnnualRegistryResponseDTO;
 import br.org.apae.api.common.exceptions.handler.GlobalExceptionHandler;
 import br.org.apae.api.helpers.AuthTestHelper;
 import br.org.apae.api.patient.application.interfaces.AnnualRegistryApplicationService;

--- a/apps/api/src/test/java/br/org/apae/api/controllers/patient/PatientRegistrationTests.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/patient/PatientRegistrationTests.java
@@ -3,7 +3,7 @@ package br.org.apae.api.controllers.patient;
 import br.org.apae.api.auth.application.internal.UserService;
 import br.org.apae.api.auth.infrastructure.security.JwtProvider;
 import br.org.apae.api.common.dto.address.CreateAddressDTO;
-import br.org.apae.api.common.dto.patient.request.annual_registry.CreateAnnualRegistryDTO;
+import br.org.apae.api.common.dto.patient.request.annualregistry.CreateAnnualRegistryDTO;
 import br.org.apae.api.common.dto.patient.request.disorder.CreateDisorderDTO;
 import br.org.apae.api.common.dto.patient.request.documents.CreateDocumentsDTO;
 import br.org.apae.api.common.dto.patient.request.guardian.CreateGuardianDTO;

--- a/apps/api/src/test/java/br/org/apae/api/controllers/patient/mocks/patient/PatientCreator.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/patient/mocks/patient/PatientCreator.java
@@ -2,7 +2,7 @@ package br.org.apae.api.controllers.patient.mocks.patient;
 
 import br.org.apae.api.common.dto.address.AddressResponseDTO;
 import br.org.apae.api.common.dto.address.CreateAddressDTO;
-import br.org.apae.api.common.dto.patient.request.annual_registry.CreateAnnualRegistryDTO;
+import br.org.apae.api.common.dto.patient.request.annualregistry.CreateAnnualRegistryDTO;
 import br.org.apae.api.common.dto.patient.request.disorder.CreateDisorderDTO;
 import br.org.apae.api.common.dto.patient.request.documents.CreateDocumentsDTO;
 import br.org.apae.api.common.dto.patient.request.guardian.CreateGuardianDTO;


### PR DESCRIPTION
# Qual é o objetivo desta PR?

Esta Pull Request resolve uma inconsistência de nomenclatura na estrutura do projeto. O pacote annual_registry utilizava um underscore (sublinhado), o que foge às convenções oficiais da linguagem Java para a nomenclatura de pacotes (que devem ser em minúsculas e sem separadores). O objetivo foi adequar o pacote ao padrão do projeto.

# O que foi feito?

- A pasta física e o pacote lógico foram renomeados de annual_registry para annualregistry.

- Atualização da declaração package em todas as classes (Controllers, DTOs, etc.) contidas no diretório.

- Atualização dos imports correspondentes nas classes que consumiam os DTOs e serviços deste pacote (como os testes e implementações).