### PR TITLE
846 traduz mensagem de erro ao editar agendamento inativo

### DIFF
--- a/apps/api/src/main/java/br/org/apae/api/appointment/application/internal/AppointmentApplicationServiceImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/appointment/application/internal/AppointmentApplicationServiceImpl.java
@@ -375,7 +375,7 @@ public class AppointmentApplicationServiceImpl implements AppointmentApplication
                 .orElseThrow(() -> new IllegalArgumentException("Rule not found"));
 
         if (!current.isActive()) {
-            throw new IllegalStateException("Only active rules can be edited");
+            throw new IllegalStateException("Apenas agendamentos ativos podem ser editados");
         }
 
         LocalDate startDate = dto.initialDate() != null ? dto.initialDate() : current.getInitialDate();


### PR DESCRIPTION
# Qual é o objetivo desta PR?

Esta Pull Request corrige uma falha de tradução no backend. O método de atualização de regras de agendamento (update no AppointmentApplicationServiceImpl) estava lançando uma IllegalStateException com a mensagem hardcoded em inglês ("Only active rules can be edited"). Como o frontend renderiza diretamente as mensagens de erro vindas da API, isso causava uma quebra de padrão de idioma na interface. O objetivo foi traduzir a mensagem para português.

# O que foi feito?

- Localização da exceção lançada ao tentar editar um agendamento inativo (current.isActive() == false).

- Tradução da mensagem da exceção de "Only active rules can be edited" para "Apenas agendamentos ativos podem ser editados".