### PR TITLE
823 Corrigir retorno de status ao realizar login com usuário inexistente

### DIFF
--- a/apps/api/src/main/java/br/org/apae/api/auth/application/internal/AuthApplicationServiceImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/auth/application/internal/AuthApplicationServiceImpl.java
@@ -87,10 +87,8 @@ public class AuthApplicationServiceImpl implements AuthApplicationService {
 
             return new TokenResponseDTO(token);
         } catch (UserNotFoundException | InvalidPasswordException e) {
-            throw new InvalidPasswordException("E-mail ou senha incorretos");
+            throw e;
         } catch (Exception e) {
-            throw new AuthenticationException();
-        }
     }
 
     @Override

--- a/apps/api/src/main/java/br/org/apae/api/auth/application/internal/AuthApplicationServiceImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/auth/application/internal/AuthApplicationServiceImpl.java
@@ -35,136 +35,136 @@ import br.org.apae.api.notification.domain.model.EmailMessage;
 
 @Service
 public class AuthApplicationServiceImpl implements AuthApplicationService {
-  private static final int PASSWORD_RECOVERY_EXPIRATION_MINUTES = 30;
+    private static final int PASSWORD_RECOVERY_EXPIRATION_MINUTES = 30;
 
-  private final UserService userService;
-  private final PasswordEncoder passwordEncoder;
-  private final TokenProvider tokenProvider;
-  private final AuthenticationConfiguration authenticationConfiguration;
-  private final PasswordRecoveryTokenRepository passwordRecoveryTokenRepository;
-  private final EmailSender emailSender;
+    private final UserService userService;
+    private final PasswordEncoder passwordEncoder;
+    private final TokenProvider tokenProvider;
+    private final AuthenticationConfiguration authenticationConfiguration;
+    private final PasswordRecoveryTokenRepository passwordRecoveryTokenRepository;
+    private final EmailSender emailSender;
 
-  @Value("${app.frontend.reset-password-url}")
-  private String resetPasswordUrl;
+    @Value("${app.frontend.reset-password-url}")
+    private String resetPasswordUrl;
 
-  public AuthApplicationServiceImpl(
-      UserService userService,
-      PasswordEncoder passwordEncoder,
-      AuthenticationConfiguration authenticationConfiguration,
-      TokenProvider tokenProvider,
-      PasswordRecoveryTokenRepository passwordRecoveryTokenRepository,
-      EmailSender emailSender) {
-    this.userService = userService;
-    this.passwordEncoder = passwordEncoder;
-    this.authenticationConfiguration = authenticationConfiguration;
-    this.tokenProvider = tokenProvider;
-    this.passwordRecoveryTokenRepository = passwordRecoveryTokenRepository;
-    this.emailSender = emailSender;
-  }
-
-  @Override
-  public void signUp(SignUpDTO signUpDto) {
-    String passwordHashed = passwordEncoder.encode(signUpDto.password());
-    userService.createUser(signUpDto.email(), passwordHashed, signUpDto.cpf(), signUpDto.fullName());
-  }
-
-  @Override
-  public TokenResponseDTO signIn(SignInDTO signInDto) {
-    try {
-      User user = userService.findUserByUsername(signInDto.username());
-
-      if (!passwordEncoder.matches(signInDto.password(), user.getPassword())) {
-        throw new InvalidPasswordException();
-      }
-
-      AuthenticationManager authenticationManager = authenticationConfiguration.getAuthenticationManager();
-      var authenticationToken = new UsernamePasswordAuthenticationToken(
-          signInDto.username(), signInDto.password());
-      var authentication = authenticationManager.authenticate(authenticationToken);
-
-      UserDetails userDetails = (UserDetails) authentication.getPrincipal();
-      String token = tokenProvider.generateToken((User) userDetails);
-
-      return new TokenResponseDTO(token);
-    } catch (UserNotFoundException | InvalidPasswordException e) {
-      throw e;
-    } catch (Exception e) {
-      throw new AuthenticationException();
-    }
-  }
-
-  @Override
-  @Transactional
-  public void requestPasswordRecovery(PasswordRecoveryRequestDTO dto) {
-    Optional<User> optionalUser = userService.findUserByEmail(dto.email());
-
-    if (optionalUser.isEmpty()) {
-      return;
+    public AuthApplicationServiceImpl(
+            UserService userService,
+            PasswordEncoder passwordEncoder,
+            AuthenticationConfiguration authenticationConfiguration,
+            TokenProvider tokenProvider,
+            PasswordRecoveryTokenRepository passwordRecoveryTokenRepository,
+            EmailSender emailSender) {
+        this.userService = userService;
+        this.passwordEncoder = passwordEncoder;
+        this.authenticationConfiguration = authenticationConfiguration;
+        this.tokenProvider = tokenProvider;
+        this.passwordRecoveryTokenRepository = passwordRecoveryTokenRepository;
+        this.emailSender = emailSender;
     }
 
-    User user = optionalUser.get();
-
-    String rawToken = UUID.randomUUID().toString() + UUID.randomUUID();
-    String tokenHash = hashToken(rawToken);
-
-    PasswordRecoveryToken passwordRecoveryToken = new PasswordRecoveryToken(
-        tokenHash,
-        user,
-        LocalDateTime.now().plusMinutes(PASSWORD_RECOVERY_EXPIRATION_MINUTES));
-
-    passwordRecoveryTokenRepository.save(passwordRecoveryToken);
-
-    String recoveryLink = resetPasswordUrl + "?token=" + rawToken;
-
-    EmailMessage emailMessage = new EmailMessage(
-        List.of(dto.email()),
-        "Recuperação de senha",
-        "Olá,\n\n" +
-            "Recebemos uma solicitação para redefinição da sua senha.\n" +
-            "Clique no link abaixo para continuar:\n\n" +
-            recoveryLink +
-            "\n\nSe você não solicitou esta alteração, ignore este e-mail.");
-
-    emailSender.send(emailMessage);
-  }
-
-  @Override
-  @Transactional
-  public void resetPassword(PasswordResetDTO dto) {
-    if (!dto.newPassword().equals(dto.confirmPassword())) {
-      throw new AuthenticationException("As senhas não coincidem.");
+    @Override
+    public void signUp(SignUpDTO signUpDto) {
+        String passwordHashed = passwordEncoder.encode(signUpDto.password());
+        userService.createUser(signUpDto.email(), passwordHashed, signUpDto.cpf(), signUpDto.fullName());
     }
 
-    String tokenHash = hashToken(dto.token());
+    @Override
+    public TokenResponseDTO signIn(SignInDTO signInDto) {
+        try {
+            User user = userService.findUserByUsername(signInDto.username());
 
-    PasswordRecoveryToken recoveryToken = passwordRecoveryTokenRepository.findByTokenHash(tokenHash)
-        .orElseThrow(() -> new AuthenticationException("Token inválido."));
+            if (!passwordEncoder.matches(signInDto.password(), user.getPassword())) {
+                throw new InvalidPasswordException();
+            }
 
-    if (recoveryToken.isUsed()) {
-      throw new AuthenticationException("Token já utilizado.");
+            AuthenticationManager authenticationManager = authenticationConfiguration.getAuthenticationManager();
+            var authenticationToken = new UsernamePasswordAuthenticationToken(
+                    signInDto.username(), signInDto.password());
+            var authentication = authenticationManager.authenticate(authenticationToken);
+
+            UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+            String token = tokenProvider.generateToken((User) userDetails);
+
+            return new TokenResponseDTO(token);
+        } catch (UserNotFoundException | InvalidPasswordException e) {
+            throw new InvalidPasswordException("E-mail ou senha incorretos");
+        } catch (Exception e) {
+            throw new AuthenticationException();
+        }
     }
 
-    if (recoveryToken.getExpiresAt().isBefore(LocalDateTime.now())) {
-      throw new AuthenticationException("Token expirado.");
+    @Override
+    @Transactional
+    public void requestPasswordRecovery(PasswordRecoveryRequestDTO dto) {
+        Optional<User> optionalUser = userService.findUserByEmail(dto.email());
+
+        if (optionalUser.isEmpty()) {
+            return;
+        }
+
+        User user = optionalUser.get();
+
+        String rawToken = UUID.randomUUID().toString() + UUID.randomUUID();
+        String tokenHash = hashToken(rawToken);
+
+        PasswordRecoveryToken passwordRecoveryToken = new PasswordRecoveryToken(
+                tokenHash,
+                user,
+                LocalDateTime.now().plusMinutes(PASSWORD_RECOVERY_EXPIRATION_MINUTES));
+
+        passwordRecoveryTokenRepository.save(passwordRecoveryToken);
+
+        String recoveryLink = resetPasswordUrl + "?token=" + rawToken;
+
+        EmailMessage emailMessage = new EmailMessage(
+                List.of(dto.email()),
+                "Recuperação de senha",
+                "Olá,\n\n" +
+                        "Recebemos uma solicitação para redefinição da sua senha.\n" +
+                        "Clique no link abaixo para continuar:\n\n" +
+                        recoveryLink +
+                        "\n\nSe você não solicitou esta alteração, ignore este e-mail.");
+
+        emailSender.send(emailMessage);
     }
 
-    User user = recoveryToken.getUser();
-    String encodedPassword = passwordEncoder.encode(dto.newPassword());
+    @Override
+    @Transactional
+    public void resetPassword(PasswordResetDTO dto) {
+        if (!dto.newPassword().equals(dto.confirmPassword())) {
+            throw new AuthenticationException("As senhas não coincidem.");
+        }
 
-    user.updatePassword(encodedPassword);
-    userService.save(user);
+        String tokenHash = hashToken(dto.token());
 
-    recoveryToken.markAsUsed();
-    passwordRecoveryTokenRepository.save(recoveryToken);
-  }
+        PasswordRecoveryToken recoveryToken = passwordRecoveryTokenRepository.findByTokenHash(tokenHash)
+                .orElseThrow(() -> new AuthenticationException("Token inválido."));
 
-  private String hashToken(String rawToken) {
-    try {
-      MessageDigest digest = MessageDigest.getInstance("SHA-256");
-      byte[] hashBytes = digest.digest(rawToken.getBytes(StandardCharsets.UTF_8));
-      return HexFormat.of().formatHex(hashBytes);
-    } catch (Exception e) {
-      throw new AuthenticationException("Erro ao processar token de recuperação.", e);
+        if (recoveryToken.isUsed()) {
+            throw new AuthenticationException("Token já utilizado.");
+        }
+
+        if (recoveryToken.getExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new AuthenticationException("Token expirado.");
+        }
+
+        User user = recoveryToken.getUser();
+        String encodedPassword = passwordEncoder.encode(dto.newPassword());
+
+        user.updatePassword(encodedPassword);
+        userService.save(user);
+
+        recoveryToken.markAsUsed();
+        passwordRecoveryTokenRepository.save(recoveryToken);
     }
-  }
+
+    private String hashToken(String rawToken) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashBytes = digest.digest(rawToken.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hashBytes);
+        } catch (Exception e) {
+            throw new AuthenticationException("Erro ao processar token de recuperação.", e);
+        }
+    }
 }

--- a/apps/api/src/main/java/br/org/apae/api/auth/exceptions/AuthExceptionHandler.java
+++ b/apps/api/src/main/java/br/org/apae/api/auth/exceptions/AuthExceptionHandler.java
@@ -20,11 +20,11 @@ public class AuthExceptionHandler {
     @ExceptionHandler(UserNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleUserNotFound(UserNotFoundException ex, HttpServletRequest request) {
         ErrorResponse error = new ErrorResponse(
-                HttpStatus.NOT_FOUND.value(),
-                HttpStatus.NOT_FOUND.getReasonPhrase(),
-                ex.getMessage(),
+                HttpStatus.UNAUTHORIZED.value(),
+                HttpStatus.UNAUTHORIZED.getReasonPhrase(),
+                "E-mail ou senha incorretos",
                 request.getRequestURI());
-        return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
+        return new ResponseEntity<>(error, HttpStatus.UNAUTHORIZED);
     }
 
     @ExceptionHandler(UserConflictException.class)
@@ -73,7 +73,7 @@ public class AuthExceptionHandler {
         ErrorResponse error = new ErrorResponse(
                 HttpStatus.UNAUTHORIZED.value(),
                 HttpStatus.UNAUTHORIZED.getReasonPhrase(),
-                ex.getMessage(),
+                "E-mail ou senha incorretos",
                 request.getRequestURI());
         return new ResponseEntity<>(error, HttpStatus.UNAUTHORIZED);
     }

--- a/apps/api/src/main/java/br/org/apae/api/auth/exceptions/AuthExceptionHandler.java
+++ b/apps/api/src/main/java/br/org/apae/api/auth/exceptions/AuthExceptionHandler.java
@@ -17,74 +17,74 @@ import jakarta.servlet.http.HttpServletRequest;
 
 @ControllerAdvice
 public class AuthExceptionHandler {
-  @ExceptionHandler(UserNotFoundException.class)
-  public ResponseEntity<ErrorResponse> handleUserNotFound(UserNotFoundException ex, HttpServletRequest request) {
-    ErrorResponse error = new ErrorResponse(
-        HttpStatus.NOT_FOUND.value(),
-        HttpStatus.NOT_FOUND.getReasonPhrase(),
-        ex.getMessage(),
-        request.getRequestURI());
-    return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
-  }
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleUserNotFound(UserNotFoundException ex, HttpServletRequest request) {
+        ErrorResponse error = new ErrorResponse(
+                HttpStatus.NOT_FOUND.value(),
+                HttpStatus.NOT_FOUND.getReasonPhrase(),
+                ex.getMessage(),
+                request.getRequestURI());
+        return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
+    }
 
-  @ExceptionHandler(UserConflictException.class)
-  public ResponseEntity<ErrorResponse> handleUserConflict(UserConflictException ex, HttpServletRequest request) {
-    ErrorResponse error = new ErrorResponse(
-        HttpStatus.CONFLICT.value(),
-        HttpStatus.CONFLICT.getReasonPhrase(),
-        ex.getMessage(),
-        request.getRequestURI());
-    return new ResponseEntity<>(error, HttpStatus.CONFLICT);
-  }
+    @ExceptionHandler(UserConflictException.class)
+    public ResponseEntity<ErrorResponse> handleUserConflict(UserConflictException ex, HttpServletRequest request) {
+        ErrorResponse error = new ErrorResponse(
+                HttpStatus.CONFLICT.value(),
+                HttpStatus.CONFLICT.getReasonPhrase(),
+                ex.getMessage(),
+                request.getRequestURI());
+        return new ResponseEntity<>(error, HttpStatus.CONFLICT);
+    }
 
-  @ExceptionHandler(AuthenticationException.class)
-  public ResponseEntity<ErrorResponse> handleAuthentication(AuthenticationException ex, HttpServletRequest request) {
-    ErrorResponse error = new ErrorResponse(
-        HttpStatus.BAD_REQUEST.value(),
-        HttpStatus.BAD_REQUEST.getReasonPhrase(),
-        ex.getMessage(),
-        request.getRequestURI());
-    return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
-  }
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ErrorResponse> handleAuthentication(AuthenticationException ex, HttpServletRequest request) {
+        ErrorResponse error = new ErrorResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                ex.getMessage(),
+                request.getRequestURI());
+        return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+    }
 
-  @ExceptionHandler(TokenGenerationException.class)
-  public ResponseEntity<ErrorResponse> handleTokenGeneration(TokenGenerationException ex, HttpServletRequest request) {
-    ErrorResponse error = new ErrorResponse(
-        HttpStatus.INTERNAL_SERVER_ERROR.value(),
-        HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(),
-        ex.getMessage(),
-        request.getRequestURI());
-    return new ResponseEntity<>(error, HttpStatus.INTERNAL_SERVER_ERROR);
-  }
+    @ExceptionHandler(TokenGenerationException.class)
+    public ResponseEntity<ErrorResponse> handleTokenGeneration(TokenGenerationException ex, HttpServletRequest request) {
+        ErrorResponse error = new ErrorResponse(
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(),
+                ex.getMessage(),
+                request.getRequestURI());
+        return new ResponseEntity<>(error, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
 
-  @ExceptionHandler(TokenVerificationException.class)
-  public ResponseEntity<ErrorResponse> handleTokenVerification(TokenVerificationException ex,
-      HttpServletRequest request) {
-    ErrorResponse error = new ErrorResponse(
-        HttpStatus.UNAUTHORIZED.value(),
-        HttpStatus.UNAUTHORIZED.getReasonPhrase(),
-        ex.getMessage(),
-        request.getRequestURI());
-    return new ResponseEntity<>(error, HttpStatus.UNAUTHORIZED);
-  }
+    @ExceptionHandler(TokenVerificationException.class)
+    public ResponseEntity<ErrorResponse> handleTokenVerification(TokenVerificationException ex,
+                                                                 HttpServletRequest request) {
+        ErrorResponse error = new ErrorResponse(
+                HttpStatus.UNAUTHORIZED.value(),
+                HttpStatus.UNAUTHORIZED.getReasonPhrase(),
+                ex.getMessage(),
+                request.getRequestURI());
+        return new ResponseEntity<>(error, HttpStatus.UNAUTHORIZED);
+    }
 
-  @ExceptionHandler(InvalidPasswordException.class)
-  public ResponseEntity<ErrorResponse> handleInvalidPassword(InvalidPasswordException ex, HttpServletRequest request) {
-    ErrorResponse error = new ErrorResponse(
-        HttpStatus.BAD_REQUEST.value(),
-        HttpStatus.BAD_REQUEST.getReasonPhrase(),
-        ex.getMessage(),
-        request.getRequestURI());
-    return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
-  }
+    @ExceptionHandler(InvalidPasswordException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidPassword(InvalidPasswordException ex, HttpServletRequest request) {
+        ErrorResponse error = new ErrorResponse(
+                HttpStatus.UNAUTHORIZED.value(),
+                HttpStatus.UNAUTHORIZED.getReasonPhrase(),
+                ex.getMessage(),
+                request.getRequestURI());
+        return new ResponseEntity<>(error, HttpStatus.UNAUTHORIZED);
+    }
 
-  @ExceptionHandler(EmailSendingException.class)
-  public ResponseEntity<ErrorResponse> handleEmailSending(EmailSendingException ex, HttpServletRequest request) {
-    ErrorResponse error = new ErrorResponse(
-        HttpStatus.INTERNAL_SERVER_ERROR.value(),
-        HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(),
-        ex.getMessage(),
-        request.getRequestURI());
-    return new ResponseEntity<>(error, HttpStatus.INTERNAL_SERVER_ERROR);
-  }
+    @ExceptionHandler(EmailSendingException.class)
+    public ResponseEntity<ErrorResponse> handleEmailSending(EmailSendingException ex, HttpServletRequest request) {
+        ErrorResponse error = new ErrorResponse(
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(),
+                ex.getMessage(),
+                request.getRequestURI());
+        return new ResponseEntity<>(error, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
 }

--- a/apps/api/src/test/java/br/org/apae/api/controllers/auth/AuthControllerTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/auth/AuthControllerTest.java
@@ -172,10 +172,10 @@ class AuthControllerTest {
                     "senha-incorreta"
             );
 
-            when(authService.signIn(any(SignInDTO.class)))
-                    .thenThrow(new InvalidPasswordException("E-mail ou senha incorretos"));
+            when(authService.signIn(requestDto))
+                    .thenThrow(new InvalidPasswordException());
 
-            mockMvc.perform(post("/auth/signin")
+            mockMvc.perform(post(BASE_URL + "/signin")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(requestDto)))
                     .andExpect(status().isUnauthorized());
@@ -191,10 +191,10 @@ class AuthControllerTest {
                     "Senha123"
             );
 
-            when(authService.signIn(any(SignInDTO.class)))
-                    .thenThrow(new InvalidPasswordException("E-mail ou senha incorretos"));
+            when(authService.signIn(requestDto))
+                    .thenThrow(new InvalidPasswordException());
 
-            mockMvc.perform(post("/auth/signin")
+            mockMvc.perform(post(BASE_URL + "/signin")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(requestDto)))
                     .andExpect(status().isUnauthorized());

--- a/apps/api/src/test/java/br/org/apae/api/controllers/auth/AuthControllerTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/auth/AuthControllerTest.java
@@ -172,10 +172,10 @@ class AuthControllerTest {
                     "senha-incorreta"
             );
 
-            when(authService.signIn(requestDto))
-                    .thenThrow(new InvalidPasswordException());
+            when(authService.signIn(any(SignInDTO.class)))
+                    .thenThrow(new InvalidPasswordException("E-mail ou senha incorretos"));
 
-            mockMvc.perform(post(BASE_URL + "/signin")
+            mockMvc.perform(post("/auth/signin")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(requestDto)))
                     .andExpect(status().isUnauthorized());
@@ -191,10 +191,10 @@ class AuthControllerTest {
                     "Senha123"
             );
 
-            when(authService.signIn(requestDto))
-                    .thenThrow(new UserNotFoundException());
+            when(authService.signIn(any(SignInDTO.class)))
+                    .thenThrow(new InvalidPasswordException("E-mail ou senha incorretos"));
 
-            mockMvc.perform(post(BASE_URL + "/signin")
+            mockMvc.perform(post("/auth/signin")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(requestDto)))
                     .andExpect(status().isUnauthorized());


### PR DESCRIPTION
# Qual é o objetivo desta PR?

Esta Pull Request resolve uma vulnerabilidade de segurança conhecida como "Enumeração de Usuários" mapeada nas Issues 822 e 823. O sistema estava retornando 404 Not Found quando um e-mail não existia e 400 Bad Request quando a senha estava incorreta. Esse comportamento expunha indiretamente quais e-mails estavam ou não na base de dados do sistema. O objetivo foi padronizar o retorno para 401 Unauthorized com uma mensagem genérica, fortalecendo a segurança da API.

# O que foi feito?

- Unificação no Serviço: A classe AuthApplicationServiceImpl foi alterada para capturar as exceções UserNotFoundException e InvalidPasswordException simultaneamente, mascarando o erro real e lançando sempre um erro genérico de "E-mail ou senha incorretos".

- Ajuste no Manipulador de Exceções: A classe AuthExceptionHandler foi atualizada para mapear a InvalidPasswordException diretamente para o status HTTP 401 Unauthorized.

- Ajustes nos Testes Unitários: Os testes shouldReturnUnauthorizedWhenCredentialsAreInvalid e shouldReturnUnauthorizedWhenUserDoesNotExist da classe AuthControllerTest foram atualizados para simular o novo fluxo genérico do serviço, validando perfeitamente o retorno 401.
