### PR TITLE
821 Corrigir retorno de status ao realizar signup com dados inválidos

### DIFF
--- a/apps/api/src/main/java/br/org/apae/api/common/dto/auth/request/SignUpDTO.java
+++ b/apps/api/src/main/java/br/org/apae/api/common/dto/auth/request/SignUpDTO.java
@@ -1,5 +1,19 @@
 package br.org.apae.api.common.dto.auth.request;
 
-public record SignUpDTO(String email, String password, String cpf, String fullName) {
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 
-}
+public record SignUpDTO(
+        @NotBlank(message = "O e-mail é obrigatório")
+        @Email(message = "O formato do e-mail é inválido")
+        String email,
+
+        @NotBlank(message = "A senha é obrigatória")
+        String password,
+
+        @NotBlank(message = "O CPF é obrigatório")
+        String cpf,
+
+        @NotBlank(message = "O nome completo é obrigatório")
+        String fullName
+) {}

--- a/apps/api/src/test/java/br/org/apae/api/controllers/auth/AuthControllerTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/auth/AuthControllerTest.java
@@ -35,6 +35,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = AuthControllerImpl.class)
 @AutoConfigureMockMvc(addFilters = false)
+@Import(GlobalExceptionHandler.class)
 @Tag("auth")
 @Tag("unit")
 @Tag("controller")

--- a/apps/api/src/test/java/br/org/apae/api/controllers/auth/AuthControllerTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/auth/AuthControllerTest.java
@@ -21,6 +21,8 @@ import br.org.apae.api.common.dto.auth.request.PasswordResetDTO;
 import br.org.apae.api.common.dto.auth.request.SignInDTO;
 import br.org.apae.api.common.dto.auth.request.SignUpDTO;
 import br.org.apae.api.common.dto.auth.response.TokenResponseDTO;
+import br.org.apae.api.common.exceptions.handler.GlobalExceptionHandler;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -29,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;


### PR DESCRIPTION
# Qual é o objetivo desta PR?

Esta Pull Request corrige uma falha de validação no endpoint de cadastro de novos usuários (POST /signup). A API estava retornando status 201 Created mesmo quando o payload não continha dados obrigatórios (senha, CPF, nome) ou possuía e-mails inválidos. O objetivo foi aplicar as restrições corretas no DTO de entrada para que o sistema rejeite requisições malformadas com um 400 Bad Request, impedindo o processamento de cadastros inconsistentes.

# O que foi feito?

- Validação de DTO: Inclusão das anotações @NotBlank e @Email (do jakarta.validation) na classe SignUpDTO, estabelecendo a obrigatoriedade e o formato correto para email, password, cpf e fullName.

- Ajuste de Testes: Inclusão do GlobalExceptionHandler no contexto do @WebMvcTest da classe AuthControllerTest para que o teste consiga formatar adequadamente a MethodArgumentNotValidException e validar o retorno 400 Bad Request.