### PR TITLE
822 fix Corrigir retorno de status ao realizar login com senha inválida

### DIFF
--- a/apps/api/src/main/java/br/org/apae/api/auth/application/internal/AuthApplicationServiceImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/auth/application/internal/AuthApplicationServiceImpl.java
@@ -87,7 +87,7 @@ public class AuthApplicationServiceImpl implements AuthApplicationService {
 
       return new TokenResponseDTO(token);
     } catch (UserNotFoundException | InvalidPasswordException e) {
-        throw new InvalidPasswordException("E-mail ou senha incorretos");
+        throw new InvalidPasswordException();
     } catch (Exception e) {
       throw new AuthenticationException();
     }

--- a/apps/api/src/main/java/br/org/apae/api/auth/application/internal/AuthApplicationServiceImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/auth/application/internal/AuthApplicationServiceImpl.java
@@ -87,7 +87,7 @@ public class AuthApplicationServiceImpl implements AuthApplicationService {
 
       return new TokenResponseDTO(token);
     } catch (UserNotFoundException | InvalidPasswordException e) {
-      throw e;
+        throw new InvalidPasswordException("E-mail ou senha incorretos");
     } catch (Exception e) {
       throw new AuthenticationException();
     }

--- a/apps/api/src/main/java/br/org/apae/api/auth/domain/exceptions/InvalidPasswordException.java
+++ b/apps/api/src/main/java/br/org/apae/api/auth/domain/exceptions/InvalidPasswordException.java
@@ -4,6 +4,6 @@ public class InvalidPasswordException extends RuntimeException {
   private static final String MESSAGE = "Senha incorreta.";
 
   public InvalidPasswordException() {
-    super(MESSAGE);
+    super("E-mail ou senha incorretos");
   }
 }

--- a/apps/api/src/main/java/br/org/apae/api/auth/exceptions/AuthExceptionHandler.java
+++ b/apps/api/src/main/java/br/org/apae/api/auth/exceptions/AuthExceptionHandler.java
@@ -68,15 +68,15 @@ public class AuthExceptionHandler {
     return new ResponseEntity<>(error, HttpStatus.UNAUTHORIZED);
   }
 
-  @ExceptionHandler(InvalidPasswordException.class)
-  public ResponseEntity<ErrorResponse> handleInvalidPassword(InvalidPasswordException ex, HttpServletRequest request) {
-    ErrorResponse error = new ErrorResponse(
-        HttpStatus.BAD_REQUEST.value(),
-        HttpStatus.BAD_REQUEST.getReasonPhrase(),
-        ex.getMessage(),
-        request.getRequestURI());
-    return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
-  }
+    @ExceptionHandler(InvalidPasswordException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidPassword(InvalidPasswordException ex, HttpServletRequest request) {
+        ErrorResponse error = new ErrorResponse(
+                HttpStatus.UNAUTHORIZED.value(),
+                HttpStatus.UNAUTHORIZED.getReasonPhrase(),
+                ex.getMessage(),
+                request.getRequestURI());
+        return new ResponseEntity<>(error, HttpStatus.UNAUTHORIZED);
+    }
 
   @ExceptionHandler(EmailSendingException.class)
   public ResponseEntity<ErrorResponse> handleEmailSending(EmailSendingException ex, HttpServletRequest request) {

--- a/apps/api/src/test/java/br/org/apae/api/controllers/auth/AuthControllerTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/auth/AuthControllerTest.java
@@ -172,10 +172,10 @@ class AuthControllerTest {
                     "senha-incorreta"
             );
 
-            when(authService.signIn(requestDto))
-                    .thenThrow(new InvalidPasswordException());
+            when(authService.signIn(any(SignInDTO.class)))
+                    .thenThrow(new InvalidPasswordException("E-mail ou senha incorretos"));
 
-            mockMvc.perform(post(BASE_URL + "/signin")
+            mockMvc.perform(post("/auth/signin")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(requestDto)))
                     .andExpect(status().isUnauthorized());
@@ -191,10 +191,10 @@ class AuthControllerTest {
                     "Senha123"
             );
 
-            when(authService.signIn(requestDto))
-                    .thenThrow(new UserNotFoundException());
+            when(authService.signIn(any(SignInDTO.class)))
+                    .thenThrow(new InvalidPasswordException("E-mail ou senha incorretos"));
 
-            mockMvc.perform(post(BASE_URL + "/signin")
+            mockMvc.perform(post("/auth/signin")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(requestDto)))
                     .andExpect(status().isUnauthorized());

--- a/apps/api/src/test/java/br/org/apae/api/controllers/auth/AuthControllerTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/auth/AuthControllerTest.java
@@ -173,9 +173,9 @@ class AuthControllerTest {
             );
 
             when(authService.signIn(any(SignInDTO.class)))
-                    .thenThrow(new InvalidPasswordException("E-mail ou senha incorretos"));
+                    .thenThrow(new InvalidPasswordException());
 
-            mockMvc.perform(post("/auth/signin")
+            mockMvc.perform(post(BASE_URL + "/signin")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(requestDto)))
                     .andExpect(status().isUnauthorized());
@@ -192,9 +192,9 @@ class AuthControllerTest {
             );
 
             when(authService.signIn(any(SignInDTO.class)))
-                    .thenThrow(new InvalidPasswordException("E-mail ou senha incorretos"));
+                    .thenThrow(new InvalidPasswordException());
 
-            mockMvc.perform(post("/auth/signin")
+            mockMvc.perform(post(BASE_URL + "/signin")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(requestDto)))
                     .andExpect(status().isUnauthorized());


### PR DESCRIPTION
# Qual é o objetivo desta PR?

Esta Pull Request resolve uma vulnerabilidade de segurança conhecida como "Enumeração de Usuários" mapeada nas Issues 822 e 823. O sistema estava retornando 404 Not Found quando um e-mail não existia e 400 Bad Request quando a senha estava incorreta. Esse comportamento expunha indiretamente quais e-mails estavam ou não na base de dados do sistema. O objetivo foi padronizar o retorno para 401 Unauthorized com uma mensagem genérica, fortalecendo a segurança da API.

# O que foi feito?

- Unificação no Serviço: A classe AuthApplicationServiceImpl foi alterada para capturar as exceções UserNotFoundException e InvalidPasswordException simultaneamente, mascarando o erro real e lançando sempre um erro genérico de "E-mail ou senha incorretos".

- Ajuste no Manipulador de Exceções: A classe AuthExceptionHandler foi atualizada para mapear a InvalidPasswordException diretamente para o status HTTP 401 Unauthorized.

- Ajustes nos Testes Unitários: Os testes shouldReturnUnauthorizedWhenCredentialsAreInvalid e shouldReturnUnauthorizedWhenUserDoesNotExist da classe AuthControllerTest foram atualizados para simular o novo fluxo genérico do serviço, validando perfeitamente o retorno 401.
