### PR TITLE
824-test-completar-cobertura-de-testes-em-disordercontrollertest

### DIFF
--- a/apps/api/src/test/java/br/org/apae/api/controllers/disorder/DisorderControllerTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/disorder/DisorderControllerTest.java
@@ -243,4 +243,58 @@ class DisorderControllerTest {
         mockMvc.perform(delete(BASE_URL + "/{id}", id).header("Authorization", AuthTestHelper.bearerToken()))
                 .andExpect(status().isNotFound());
     }
+
+    @Test
+    @DisplayName("Deve retornar BadRequest (400) ao tentar criar transtorno com nome nulo")
+    void shouldReturnBadRequestWhenCreateDisorderWithNullName() throws Exception {
+        CreateDisorderDTO requestDto = new CreateDisorderDTO(null);
+
+        mockMvc.perform(post(BASE_URL)
+                        .header("Authorization", AuthTestHelper.bearerToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Deve retornar BadRequest (400) ao tentar criar transtorno com nome em branco")
+    void shouldReturnBadRequestWhenCreateDisorderWithBlankName() throws Exception {
+        CreateDisorderDTO requestDto = new CreateDisorderDTO("");
+
+        mockMvc.perform(post(BASE_URL)
+                        .header("Authorization", AuthTestHelper.bearerToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Deve retornar BadRequest (400) ao tentar atualizar transtorno com nome nulo")
+    void shouldReturnBadRequestWhenUpdateDisorderWithNullName() throws Exception {
+        UUID id = UUID.randomUUID();
+        UpdateDisorderDTO updateDto = new UpdateDisorderDTO(null);
+
+        mockMvc.perform(put(BASE_URL + "/{id}", id)
+                        .header("Authorization", AuthTestHelper.bearerToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateDto))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Deve retornar BadRequest (400) ao tentar atualizar transtorno com nome em branco")
+    void shouldReturnBadRequestWhenUpdateDisorderWithBlankName() throws Exception {
+        UUID id = UUID.randomUUID();
+        UpdateDisorderDTO updateDto = new UpdateDisorderDTO("");
+
+        mockMvc.perform(put(BASE_URL + "/{id}", id)
+                        .header("Authorization", AuthTestHelper.bearerToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateDto))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
 }


### PR DESCRIPTION
# Qual é o objetivo desta PR?

Esta Pull Request atende à necessidade de garantir a cobertura completa de testes sobre as validações de entrada (@Valid) nos endpoints de Transtornos (Disorders). O cenário atual não cobria as rejeições de payload quando o nome do transtorno não estava em conformidade.

# O que foi feito?

Adição de 4 novos cenários de testes no arquivo DisorderControllerTest.java focado em validar os retornos de erro (400 Bad Request) em situações de entradas inválidas:

- Criação de transtorno (POST /disorders) com name nulo.

- Criação de transtorno (POST /disorders) com name em branco ("").

- Atualização de transtorno (PUT /disorders/{id}) com name nulo.

- Atualização de transtorno (PUT /disorders/{id}) com name em branco ("").