### PR TITLE
[TEST] Adicionar @Valid no updateVaccine e cobrir cenário 409 no VaccineControllerTest #825

### DIFF
--- a/apps/api/src/main/java/br/org/apae/api/controllers/vaccine/VaccineControllerImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/controllers/vaccine/VaccineControllerImpl.java
@@ -4,6 +4,7 @@ import br.org.apae.api.patient.application.interfaces.VaccineApplicationService;
 import br.org.apae.api.common.dto.patient.request.vaccine.CreateVaccineDTO;
 import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
 import br.org.apae.api.patient.interfaces.controllers.VaccineController;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import java.util.List;
 import java.util.UUID;
@@ -46,7 +47,7 @@ public class VaccineControllerImpl implements VaccineController {
     }
 
     @Override
-    public ResponseEntity<VaccineResponseDTO> updateVaccine(UUID id, CreateVaccineDTO vaccineDTO) {
+    public ResponseEntity<VaccineResponseDTO> updateVaccine(UUID id, @Valid CreateVaccineDTO vaccineDTO) {
         VaccineResponseDTO updatedVaccine = vaccineService.updateVaccine(id, vaccineDTO);
         return ResponseEntity.ok(updatedVaccine);
     }

--- a/apps/api/src/test/java/br/org/apae/api/controllers/vaccine/VaccineControllerTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/vaccine/VaccineControllerTest.java
@@ -48,7 +48,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Tag("patient")
 @Tag("unit")
 @Tag("controller")
-public class VaccineControllerTest {
+public class    VaccineControllerTest {
 
     @TestConfiguration
     @EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
@@ -238,6 +238,22 @@ public class VaccineControllerTest {
                         .content(objectMapper.writeValueAsString(updateDto))
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("Deve retornar Conflict (409) ao tentar atualizar vacina com nome já existente")
+    void shouldReturnConflictWhenUpdateVaccineWithDuplicateName() throws Exception {
+        UUID id = UUID.randomUUID();
+        CreateVaccineDTO updateDto = new CreateVaccineDTO("Hepatite B");
+        when(vaccineService.updateVaccine(eq(id), any(CreateVaccineDTO.class)))
+                .thenThrow(new VaccineConflictException(updateDto.name()));
+
+        mockMvc.perform(put(BASE_URL + "/{id}", id)
+                        .header("Authorization", AuthTestHelper.bearerToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateDto))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isConflict());
     }
 
     @Test


### PR DESCRIPTION
# O que mudou?

`@Valid` estava ausente na sobrescrita do método `updateVaccine` em `VaccineControllerImpl`, fazendo com que a validação de entrada fosse ignorada nas requisições `PUT /vaccines/{id}`. Além disso, `VaccineControllerTest` não cobria o cenário de conflito de nome (409) na atualização.

## Tarefas Relacionadas

* Issue: https://github.com/IFPBEsp/APAE/issues/825

## Mudanças Realizadas

* Adicionado `@Valid` no parâmetro `CreateVaccineDTO` do método `updateVaccine` em `VaccineControllerImpl`
* Adicionado teste `shouldReturnConflictWhenUpdateVaccineWithDuplicateName` cobrindo o retorno `409 Conflict` quando o nome informado já está em uso durante a atualização

## Evidências

<img width="1920" height="1080" alt="Captura de tela de 2026-06-02 21-01-57" src="https://github.com/user-attachments/assets/87faf403-99ca-4780-83d0-750e528ce648" />
