### PR TITLE
fix: corrige contagem incorreta dos cards de agendamentos ativos/inat…

### DIFF
--- a/apps/apae/src/app/page.tsx
+++ b/apps/apae/src/app/page.tsx
@@ -106,30 +106,13 @@ export default function DashboardPage() {
     };
 
   const fetchTodayAppointmentsByStatus = async () => {
-    if (!todayAppointments.length || !allAppointments.length) return;
+    if (!allAppointments.length) return;
 
-    const appointmentMap = new Map(
-      allAppointments.map(a => [a.id, a])
-    );
-
-    const active: TodayAppointment[] = [];
-    const inactive: TodayAppointment[] = [];
-
-    for (const today of todayAppointments) {
-      const related = appointmentMap.get(today.ruleId);
-
-      if (!related) continue;
-
-      if (related.isActive) {
-        active.push(today);
-      } else {
-        inactive.push(today);
-      }
-    }
-
-    setActiveAppointments(active);
-    setInactiveAppointments(inactive);
+    setActiveAppointments(allAppointments.filter(a => a.isActive === true) as any);
+    setInactiveAppointments(allAppointments.filter(a => a.isActive === false) as any);
   };
+
+
 
   useEffect(() => {
 
@@ -146,7 +129,7 @@ export default function DashboardPage() {
 
   useEffect(() => {
     fetchTodayAppointmentsByStatus();
-  }, [todayAppointments, allAppointments]);
+  }, [allAppointments]);
 
   const markAsPerformedHandle = async (id: UUID) => {
     await markAsPerformed(id);
@@ -230,14 +213,14 @@ export default function DashboardPage() {
           <InfoCard
             title="Ativos"
             icon={UserRoundCheck}
-            value={activeAppointments.length}
+            value={allAppointments.filter(a => a.isActive).length}
             titleClassName="text-[#0D4F97]"
             valueClassName="text-[#0D4F97]"
           />
           <InfoCard
             title="Inativos"
             icon={UserRoundX}
-            value={inactiveAppointments.length}
+            value={allAppointments.filter(a => !a.isActive).length}
             titleClassName="text-[#0D4F97]"
             valueClassName="text-[#0D4F97]"
           />

--- a/apps/apae/src/types/appointment.ts
+++ b/apps/apae/src/types/appointment.ts
@@ -12,4 +12,5 @@ export interface TodayAppointment {
 	effectiveDateTime: Date;
 	ruleId: UUID,
 	hasAbsence: boolean;
+	isActive: boolean;
 }


### PR DESCRIPTION

# O que mudou?

Antes, na tela de "Agendamentos do Dia" os cards de "Ativo" e "Inativo" não contabilizavam corretamente os agendamentos em seus respectivos status. Agora, após as mudanças, eles seguem funcionando perfeitamente.

## Tarefas Relacionadas
* Outras issues: 
#671 
#668 

## Mudanças Realizadas

* Substituída a fonte de dados dos cards "Ativos" e "Inativos" de todayAppointments para allAppointments, que possui o campo isActive
* Os cards passaram a calcular a contagem diretamente via .filter(a => a.isActive) no render, garantindo consistência com a tela "Todos os agendamentos"
## Evidências

Antes:
<img width="1608" height="482" alt="image" src="https://github.com/user-attachments/assets/f20e6fed-19ea-4ab0-aef7-1838267b2ab8" />
Depois:
<img width="1906" height="803" alt="image" src="https://github.com/user-attachments/assets/138bba42-99af-44c9-bebc-241101d106b9" />
Agora ele mostra em tempo real a quantidade de agendamentos ativos/inativos
