### PR TITLE
fix: adiciona mensagem de erro ao tentar apagar agendamentos com hist…

### DIFF
--- a/apps/apae/src/app/appointments/[id]/page.tsx
+++ b/apps/apae/src/app/appointments/[id]/page.tsx
@@ -170,7 +170,7 @@ export default function ViewAppointment() {
                 </DialogContent>
               </Dialog>
               <div className="rounded-full overflow-hidden border-1 border-[#0D4F97]">
-                <TrashButton id={id} realized={false} />
+                <TrashButton id={id} realized={false} hasHistory={!!(appointment.replacedByDate || appointment.updatedFromDate)}/>
               </div>
             </CardAction>
           </CardHeader>

--- a/apps/apae/src/components/buttons/trashButton.tsx
+++ b/apps/apae/src/components/buttons/trashButton.tsx
@@ -1,5 +1,5 @@
 "use client";
-
+import { toast } from "react-toastify";
 import { Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { deleteAppointment } from "@/app/services/appointmentService";
@@ -17,9 +17,11 @@ import {
 
 export default function TrashButton({
   id,
+    hasHistory,
 }: {
   id: string;
   realized: boolean;
+  hasHistory: boolean
 }) {
   const router = useRouter();
 
@@ -27,6 +29,22 @@ export default function TrashButton({
     await deleteAppointment(id);
     router.back();
   };
+
+  if (hasHistory) {
+    return (
+        <Button
+            className="bg-transparent cursor-not-allowed text-[#970D0D] opacity-50 hover:bg-[rgba(0,0,0,0.1)] transition-colors"
+            onClick={() =>
+                toast.warning(
+                    "Este agendamento possui histórico e não pode ser excluído."
+                )
+            }
+        >
+          <Trash2 />
+        </Button>
+    );
+  }
+
 
   return (
     <Dialog>


### PR DESCRIPTION
# O que mudou?

O botão de exclusão agora bloqueia a ação quando o agendamento possui histórico, exibindo uma mensagem amigável ao usuário em vez de lançar um Runtime Error.

## Tarefas Relacionadas

* Issue: {#845}

## Mudanças Realizadas

* Adicionada prop hasHistory no TrashButton para indicar se o agendamento possui histórico
* Ao clicar no botão com hasHistory=true, a requisição de exclusão é bloqueada e um toast de aviso é exibido
* Na página de detalhes, hasHistory é calculado verificando se replacedByDate ou updatedFromDate estão preenchidos
## Evidências

Inclua imagens, vídeos, prints de logs, ou qualquer evidência que comprove que a funcionalidade está funcionando conforme o esperado.
