### PR TITLE
feat: adiciona botao de voltar na primeira etapa de cadastro

### DIFF
--- a/apps/apae/src/app/patients/create/personal/page.tsx
+++ b/apps/apae/src/app/patients/create/personal/page.tsx
@@ -26,7 +26,7 @@ import { Personal, PersonalData } from "@/schemas/member-schemas";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { useState, useEffect } from "react";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter  } from "next/navigation";
 import { handleBackendValidationErrors } from "@/lib/utils/form-errors";
 import { formatCivilDateDisplayValue } from "@/lib/date";
 import { InputMask } from "@react-input/mask";
@@ -43,6 +43,7 @@ export default function MembersRegisterPersonalPage() {
   const [isLoading, setIsLoading] = useState(false);
 
   const pathname = usePathname();
+  const router = useRouter();
   const isEditing = pathname.includes("/edit");
   const form = useForm<z.infer<typeof Personal>>({
     mode: "onBlur",
@@ -86,9 +87,19 @@ export default function MembersRegisterPersonalPage() {
         title={isEditing ? "Editar Dados Pessoais" : "Dados Pessoais"}
         onSubmit={form.handleSubmit(onSubmit)}
         buttons={
-          <FormButton type="submit" disabled={isLoading}>
-            {isLoading ? "Validando..." : "Próximo"}
-          </FormButton>
+          <div className="flex gap-4">
+            <FormButton
+              type="button"
+              disabled={isLoading}
+              onClick={() => router.push("/patients")}
+            >
+              Voltar
+            </FormButton>
+
+            <FormButton type="submit" disabled={isLoading}>
+              {isLoading ? "Validando..." : "Próximo"}
+            </FormButton>
+          </div>
         }
       >
         <DoubleColumn>


### PR DESCRIPTION
Descrição:
Esta alteração implementa o botão de "Voltar" na primeira etapa (Dados Pessoais) do formulário de cadastro de pacientes/alunos. O objetivo é melhorar a usabilidade (UX), permitindo que o usuário retorne à listagem geral sem depender exclusivamente do menu lateral.

Mudanças Realizadas:
Navegação: Implementação do hook useRouter para redirecionamento.
Interface: Adição do componente FormButton configurado para retornar à rota /patients.
Consistência Visual: O botão segue o padrão de estilo (amarelo/azul) utilizado nas demais telas de formulário do projeto.

Como Testar:
Acesse a tela de cadastro de um novo paciente.
Na primeira etapa ("Dados Pessoais"), verifique se o botão Voltar aparece ao lado do botão Próximo.
Clique no botão Voltar e confirme se você é redirecionado para a listagem de pacientes.
