### PR TITLE
feat: move componentes para seus domínios corretos (#740)

### DIFF
--- a/apps/apae/src/app/patients/[id]/documents/[type]/page.tsx
+++ b/apps/apae/src/app/patients/[id]/documents/[type]/page.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { useRouter, useParams } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import FileCard from "@/components/fileCard";
+import FileCard from "@/domains/documents/shared/file-card";
 import ReplaceDocumentModal from "@/components/documents/ReplaceDocumentModal";
 import { toast } from "react-toastify";
 import {

--- a/apps/apae/src/app/patients/[id]/page.tsx
+++ b/apps/apae/src/app/patients/[id]/page.tsx
@@ -4,13 +4,13 @@
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import DocumentCategoriesCard from "@/components/DocumentCategoriesCard";
+import DocumentCategoriesCard from "@/domains/documents/shared/document-categories-card";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState, useCallback } from "react";
 import { toast } from "react-toastify";
 import { Loader2, ArrowLeft, SquarePen, Plus } from "lucide-react";
-import AnnualRegistryEditModal from "@/components/AnnualRegistryEditModal";
+import AnnualRegistryEditModal from "@/domains/patients/annual-registry/annual-registry-edit-modal";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { PatientResponse } from "@/types/patient";
 

--- a/apps/apae/src/domains/documents/shared/document-categories-card.tsx
+++ b/apps/apae/src/domains/documents/shared/document-categories-card.tsx
@@ -1,0 +1,44 @@
+'use client';
+import React from 'react';
+import { User, ClipboardPlus, LibraryBigIcon } from 'lucide-react';
+
+interface Category {
+  label: string;
+  icon: React.ReactNode;
+  type: string;
+}
+
+interface DocumentCategoriesCardProps {
+  onClickCategory: (type: string) => void;
+  categories?: Category[];
+}
+
+const DocumentCategoriesCard: React.FC<DocumentCategoriesCardProps> = ({
+  onClickCategory,
+  categories = [
+    { label: 'Pessoais', icon: <User />, type: 'personals' },
+    { label: 'Médicos', icon: <ClipboardPlus />, type: 'medicals' },
+    { label: 'Escolares', icon: <LibraryBigIcon />, type: 'schools' },
+  ],
+}) => {
+  return (
+    <div className="rounded-4xl bg-[#0D4F97] p-6 text-white w-full mx-auto">
+      <h2 className="text-center text-2xl font-semibold mb-4">Documentos</h2>
+
+      <div className="flex justify-around gap-2 flex-wrap">
+        {categories.map((category) => (
+          <div
+            key={category.type}
+            onClick={() => onClickCategory(category.type)}
+            className="flex flex-col items-center justify-center cursor-pointer border-2 border-white px-4 py-3 rounded-lg hover:bg-white hover:text-[#003366] transition-colors duration-200"
+          >
+            {category.icon}
+            <span className="mt-2 text-sm font-medium">{category.label}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default DocumentCategoriesCard;

--- a/apps/apae/src/domains/documents/shared/file-card.tsx
+++ b/apps/apae/src/domains/documents/shared/file-card.tsx
@@ -1,20 +1,16 @@
 "use client";
 
-import Image from "next/image";
-import { useState } from "react";
-
 import * as React from "react";
 import { FileText, ExternalLink } from "lucide-react";
 import {
   Dialog,
   DialogContent,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 
-interface Props {
+interface FileCardProps {
   file: {
     fileName: string;
     link: string;
@@ -25,27 +21,13 @@ interface Props {
   onReplace?: () => void;
 }
 
-export default function FileCard({
-  file,
-  canReplace = false,
-  onReplace,
-}: Props) {
+export default function FileCard({ file, canReplace = false, onReplace }: FileCardProps) {
   const [open, setOpen] = React.useState(false);
-
-  // State for the Modal (Large Preview)
-  const [modalViewType, setModalViewType] = React.useState<"img" | "iframe">(
-    "img",
-  );
-
-  // NEW: Status for the Miniature (Small Card)
-  const [thumbnailView, setThumbnailView] = React.useState<"img" | "icon">(
-    "img",
-  );
+  const [modalViewType, setModalViewType] = React.useState<"img" | "iframe">("img");
+  const [thumbnailView, setThumbnailView] = React.useState<"img" | "icon">("img");
 
   React.useEffect(() => {
-    if (open) {
-      setModalViewType("img");
-    }
+    if (open) setModalViewType("img");
   }, [open]);
 
   return (
@@ -56,24 +38,17 @@ export default function FileCard({
       >
         <p className="truncate mb-2 text-sm font-medium">{file.fileName}</p>
 
-        {/* MINIATURE AREA */}
         <div className="flex flex-col items-center justify-center bg-blue-50 text-blue-900 rounded-md w-full h-32 border border-blue-100 overflow-hidden relative">
           {thumbnailView === "img" ? (
             <img
               src={file.link}
               alt={file.fileName}
-              // Object-cover makes the image fill the entire square in an elegant way.
               className="w-full h-full object-cover"
-              // If it fails (for PDF), switch to the icon.
               onError={() => setThumbnailView("icon")}
             />
           ) : (
             <>
-              <FileText
-                size={40}
-                strokeWidth={1.5}
-                className="mb-1 text-blue-800"
-              />
+              <FileText size={40} strokeWidth={1.5} className="mb-1 text-blue-800" />
               <span className="text-[10px] font-bold uppercase tracking-wider text-blue-800">
                 Documento
               </span>
@@ -86,24 +61,19 @@ export default function FileCard({
             type="button"
             variant="secondary"
             className="mt-3 w-full border border-blue-100 bg-blue-50 text-blue-900 hover:bg-blue-100"
-            onClick={(event) => {
-              event.stopPropagation();
-              onReplace();
-            }}
+            onClick={(e) => { e.stopPropagation(); onReplace(); }}
           >
             Substituir
           </Button>
         )}
       </div>
 
-      {/* Preview Modal (KEPT AS IT WORKED) */}
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent className="sm:max-w-[900px] max-h-[90vh] overflow-hidden bg-white">
           <DialogHeader className="flex flex-row items-center justify-between">
             <DialogTitle className="truncate pr-4">{file.fileName}</DialogTitle>
           </DialogHeader>
 
-          {/* Large Preview Area */}
           <div className="flex justify-center items-center w-full h-[60vh] bg-gray-50 rounded-lg overflow-hidden relative">
             {modalViewType === "img" && (
               <img
@@ -113,23 +83,13 @@ export default function FileCard({
                 onError={() => setModalViewType("iframe")}
               />
             )}
-
             {modalViewType === "iframe" && (
-              <iframe
-                src={file.link}
-                title={file.fileName}
-                className="w-full h-full border-0"
-              />
+              <iframe src={file.link} title={file.fileName} className="w-full h-full border-0" />
             )}
           </div>
 
-          {/* Button to open in new tab */}
           <div className="flex justify-center mt-4 pb-2">
-            <Button
-              variant="default"
-              onClick={() => window.open(file.link, "_blank")}
-              className="gap-2"
-            >
+            <Button variant="default" onClick={() => window.open(file.link, "_blank")} className="gap-2">
               <ExternalLink size={18} />
               Abrir em nova guia
             </Button>

--- a/apps/apae/src/domains/documents/shared/file-card.tsx
+++ b/apps/apae/src/domains/documents/shared/file-card.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import Image from "next/image";
+import { useState } from "react";
+
+import * as React from "react";
+import { FileText, ExternalLink } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  file: {
+    fileName: string;
+    link: string;
+    type?: string;
+    originalName?: string;
+  };
+  canReplace?: boolean;
+  onReplace?: () => void;
+}
+
+export default function FileCard({
+  file,
+  canReplace = false,
+  onReplace,
+}: Props) {
+  const [open, setOpen] = React.useState(false);
+
+  // State for the Modal (Large Preview)
+  const [modalViewType, setModalViewType] = React.useState<"img" | "iframe">(
+    "img",
+  );
+
+  // NEW: Status for the Miniature (Small Card)
+  const [thumbnailView, setThumbnailView] = React.useState<"img" | "icon">(
+    "img",
+  );
+
+  React.useEffect(() => {
+    if (open) {
+      setModalViewType("img");
+    }
+  }, [open]);
+
+  return (
+    <>
+      <div
+        className="cursor-pointer p-3 border rounded hover:bg-gray-100 overflow-hidden flex flex-col"
+        onClick={() => setOpen(true)}
+      >
+        <p className="truncate mb-2 text-sm font-medium">{file.fileName}</p>
+
+        {/* MINIATURE AREA */}
+        <div className="flex flex-col items-center justify-center bg-blue-50 text-blue-900 rounded-md w-full h-32 border border-blue-100 overflow-hidden relative">
+          {thumbnailView === "img" ? (
+            <img
+              src={file.link}
+              alt={file.fileName}
+              // Object-cover makes the image fill the entire square in an elegant way.
+              className="w-full h-full object-cover"
+              // If it fails (for PDF), switch to the icon.
+              onError={() => setThumbnailView("icon")}
+            />
+          ) : (
+            <>
+              <FileText
+                size={40}
+                strokeWidth={1.5}
+                className="mb-1 text-blue-800"
+              />
+              <span className="text-[10px] font-bold uppercase tracking-wider text-blue-800">
+                Documento
+              </span>
+            </>
+          )}
+        </div>
+
+        {canReplace && onReplace && (
+          <Button
+            type="button"
+            variant="secondary"
+            className="mt-3 w-full border border-blue-100 bg-blue-50 text-blue-900 hover:bg-blue-100"
+            onClick={(event) => {
+              event.stopPropagation();
+              onReplace();
+            }}
+          >
+            Substituir
+          </Button>
+        )}
+      </div>
+
+      {/* Preview Modal (KEPT AS IT WORKED) */}
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-[900px] max-h-[90vh] overflow-hidden bg-white">
+          <DialogHeader className="flex flex-row items-center justify-between">
+            <DialogTitle className="truncate pr-4">{file.fileName}</DialogTitle>
+          </DialogHeader>
+
+          {/* Large Preview Area */}
+          <div className="flex justify-center items-center w-full h-[60vh] bg-gray-50 rounded-lg overflow-hidden relative">
+            {modalViewType === "img" && (
+              <img
+                src={file.link}
+                alt={file.fileName}
+                className="w-full h-full object-contain"
+                onError={() => setModalViewType("iframe")}
+              />
+            )}
+
+            {modalViewType === "iframe" && (
+              <iframe
+                src={file.link}
+                title={file.fileName}
+                className="w-full h-full border-0"
+              />
+            )}
+          </div>
+
+          {/* Button to open in new tab */}
+          <div className="flex justify-center mt-4 pb-2">
+            <Button
+              variant="default"
+              onClick={() => window.open(file.link, "_blank")}
+              className="gap-2"
+            >
+              <ExternalLink size={18} />
+              Abrir em nova guia
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/apae/src/domains/documents/shared/file-restore-alert.tsx
+++ b/apps/apae/src/domains/documents/shared/file-restore-alert.tsx
@@ -1,0 +1,16 @@
+import { AlertCircle } from "lucide-react";
+
+export function FileRestoreAlert() {
+  return (
+    <div className="flex gap-3 p-4 mb-6 border-l-4 rounded-r-md bg-amber-50 border-amber-400 animate-in fade-in slide-in-from-top-2">
+      <AlertCircle className="flex-shrink-0 w-5 h-5 text-amber-600 mt-0.5" />
+      <div>
+        <h4 className="text-sm font-bold text-amber-900">Rascunho recuperado</h4>
+        <p className="mt-1 text-xs leading-relaxed text-amber-800">
+          Seus dados de texto foram restaurados, mas por segurança, 
+          <strong> arquivos e laudos precisam ser selecionados novamente.</strong>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/apae/src/domains/patients/annual-registry/annual-registry-edit-modal.tsx
+++ b/apps/apae/src/domains/patients/annual-registry/annual-registry-edit-modal.tsx
@@ -1,543 +1,277 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { AnnualRegistryFormSchema, AnnualRegistryFormValues } from "@/schemas/anualRegistrySchema";
-import { toast } from "react-toastify";
 import { Loader2, Upload, FileText, RefreshCw, ExternalLink } from "lucide-react";
-
 import { StringMultiSelect } from "@/components/StringMultiSelect";
 import { GenericDatabaseSelect } from "@/components/GenericDatabaseSelect";
-
-interface DocumentDTO {
-    id: string;
-    name: string;
-    category: string;
-    type: string;
-    url: string;
-}
+import { useAnnualRegistryModal, availableYears } from "./use-annual-registry-modal";
+import { MEDICAL_DOC_TYPES, DOC_TYPE_TRANSLATIONS, type AnnualRegistry } from "./annual-registry.types";
 
 interface AnnualRegistryEditModalProps {
-    isOpen: boolean;
-    onClose: (str?: string) => void;
-    patientId: string;
-    currentYear: string;
-    initialData: AnnualRegistry | null;
-    mode?: "create" | "edit";
+  isOpen: boolean;
+  onClose: (str?: string) => void;
+  patientId: string;
+  currentYear: string;
+  initialData: AnnualRegistry | null;
+  mode?: "create" | "edit";
 }
-
-interface DisorderItem {
-    id?: string | number;
-    name?: string;
-    label?: string;
-    value?: string;
-}
-
-interface ServiceAreaItem {
-    id?: string | number;
-    area?: string;
-    name?: string;
-    label?: string;
-    value?: string;
-}
-
-interface AnnualRegistry {
-    id?: string;
-    bpc: boolean | string;
-    familyIncome: number | string;
-    diseases: string;
-    continuousMedication: string;
-    medications?: string;
-    medicamentos?: string;
-    medication?: string;
-    disorders?: DisorderItem[];
-    serviceAreas?: ServiceAreaItem[];
-    serviceArea?: ServiceAreaItem[];
-    serviceTypes?: ServiceAreaItem[];
-}
-
-interface FullPatientData {
-    vaccineNames?: { name: string }[] | string[];
-    allergies?: string;
-    additionals?: {
-        medications?: string;
-        diseases?: string;
-        [key: string]: any;
-    };
-    address?: Record<string, string | null | undefined>;
-    guardian?: Record<string, string | Record<string, string> | null | undefined>;
-    parents?: Array<Record<string, string | boolean>>;
-    nationality?: string;
-    birthplace?: string;
-    [key: string]: unknown;
-}
-
-const MEDICAL_DOC_TYPES = [
-    { value: "MEDICAL_REPORT", label: "Laudo Médico" },
-    { value: "EXAMINATION", label: "Exame" },
-    { value: "REFERRAL", label: "Encaminhamento" },
-    { value: "OTHER", label: "Outro" }
-];
-
-const docTypeTranslations: Record<string, string> = {
-    MEDICAL_REPORT: "Laudo Médico",
-    EXAMINATION: "Exame",
-    REFERRAL: "Encaminhamento",
-    OTHER: "Outro",
-    VACCINE_CARD: "Cartão de Vacina"
-};
 
 export default function AnnualRegistryEditModal({
-    isOpen,
-    onClose,
-    patientId,
-    currentYear,
-    initialData,
-    mode = "edit"
+  isOpen,
+  onClose,
+  patientId,
+  currentYear,
+  initialData,
+  mode = "edit",
 }: AnnualRegistryEditModalProps) {
+  const {
+    form,
+    documents,
+    isLoadingDocs,
+    isUploading,
+    docType,
+    setDocType,
+    fileInputRef,
+    handleFileUpload,
+    handleMoneyChange,
+    onSubmit,
+    loadDocuments,
+  } = useAnnualRegistryModal({ isOpen, patientId, currentYear, initialData, mode, onClose });
 
-    const [documents, setDocuments] = useState<DocumentDTO[]>([]);
-    const [isLoadingDocs, setIsLoadingDocs] = useState(false);
-    const [isUploading, setIsUploading] = useState(false);
-    const [docType, setDocType] = useState("MEDICAL_REPORT");
+  const { isSubmitting, errors } = form.formState;
+  const isCreateMode = mode === "create";
 
-    const [fullPatientData, setFullPatientData] = useState<FullPatientData | null>(null);
-    const fileInputRef = useRef<HTMLInputElement>(null);
+  return (
+    <Dialog open={isOpen} onOpenChange={() => onClose()}>
+      <DialogContent className="!max-w-[1200px] w-[95vw] h-[85vh] flex flex-col p-0 overflow-hidden bg-slate-50 rounded-xl shadow-xl">
+        <DialogHeader className="px-6 py-4 bg-[#0D4F97] text-white shrink-0">
+          <DialogTitle className="text-xl font-bold font-baloo">
+            {isCreateMode ? "Novo Registro Anual" : "Edição de Saúde & Social"}
+          </DialogTitle>
+          <p className="text-blue-200 text-xs mt-0.5 opacity-90">
+            {isCreateMode ? "Preencha os dados para iniciar um novo ano." : `Referência: ${currentYear}`}
+          </p>
+        </DialogHeader>
 
-    const currentYearInt = new Date().getFullYear();
-    const availableYears = Array.from({ length: 32 }, (_, i) => (currentYearInt + 1 - i).toString());
+        <div className="flex-1 overflow-y-auto p-5 pb-24">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 h-full">
+            <div className="bg-white p-5 rounded-xl shadow-sm border border-slate-200 h-fit">
+              <h3 className="text-[#0D4F97] font-bold text-base mb-4 pb-2 border-b border-slate-100 flex items-center gap-2">
+                <span className="bg-blue-50 p-1.5 rounded-lg text-[#0D4F97]"><FileText className="h-4 w-4" /></span>
+                Dados Clínicos e Sociais
+              </h3>
+              <Form {...form}>
+                <form id="health-form" onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+                  {isCreateMode && (
+                    <FormField control={form.control} name="year" render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className={`font-bold text-xs ${errors.year ? "text-red-500" : "text-slate-700"}`}>Ano de Referência</FormLabel>
+                        <Select onValueChange={field.onChange} defaultValue={field.value}>
+                          <FormControl>
+                            <SelectTrigger className={`bg-slate-50 h-10 text-sm ${errors.year ? "border-red-500 ring-red-500" : "border-slate-200"}`}>
+                              <SelectValue placeholder="Selecione o ano" />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent className="max-h-60">
+                            {availableYears.map((year) => (
+                              <SelectItem key={year} value={year}>{year}</SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <FormMessage className="text-red-500 text-[10px]" />
+                      </FormItem>
+                    )} />
+                  )}
 
-    const form = useForm<AnnualRegistryFormValues>({
-        resolver: zodResolver(AnnualRegistryFormSchema),
-        mode: "onChange",
-        defaultValues: {
-            year: currentYear || currentYearInt.toString(),
-            bpc: "false",
-            familyIncome: "",
-            diseases: "",
-            continuousMedication: "",
-            disorders: [],
-            allergies: "",
-            vaccines: [],
-            serviceTypes: []
-        },
-    });
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <FormField control={form.control} name="bpc" render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className="text-slate-700 font-bold text-xs">Recebe BPC?</FormLabel>
+                        <Select onValueChange={field.onChange} value={field.value}>
+                          <FormControl><SelectTrigger className="bg-slate-50 border-slate-200 h-10 text-sm"><SelectValue placeholder="Selecione" /></SelectTrigger></FormControl>
+                          <SelectContent>
+                            <SelectItem value="true">Sim</SelectItem>
+                            <SelectItem value="false">Não</SelectItem>
+                          </SelectContent>
+                        </Select>
+                        <FormMessage />
+                      </FormItem>
+                    )} />
 
-    const { isSubmitting, errors } = form.formState;
+                    <FormField control={form.control} name="familyIncome" render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className={`font-bold text-xs ${errors.familyIncome ? "text-red-500" : "text-slate-700"}`}>Renda Familiar</FormLabel>
+                        <FormControl>
+                          <Input
+                            {...field}
+                            className={`bg-slate-50 h-10 text-sm ${errors.familyIncome ? "border-red-500 focus-visible:ring-red-500" : "border-slate-200"}`}
+                            placeholder="R$ 0,00"
+                            value={field.value}
+                            onChange={(e) => handleMoneyChange(e, field.onChange)}
+                          />
+                        </FormControl>
+                        <FormMessage className="text-red-500 text-[10px]" />
+                      </FormItem>
+                    )} />
+                  </div>
 
-    useEffect(() => {
-        if (isOpen && patientId) {
-            if (mode === "edit") fetchDocuments();
-            else setDocuments([]);
-            fetchPatientData();
-        }
-    }, [isOpen, patientId, mode]);
+                  <div className="space-y-3">
+                    <FormField control={form.control} name="diseases" render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className={`font-bold text-xs ${errors.diseases ? "text-red-500" : "text-slate-700"}`}>Doenças</FormLabel>
+                        <FormControl>
+                          <div className={errors.diseases ? "border-red-500 border rounded-md" : ""}>
+                            <StringMultiSelect value={field.value || ""} onChange={field.onChange} placeholder="Digite doenças..." />
+                          </div>
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )} />
 
-    useEffect(() => {
-        if (isOpen) {
-            if (mode === "edit" && initialData) {
-                const rawBpc = initialData.bpc;
-                const bpcString = (rawBpc === true || String(rawBpc) === "true") ? "true" : "false";
+                    <FormField control={form.control} name="allergies" render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className={`font-bold text-xs ${errors.allergies ? "text-red-500" : "text-slate-700"}`}>Alergias</FormLabel>
+                        <FormControl>
+                          <div className={errors.allergies ? "border-red-500 border rounded-md" : ""}>
+                            <StringMultiSelect value={field.value || ""} onChange={field.onChange} placeholder="Digite alergias..." />
+                          </div>
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )} />
 
-                const vaccineList = Array.isArray(fullPatientData?.vaccineNames)
-                    ? fullPatientData.vaccineNames.map((v: any) => (typeof v === 'string' ? { name: v } : v))
-                    : [];
+                    <FormField control={form.control} name="continuousMedication" render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className={`font-bold text-xs ${errors.continuousMedication ? "text-red-500" : "text-slate-700"}`}>Medicamentos</FormLabel>
+                        <FormControl>
+                          <div className={errors.continuousMedication ? "border-red-500 border rounded-md" : ""}>
+                            <StringMultiSelect value={field.value || ""} onChange={field.onChange} placeholder="Digite medicamentos..." />
+                          </div>
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )} />
 
-                const sourceServiceAreas = initialData.serviceArea || initialData.serviceAreas || initialData.serviceTypes || [];
-                const serviceTypeList = Array.isArray(sourceServiceAreas) ? sourceServiceAreas.map((s: any) => ({
-                    id: s.id,
-                    area: s.area || s.name,
-                    name: s.name || s.area
-                })) : [];
+                    <FormField control={form.control} name="vaccines" render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className={`font-bold text-xs ${errors.vaccines ? "text-red-500" : "text-slate-700"}`}>Vacinas</FormLabel>
+                        <FormControl>
+                          <GenericDatabaseSelect value={field.value || []} onChange={field.onChange} endpoint="/apae-geral/api/vaccines" labelSingular="Vacina" labelKey="name" placeholder="Selecione vacinas..." />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )} />
+                  </div>
 
-                const medicationValue = initialData.continuousMedication || 
-                                        initialData.medications || 
-                                        initialData.medicamentos || 
-                                        (initialData as any).medication || "";
+                  <div className="pt-1 space-y-3">
+                    <FormField control={form.control} name="disorders" render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className={`font-bold text-xs ${errors.disorders ? "text-red-500" : "text-slate-700"} mb-1.5 block`}>Transtornos</FormLabel>
+                        <FormControl>
+                          <GenericDatabaseSelect value={field.value || []} onChange={field.onChange} endpoint="/apae-geral/api/disorders" labelSingular="Transtorno" labelKey="name" placeholder="Selecione transtornos..." />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )} />
 
-                form.reset({
-                    year: currentYear,
-                    bpc: bpcString,
-                    familyIncome: initialData.familyIncome ? formatCurrencyForDisplay(initialData.familyIncome) : "",
-                    diseases: initialData.diseases ?? "",
-                    continuousMedication: medicationValue,
-                    allergies: fullPatientData?.allergies ?? "",
-                    disorders: initialData.disorders || [],
-                    vaccines: vaccineList,
-                    serviceTypes: serviceTypeList
-                });
+                    <FormField control={form.control} name="serviceTypes" render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className={`font-bold text-xs ${errors.serviceTypes ? "text-red-500" : "text-slate-700"} mb-1.5 block`}>Tipos de Atendimento</FormLabel>
+                        <FormControl>
+                          <GenericDatabaseSelect value={field.value || []} onChange={field.onChange} endpoint="/apae-geral/api/service-types" labelSingular="Tipo" placeholder="Selecione tipos..." labelKey="area" menuPlacement="top" />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )} />
+                  </div>
+                </form>
+              </Form>
+            </div>
 
-            } else if (mode === "create") {
-                const vaccineList = Array.isArray(fullPatientData?.vaccineNames)
-                    ? fullPatientData.vaccineNames.map((v: any) => (typeof v === 'string' ? { name: v } : v))
-                    : [];
-                
-                const existingMedication = fullPatientData?.additionals?.medications || 
-                                          (fullPatientData as any)?.medications || 
-                                          (fullPatientData as any)?.continuousMedication || "";
-
-                const existingDiseases = fullPatientData?.additionals?.diseases || 
-                                         (fullPatientData as any)?.diseases || "";
-
-                form.reset({
-                    year: currentYearInt.toString(),
-                    bpc: "false",
-                    familyIncome: "",
-                    diseases: existingDiseases,
-                    continuousMedication: existingMedication,
-                    allergies: fullPatientData?.allergies ?? "",
-                    disorders: [],
-                    vaccines: vaccineList,
-                    serviceTypes: []
-                });
-            }
-        }
-    }, [initialData, fullPatientData, isOpen, form, mode, currentYear]);
-
-    const fetchDocuments = async () => {
-        setIsLoadingDocs(true);
-        try {
-            const response = await fetch(`/apae-geral/api/patients/${patientId}/documents?category=MEDICAL&year=${currentYear}`);
-            if (response.ok) {
-                const data = await response.json().catch(() => []);
-                setDocuments(Array.isArray(data) ? data : []);
-            }
-        } catch (error) { console.error(error); }
-        finally { setIsLoadingDocs(false); }
-    };
-
-    const fetchPatientData = async () => {
-        try {
-            const response = await fetch(`/apae-geral/api/patients/${patientId}`);
-            if (response.ok) setFullPatientData(await response.json());
-        } catch (error) { console.error(error); }
-    };
-
-    const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
-        const file = e.target.files?.[0];
-        if (!file) return;
-        setIsUploading(true);
-        const formData = new FormData();
-        formData.append("file", file);
-        formData.append("category", "MEDICAL");
-        formData.append("type", docType);
-        formData.append("year", currentYear);
-        try {
-            const res = await fetch(`/apae-geral/api/patients/${patientId}/documents`, {
-                method: "POST",
-                body: formData,
-            });
-            if (!res.ok) throw new Error();
-            toast.success("Documento anexado!");
-            fetchDocuments();
-            if (fileInputRef.current) fileInputRef.current.value = "";
-        } catch { toast.error("Erro ao enviar documento."); }
-        finally { setIsUploading(false); }
-    };
-
-    const cleanCurrency = (value: string) => (!value ? "0.00" : value.replace(/[^\d,]/g, '').replace(',', '.'));
-    const formatCurrencyForDisplay = (value: number | string) => (!value ? "" : Number(value).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' }));
-
-    const handleMoneyChange = (e: React.ChangeEvent<HTMLInputElement>, onChange: (value: string) => void) => {
-        const value = e.target.value.replace(/\D/g, "");
-        if (value === "") { onChange(""); return; }
-        onChange((parseFloat(value) / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" }));
-    };
-
-    const cleanPatientData = (data: any) => {
-        if (!data) return {};
-        const { documents, annualRegistry, createdAt, updatedAt, deleted, isDeleted, age, ...rest } = data;
-        return rest;
-    };
-
-    const onSubmit = async (data: AnnualRegistryFormValues) => {
-        toast.dismiss();
-        try {
-            const registryId = initialData?.id;
-            const income = parseFloat(cleanCurrency(data.familyIncome));
-            const bpcToSend = data.bpc === "true";
-
-            const regPayload: any = {
-                bpc: bpcToSend,
-                familyIncome: income,
-                diseases: data.diseases || "Nenhuma",
-                continuousMedication: data.continuousMedication || "Nenhum",
-                medications: data.continuousMedication || "Nenhum",
-                medicamentos: data.continuousMedication || "Nenhum",
-                disorders: (data.disorders || []).map((d: any) => ({ name: d.name || d.label || d.value, id: d.id })),
-                serviceArea: (data.serviceTypes || []).map((s: any) => ({ id: s.id, area: s.area || s.name || s.label })),
-                serviceAreas: (data.serviceTypes || []).map((s: any) => ({ id: s.id, area: s.area || s.name || s.label })),
-                ano: parseInt(data.year),
-                year: parseInt(data.year)
-            };
-
-            let regRes;
-            if (mode === "create") {
-                regRes = await fetch(`/apae-geral/api/patients/${patientId}/registro-anual`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify(regPayload),
-                });
-            } else {
-                if (!registryId) throw new Error("ID do registro não encontrado.");
-                regRes = await fetch(`/apae-geral/api/patients/${patientId}/registro-anual/${registryId}`, {
-                    method: 'PUT',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify(regPayload),
-                });
-            }
-
-            if (!regRes.ok) {
-                const errorData = await regRes.json().catch(() => ({}));
-                const details = errorData.details || "";
-                const message = errorData.message || "";
-
-                if (regRes.status === 409 || details.includes("Conflito") || details.includes("já existe") || message.includes("já existe")) {
-                    form.setError("year", { type: "manual", message: "Este ano já possui um registro cadastrado." });
-                    throw new Error(`O ano ${data.year} já possui um registro. Escolha outro ano.`);
-                }
-                throw new Error("Erro ao salvar registro no servidor.");
-            }
-
-            if (fullPatientData) {
-                const vaccineList = (data.vaccines || []).map((v: any) => ({ name: v.name || v.label || v.value, id: v.id }));
-                const baseData = cleanPatientData(fullPatientData);
-                const patientPayload = {
-                    ...baseData,
-                    allergies: data.allergies || "Nenhuma",
-                    vaccineNames: vaccineList,
-                    continuousMedication: data.continuousMedication || "Nenhum"
-                };
-                await fetch(`/apae-geral/api/patients/${patientId}`, {
-                    method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(patientPayload)
-                });
-            }
-
-            onClose(mode === "create" ? data.year : undefined);
-            toast.success(mode === "create" ? "Registro criado com sucesso!" : "Alterações salvas!");
-        } catch (error: any) {
-            toast.error(error.message || "Erro ao salvar.");
-        }
-    };
-
-    const isCreateMode = mode === "create";
-
-    return (
-        <Dialog open={isOpen} onOpenChange={() => onClose()}>
-            <DialogContent className="!max-w-[1200px] w-[95vw] h-[85vh] flex flex-col p-0 overflow-hidden bg-slate-50 rounded-xl shadow-xl">
-                <DialogHeader className="px-6 py-4 bg-[#0D4F97] text-white shrink-0">
-                    <DialogTitle className="text-xl font-bold font-baloo">
-                        {isCreateMode ? "Novo Registro Anual" : "Edição de Saúde & Social"}
-                    </DialogTitle>
-                    <p className="text-blue-200 text-xs mt-0.5 opacity-90">
-                        {isCreateMode ? "Preencha os dados para iniciar um novo ano." : `Referência: ${currentYear}`}
-                    </p>
-                </DialogHeader>
-
-                <div className="flex-1 overflow-y-auto p-5 pb-24">
-                    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 h-full">
-                        <div className="bg-white p-5 rounded-xl shadow-sm border border-slate-200 h-fit">
-                            <h3 className="text-[#0D4F97] font-bold text-base mb-4 pb-2 border-b border-slate-100 flex items-center gap-2">
-                                <span className="bg-blue-50 p-1.5 rounded-lg text-[#0D4F97]"><FileText className="h-4 w-4" /></span>
-                                Dados Clínicos e Sociais
-                            </h3>
-                            <Form {...form}>
-                                <form id="health-form" onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-                                    
-                                    {isCreateMode && (
-                                        <FormField control={form.control} name="year" render={({ field }) => (
-                                            <FormItem>
-                                                <FormLabel className={`font-bold text-xs ${errors.year ? "text-red-500" : "text-slate-700"}`}>Ano de Referência</FormLabel>
-                                                <Select onValueChange={field.onChange} defaultValue={field.value}>
-                                                    <FormControl>
-                                                        <SelectTrigger className={`bg-slate-50 h-10 text-sm ${errors.year ? "border-red-500 ring-red-500" : "border-slate-200"}`}>
-                                                            <SelectValue placeholder="Selecione o ano" />
-                                                        </SelectTrigger>
-                                                    </FormControl>
-                                                    <SelectContent className="max-h-60">
-                                                        {availableYears.map(year => (
-                                                            <SelectItem key={year} value={year}>{year}</SelectItem>
-                                                        ))}
-                                                    </SelectContent>
-                                                </Select>
-                                                <FormMessage className="text-red-500 text-[10px]" />
-                                            </FormItem>
-                                        )} />
-                                    )}
-
-                                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                        <FormField control={form.control} name="bpc" render={({ field }) => (
-                                            <FormItem>
-                                                <FormLabel className="text-slate-700 font-bold text-xs">Recebe BPC?</FormLabel>
-                                                <Select onValueChange={field.onChange} value={field.value}>
-                                                    <FormControl><SelectTrigger className="bg-slate-50 border-slate-200 h-10 text-sm"><SelectValue placeholder="Selecione" /></SelectTrigger></FormControl>
-                                                    <SelectContent>
-                                                        <SelectItem value="true">Sim</SelectItem>
-                                                        <SelectItem value="false">Não</SelectItem>
-                                                    </SelectContent>
-                                                </Select>
-                                                <FormMessage />
-                                            </FormItem>
-                                        )} />
-
-                                        <FormField control={form.control} name="familyIncome" render={({ field }) => (
-                                            <FormItem>
-                                                <FormLabel className={`font-bold text-xs ${errors.familyIncome ? "text-red-500" : "text-slate-700"}`}>
-                                                    Renda Familiar
-                                                </FormLabel>
-                                                <FormControl>
-                                                    <Input 
-                                                        {...field}
-                                                        className={`bg-slate-50 h-10 text-sm ${errors.familyIncome ? "border-red-500 focus-visible:ring-red-500" : "border-slate-200"}`} 
-                                                        placeholder="R$ 0,00" 
-                                                        value={field.value} 
-                                                        onChange={(e) => handleMoneyChange(e, field.onChange)} 
-                                                    />
-                                                </FormControl>
-                                                <FormMessage className="text-red-500 text-[10px]" />
-                                            </FormItem>
-                                        )} />
-                                    </div>
-
-                                    <div className="space-y-3">
-                                        <FormField control={form.control} name="diseases" render={({ field }) => (
-                                            <FormItem>
-                                                <FormLabel className={`font-bold text-xs ${errors.diseases ? "text-red-500" : "text-slate-700"}`}>Doenças</FormLabel>
-                                                <FormControl>
-                                                    <div className={errors.diseases ? "border-red-500 border rounded-md" : ""}>
-                                                        <StringMultiSelect value={field.value || ""} onChange={field.onChange} placeholder="Digite doenças..." />
-                                                    </div>
-                                                </FormControl>
-                                                <FormMessage />
-                                            </FormItem>
-                                        )} />
-
-                                        <FormField control={form.control} name="allergies" render={({ field }) => (
-                                            <FormItem>
-                                                <FormLabel className={`font-bold text-xs ${errors.allergies ? "text-red-500" : "text-slate-700"}`}>Alergias</FormLabel>
-                                                <FormControl>
-                                                    <div className={errors.allergies ? "border-red-500 border rounded-md" : ""}>
-                                                        <StringMultiSelect value={field.value || ""} onChange={field.onChange} placeholder="Digite alergias..." />
-                                                    </div>
-                                                </FormControl>
-                                                <FormMessage />
-                                            </FormItem>
-                                        )} />
-
-                                        <FormField control={form.control} name="continuousMedication" render={({ field }) => (
-                                            <FormItem>
-                                                <FormLabel className={`font-bold text-xs ${errors.continuousMedication ? "text-red-500" : "text-slate-700"}`}>Medicamentos</FormLabel>
-                                                <FormControl>
-                                                    <div className={errors.continuousMedication ? "border-red-500 border rounded-md" : ""}>
-                                                        <StringMultiSelect value={field.value || ""} onChange={field.onChange} placeholder="Digite medicamentos..." />
-                                                    </div>
-                                                </FormControl>
-                                                <FormMessage />
-                                            </FormItem>
-                                        )} />
-
-                                        <FormField control={form.control} name="vaccines" render={({ field }) => (
-                                            <FormItem>
-                                                <FormLabel className={`font-bold text-xs ${errors.vaccines ? "text-red-500" : "text-slate-700"}`}>Vacinas</FormLabel>
-                                                <FormControl>
-                                                    <GenericDatabaseSelect value={field.value || []} onChange={field.onChange} endpoint="/apae-geral/api/vaccines" labelSingular="Vacina" labelKey="name" placeholder="Selecione vacinas..." />
-                                                </FormControl>
-                                                <FormMessage />
-                                            </FormItem>
-                                        )} />
-                                    </div>
-                                    <div className="pt-1 space-y-3">
-                                        <FormField control={form.control} name="disorders" render={({ field }) => (
-                                            <FormItem>
-                                                <FormLabel className={`font-bold text-xs ${errors.disorders ? "text-red-500" : "text-slate-700"} mb-1.5 block`}>Transtornos</FormLabel>
-                                                <FormControl>
-                                                    <GenericDatabaseSelect value={field.value || []} onChange={field.onChange} endpoint="/apae-geral/api/disorders" labelSingular="Transtorno" labelKey="name" placeholder="Selecione transtornos..." />
-                                                </FormControl>
-                                                <FormMessage />
-                                            </FormItem>
-                                        )} />
-                                        <FormField control={form.control} name="serviceTypes" render={({ field }) => (
-                                            <FormItem>
-                                                <FormLabel className={`font-bold text-xs ${errors.serviceTypes ? "text-red-500" : "text-slate-700"} mb-1.5 block`}>Tipos de Atendimento</FormLabel>
-                                                <FormControl>
-                                                    <GenericDatabaseSelect value={field.value || []} onChange={field.onChange} endpoint="/apae-geral/api/service-types" labelSingular="Tipo" placeholder="Selecione tipos..." labelKey="area" menuPlacement="top" />
-                                                </FormControl>
-                                                <FormMessage />
-                                            </FormItem>
-                                        )} />
-                                    </div>
-                                </form>
-                            </Form>
-                        </div>
-                        <div className="flex flex-col h-full bg-white p-5 rounded-xl shadow-sm border border-slate-200">
-                            <h3 className="text-[#0D4F97] font-bold text-base mb-4 pb-2 border-b border-slate-100 flex items-center justify-between">
-                                <div className="flex items-center gap-2"><span className="bg-green-50 p-1.5 rounded-lg text-green-700"><FileText className="h-4 w-4" /></span>Documentação Digital</div>
-                                <Button variant="ghost" size="sm" onClick={fetchDocuments} disabled={isLoadingDocs}><RefreshCw className={`h-4 w-4 ${isLoadingDocs ? 'animate-spin' : ''}`} /></Button>
-                            </h3>
-                            <div className="flex-1 flex flex-col">
-                                {isCreateMode ? (
-                                    <div className="flex flex-col items-center justify-center h-full text-center p-8 opacity-60">
-                                        <FileText className="h-12 w-12 text-slate-300 mb-3" />
-                                        <p className="text-slate-500 font-medium text-sm">Documentos poderão ser anexados após a criação do registro.</p>
-                                    </div>
-                                ) : (
-                                    <>
-                                        <div className="bg-slate-50 p-5 rounded-xl border-2 border-dashed border-slate-300 mb-6 group">
-                                            <label className="text-xs font-bold text-slate-500 uppercase mb-3 block text-center tracking-widest group-hover:text-[#0D4F97]">Adicionar Novo Documento</label>
-                                            <div className="flex flex-col gap-3 max-w-sm mx-auto w-full">
-                                                <Select value={docType} onValueChange={setDocType}>
-                                                    <SelectTrigger className="w-full bg-white border-slate-200 h-10 text-sm"><SelectValue /></SelectTrigger>
-                                                    <SelectContent>{MEDICAL_DOC_TYPES.map(t => <SelectItem key={t.value} value={t.value}>{t.label}</SelectItem>)}</SelectContent>
-                                                </Select>
-                                                <input type="file" ref={fileInputRef} onChange={handleFileUpload} className="hidden" accept=".pdf,.jpg,.png,.jpeg" disabled={isUploading} />
-                                                <Button variant="outline" className="w-full bg-white text-[#0D4F97] border-[#0D4F97]/20 hover:bg-[#0D4F97] hover:text-white h-10 transition-all text-sm" onClick={() => fileInputRef.current?.click()} disabled={isUploading}>{isUploading ? <Loader2 className="mr-2 h-4 w-4 animate-spin"/> : <Upload className="mr-2 h-4 w-4"/>} Selecionar Arquivo</Button>
-                                            </div>
-                                        </div>
-                                        <div className="flex-1 overflow-y-auto max-h-[400px] pr-2">
-                                            <h4 className="text-[10px] font-bold text-slate-400 uppercase mb-3 tracking-widest">Arquivos Anexados ({documents.length})</h4>
-                                            <div className="space-y-2">
-                                                {documents.length === 0 ? (
-                                                    <div className="flex flex-col items-center justify-center h-32 text-slate-400 border-2 border-slate-100 rounded-xl bg-slate-50/50"><FileText className="h-8 w-8 mb-2 opacity-20" /><p className="text-xs font-medium opacity-60">Nenhum documento encontrado.</p></div>
-                                                ) : (
-                                                    documents.map((doc) => (
-                                                        <div key={doc.id} className="group flex items-center justify-between p-3 bg-white border border-slate-100 rounded-xl shadow-sm hover:border-[#0D4F97]/20 transition-all duration-200">
-                                                            <div className="flex items-center gap-3 overflow-hidden">
-                                                                <div className="bg-blue-50 p-2 rounded-lg group-hover:bg-[#0D4F97] group-hover:text-white transition-colors duration-300"><FileText className="h-4 w-4" /></div>
-                                                                <div className="flex flex-col min-w-0">
-                                                                    <span className="text-sm font-semibold truncate text-slate-700 group-hover:text-[#0D4F97] transition-colors" title={doc.name}>{doc.name}</span>
-                                                                    <span className="text-[10px] text-slate-400 font-bold uppercase tracking-wide mt-0.5">{docTypeTranslations[doc.type] || doc.type}</span>
-                                                                </div>
-                                                            </div>
-                                                            {doc.url && (<a href={doc.url} target="_blank" rel="noreferrer" className="p-2 text-slate-400 hover:text-[#0D4F97] hover:bg-blue-50 rounded-full transition-all"><ExternalLink className="h-4 w-4" /></a>)}
-                                                        </div>
-                                                    ))
-                                                )}
-                                            </div>
-                                        </div>
-                                    </>
-                                )}
-                            </div>
-                        </div>
-                    </div>
+            <div className="flex flex-col h-full bg-white p-5 rounded-xl shadow-sm border border-slate-200">
+              <h3 className="text-[#0D4F97] font-bold text-base mb-4 pb-2 border-b border-slate-100 flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <span className="bg-green-50 p-1.5 rounded-lg text-green-700"><FileText className="h-4 w-4" /></span>
+                  Documentação Digital
                 </div>
-                <DialogFooter className="px-6 py-4 bg-white border-t border-slate-100 shrink-0 flex justify-end gap-3 z-10">
-                    <Button variant="ghost" onClick={() => onClose()} type="button" className="text-slate-500 h-10 px-5 text-sm">Cancelar</Button>
-                    <Button
-                        form="health-form"
-                        type="submit"
-                        disabled={isSubmitting}
-                        className="text-white bg-[#0D4F97] hover:bg-[#0b427d] h-10 px-6 rounded-lg font-bold transition-all text-sm disabled:opacity-70"
-                    >
-                        {isSubmitting ? <><Loader2 className="mr-2 h-4 w-4 animate-spin" /> Salvando...</> : (isCreateMode ? "Criar Registro" : "Salvar Alterações")}
-                    </Button>
-                </DialogFooter>
-            </DialogContent>
-        </Dialog>
-    );
+                <Button variant="ghost" size="sm" onClick={loadDocuments} disabled={isLoadingDocs}>
+                  <RefreshCw className={`h-4 w-4 ${isLoadingDocs ? "animate-spin" : ""}`} />
+                </Button>
+              </h3>
+
+              <div className="flex-1 flex flex-col">
+                {isCreateMode ? (
+                  <div className="flex flex-col items-center justify-center h-full text-center p-8 opacity-60">
+                    <FileText className="h-12 w-12 text-slate-300 mb-3" />
+                    <p className="text-slate-500 font-medium text-sm">Documentos poderão ser anexados após a criação do registro.</p>
+                  </div>
+                ) : (
+                  <>
+                    <div className="bg-slate-50 p-5 rounded-xl border-2 border-dashed border-slate-300 mb-6 group">
+                      <label className="text-xs font-bold text-slate-500 uppercase mb-3 block text-center tracking-widest group-hover:text-[#0D4F97]">Adicionar Novo Documento</label>
+                      <div className="flex flex-col gap-3 max-w-sm mx-auto w-full">
+                        <Select value={docType} onValueChange={setDocType}>
+                          <SelectTrigger className="w-full bg-white border-slate-200 h-10 text-sm"><SelectValue /></SelectTrigger>
+                          <SelectContent>
+                            {MEDICAL_DOC_TYPES.map((t) => <SelectItem key={t.value} value={t.value}>{t.label}</SelectItem>)}
+                          </SelectContent>
+                        </Select>
+                        <input type="file" ref={fileInputRef} onChange={handleFileUpload} className="hidden" accept=".pdf,.jpg,.png,.jpeg" disabled={isUploading} />
+                        <Button variant="outline" className="w-full bg-white text-[#0D4F97] border-[#0D4F97]/20 hover:bg-[#0D4F97] hover:text-white h-10 transition-all text-sm" onClick={() => fileInputRef.current?.click()} disabled={isUploading}>
+                          {isUploading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Upload className="mr-2 h-4 w-4" />}
+                          Selecionar Arquivo
+                        </Button>
+                      </div>
+                    </div>
+
+                    <div className="flex-1 overflow-y-auto max-h-[400px] pr-2">
+                      <h4 className="text-[10px] font-bold text-slate-400 uppercase mb-3 tracking-widest">Arquivos Anexados ({documents.length})</h4>
+                      <div className="space-y-2">
+                        {documents.length === 0 ? (
+                          <div className="flex flex-col items-center justify-center h-32 text-slate-400 border-2 border-slate-100 rounded-xl bg-slate-50/50">
+                            <FileText className="h-8 w-8 mb-2 opacity-20" />
+                            <p className="text-xs font-medium opacity-60">Nenhum documento encontrado.</p>
+                          </div>
+                        ) : (
+                          documents.map((doc) => (
+                            <div key={doc.id} className="group flex items-center justify-between p-3 bg-white border border-slate-100 rounded-xl shadow-sm hover:border-[#0D4F97]/20 transition-all duration-200">
+                              <div className="flex items-center gap-3 overflow-hidden">
+                                <div className="bg-blue-50 p-2 rounded-lg group-hover:bg-[#0D4F97] group-hover:text-white transition-colors duration-300">
+                                  <FileText className="h-4 w-4" />
+                                </div>
+                                <div className="flex flex-col min-w-0">
+                                  <span className="text-sm font-semibold truncate text-slate-700 group-hover:text-[#0D4F97] transition-colors" title={doc.name}>{doc.name}</span>
+                                  <span className="text-[10px] text-slate-400 font-bold uppercase tracking-wide mt-0.5">{DOC_TYPE_TRANSLATIONS[doc.type] || doc.type}</span>
+                                </div>
+                              </div>
+                              {doc.url && (
+                                <a href={doc.url} target="_blank" rel="noreferrer" className="p-2 text-slate-400 hover:text-[#0D4F97] hover:bg-blue-50 rounded-full transition-all">
+                                  <ExternalLink className="h-4 w-4" />
+                                </a>
+                              )}
+                            </div>
+                          ))
+                        )}
+                      </div>
+                    </div>
+                  </>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter className="px-6 py-4 bg-white border-t border-slate-100 shrink-0 flex justify-end gap-3 z-10">
+          <Button variant="ghost" onClick={() => onClose()} type="button" className="text-slate-500 h-10 px-5 text-sm">Cancelar</Button>
+          <Button form="health-form" type="submit" disabled={isSubmitting} className="text-white bg-[#0D4F97] hover:bg-[#0b427d] h-10 px-6 rounded-lg font-bold transition-all text-sm disabled:opacity-70">
+            {isSubmitting ? <><Loader2 className="mr-2 h-4 w-4 animate-spin" /> Salvando...</> : (isCreateMode ? "Criar Registro" : "Salvar Alterações")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
 }

--- a/apps/apae/src/domains/patients/annual-registry/annual-registry-edit-modal.tsx
+++ b/apps/apae/src/domains/patients/annual-registry/annual-registry-edit-modal.tsx
@@ -1,0 +1,543 @@
+"use client";
+
+import { useEffect, useState, useRef } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { AnnualRegistryFormSchema, AnnualRegistryFormValues } from "@/schemas/anualRegistrySchema";
+import { toast } from "react-toastify";
+import { Loader2, Upload, FileText, RefreshCw, ExternalLink } from "lucide-react";
+
+import { StringMultiSelect } from "@/components/StringMultiSelect";
+import { GenericDatabaseSelect } from "@/components/GenericDatabaseSelect";
+
+interface DocumentDTO {
+    id: string;
+    name: string;
+    category: string;
+    type: string;
+    url: string;
+}
+
+interface AnnualRegistryEditModalProps {
+    isOpen: boolean;
+    onClose: (str?: string) => void;
+    patientId: string;
+    currentYear: string;
+    initialData: AnnualRegistry | null;
+    mode?: "create" | "edit";
+}
+
+interface DisorderItem {
+    id?: string | number;
+    name?: string;
+    label?: string;
+    value?: string;
+}
+
+interface ServiceAreaItem {
+    id?: string | number;
+    area?: string;
+    name?: string;
+    label?: string;
+    value?: string;
+}
+
+interface AnnualRegistry {
+    id?: string;
+    bpc: boolean | string;
+    familyIncome: number | string;
+    diseases: string;
+    continuousMedication: string;
+    medications?: string;
+    medicamentos?: string;
+    medication?: string;
+    disorders?: DisorderItem[];
+    serviceAreas?: ServiceAreaItem[];
+    serviceArea?: ServiceAreaItem[];
+    serviceTypes?: ServiceAreaItem[];
+}
+
+interface FullPatientData {
+    vaccineNames?: { name: string }[] | string[];
+    allergies?: string;
+    additionals?: {
+        medications?: string;
+        diseases?: string;
+        [key: string]: any;
+    };
+    address?: Record<string, string | null | undefined>;
+    guardian?: Record<string, string | Record<string, string> | null | undefined>;
+    parents?: Array<Record<string, string | boolean>>;
+    nationality?: string;
+    birthplace?: string;
+    [key: string]: unknown;
+}
+
+const MEDICAL_DOC_TYPES = [
+    { value: "MEDICAL_REPORT", label: "Laudo Médico" },
+    { value: "EXAMINATION", label: "Exame" },
+    { value: "REFERRAL", label: "Encaminhamento" },
+    { value: "OTHER", label: "Outro" }
+];
+
+const docTypeTranslations: Record<string, string> = {
+    MEDICAL_REPORT: "Laudo Médico",
+    EXAMINATION: "Exame",
+    REFERRAL: "Encaminhamento",
+    OTHER: "Outro",
+    VACCINE_CARD: "Cartão de Vacina"
+};
+
+export default function AnnualRegistryEditModal({
+    isOpen,
+    onClose,
+    patientId,
+    currentYear,
+    initialData,
+    mode = "edit"
+}: AnnualRegistryEditModalProps) {
+
+    const [documents, setDocuments] = useState<DocumentDTO[]>([]);
+    const [isLoadingDocs, setIsLoadingDocs] = useState(false);
+    const [isUploading, setIsUploading] = useState(false);
+    const [docType, setDocType] = useState("MEDICAL_REPORT");
+
+    const [fullPatientData, setFullPatientData] = useState<FullPatientData | null>(null);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const currentYearInt = new Date().getFullYear();
+    const availableYears = Array.from({ length: 32 }, (_, i) => (currentYearInt + 1 - i).toString());
+
+    const form = useForm<AnnualRegistryFormValues>({
+        resolver: zodResolver(AnnualRegistryFormSchema),
+        mode: "onChange",
+        defaultValues: {
+            year: currentYear || currentYearInt.toString(),
+            bpc: "false",
+            familyIncome: "",
+            diseases: "",
+            continuousMedication: "",
+            disorders: [],
+            allergies: "",
+            vaccines: [],
+            serviceTypes: []
+        },
+    });
+
+    const { isSubmitting, errors } = form.formState;
+
+    useEffect(() => {
+        if (isOpen && patientId) {
+            if (mode === "edit") fetchDocuments();
+            else setDocuments([]);
+            fetchPatientData();
+        }
+    }, [isOpen, patientId, mode]);
+
+    useEffect(() => {
+        if (isOpen) {
+            if (mode === "edit" && initialData) {
+                const rawBpc = initialData.bpc;
+                const bpcString = (rawBpc === true || String(rawBpc) === "true") ? "true" : "false";
+
+                const vaccineList = Array.isArray(fullPatientData?.vaccineNames)
+                    ? fullPatientData.vaccineNames.map((v: any) => (typeof v === 'string' ? { name: v } : v))
+                    : [];
+
+                const sourceServiceAreas = initialData.serviceArea || initialData.serviceAreas || initialData.serviceTypes || [];
+                const serviceTypeList = Array.isArray(sourceServiceAreas) ? sourceServiceAreas.map((s: any) => ({
+                    id: s.id,
+                    area: s.area || s.name,
+                    name: s.name || s.area
+                })) : [];
+
+                const medicationValue = initialData.continuousMedication || 
+                                        initialData.medications || 
+                                        initialData.medicamentos || 
+                                        (initialData as any).medication || "";
+
+                form.reset({
+                    year: currentYear,
+                    bpc: bpcString,
+                    familyIncome: initialData.familyIncome ? formatCurrencyForDisplay(initialData.familyIncome) : "",
+                    diseases: initialData.diseases ?? "",
+                    continuousMedication: medicationValue,
+                    allergies: fullPatientData?.allergies ?? "",
+                    disorders: initialData.disorders || [],
+                    vaccines: vaccineList,
+                    serviceTypes: serviceTypeList
+                });
+
+            } else if (mode === "create") {
+                const vaccineList = Array.isArray(fullPatientData?.vaccineNames)
+                    ? fullPatientData.vaccineNames.map((v: any) => (typeof v === 'string' ? { name: v } : v))
+                    : [];
+                
+                const existingMedication = fullPatientData?.additionals?.medications || 
+                                          (fullPatientData as any)?.medications || 
+                                          (fullPatientData as any)?.continuousMedication || "";
+
+                const existingDiseases = fullPatientData?.additionals?.diseases || 
+                                         (fullPatientData as any)?.diseases || "";
+
+                form.reset({
+                    year: currentYearInt.toString(),
+                    bpc: "false",
+                    familyIncome: "",
+                    diseases: existingDiseases,
+                    continuousMedication: existingMedication,
+                    allergies: fullPatientData?.allergies ?? "",
+                    disorders: [],
+                    vaccines: vaccineList,
+                    serviceTypes: []
+                });
+            }
+        }
+    }, [initialData, fullPatientData, isOpen, form, mode, currentYear]);
+
+    const fetchDocuments = async () => {
+        setIsLoadingDocs(true);
+        try {
+            const response = await fetch(`/apae-geral/api/patients/${patientId}/documents?category=MEDICAL&year=${currentYear}`);
+            if (response.ok) {
+                const data = await response.json().catch(() => []);
+                setDocuments(Array.isArray(data) ? data : []);
+            }
+        } catch (error) { console.error(error); }
+        finally { setIsLoadingDocs(false); }
+    };
+
+    const fetchPatientData = async () => {
+        try {
+            const response = await fetch(`/apae-geral/api/patients/${patientId}`);
+            if (response.ok) setFullPatientData(await response.json());
+        } catch (error) { console.error(error); }
+    };
+
+    const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (!file) return;
+        setIsUploading(true);
+        const formData = new FormData();
+        formData.append("file", file);
+        formData.append("category", "MEDICAL");
+        formData.append("type", docType);
+        formData.append("year", currentYear);
+        try {
+            const res = await fetch(`/apae-geral/api/patients/${patientId}/documents`, {
+                method: "POST",
+                body: formData,
+            });
+            if (!res.ok) throw new Error();
+            toast.success("Documento anexado!");
+            fetchDocuments();
+            if (fileInputRef.current) fileInputRef.current.value = "";
+        } catch { toast.error("Erro ao enviar documento."); }
+        finally { setIsUploading(false); }
+    };
+
+    const cleanCurrency = (value: string) => (!value ? "0.00" : value.replace(/[^\d,]/g, '').replace(',', '.'));
+    const formatCurrencyForDisplay = (value: number | string) => (!value ? "" : Number(value).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' }));
+
+    const handleMoneyChange = (e: React.ChangeEvent<HTMLInputElement>, onChange: (value: string) => void) => {
+        const value = e.target.value.replace(/\D/g, "");
+        if (value === "") { onChange(""); return; }
+        onChange((parseFloat(value) / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" }));
+    };
+
+    const cleanPatientData = (data: any) => {
+        if (!data) return {};
+        const { documents, annualRegistry, createdAt, updatedAt, deleted, isDeleted, age, ...rest } = data;
+        return rest;
+    };
+
+    const onSubmit = async (data: AnnualRegistryFormValues) => {
+        toast.dismiss();
+        try {
+            const registryId = initialData?.id;
+            const income = parseFloat(cleanCurrency(data.familyIncome));
+            const bpcToSend = data.bpc === "true";
+
+            const regPayload: any = {
+                bpc: bpcToSend,
+                familyIncome: income,
+                diseases: data.diseases || "Nenhuma",
+                continuousMedication: data.continuousMedication || "Nenhum",
+                medications: data.continuousMedication || "Nenhum",
+                medicamentos: data.continuousMedication || "Nenhum",
+                disorders: (data.disorders || []).map((d: any) => ({ name: d.name || d.label || d.value, id: d.id })),
+                serviceArea: (data.serviceTypes || []).map((s: any) => ({ id: s.id, area: s.area || s.name || s.label })),
+                serviceAreas: (data.serviceTypes || []).map((s: any) => ({ id: s.id, area: s.area || s.name || s.label })),
+                ano: parseInt(data.year),
+                year: parseInt(data.year)
+            };
+
+            let regRes;
+            if (mode === "create") {
+                regRes = await fetch(`/apae-geral/api/patients/${patientId}/registro-anual`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(regPayload),
+                });
+            } else {
+                if (!registryId) throw new Error("ID do registro não encontrado.");
+                regRes = await fetch(`/apae-geral/api/patients/${patientId}/registro-anual/${registryId}`, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(regPayload),
+                });
+            }
+
+            if (!regRes.ok) {
+                const errorData = await regRes.json().catch(() => ({}));
+                const details = errorData.details || "";
+                const message = errorData.message || "";
+
+                if (regRes.status === 409 || details.includes("Conflito") || details.includes("já existe") || message.includes("já existe")) {
+                    form.setError("year", { type: "manual", message: "Este ano já possui um registro cadastrado." });
+                    throw new Error(`O ano ${data.year} já possui um registro. Escolha outro ano.`);
+                }
+                throw new Error("Erro ao salvar registro no servidor.");
+            }
+
+            if (fullPatientData) {
+                const vaccineList = (data.vaccines || []).map((v: any) => ({ name: v.name || v.label || v.value, id: v.id }));
+                const baseData = cleanPatientData(fullPatientData);
+                const patientPayload = {
+                    ...baseData,
+                    allergies: data.allergies || "Nenhuma",
+                    vaccineNames: vaccineList,
+                    continuousMedication: data.continuousMedication || "Nenhum"
+                };
+                await fetch(`/apae-geral/api/patients/${patientId}`, {
+                    method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(patientPayload)
+                });
+            }
+
+            onClose(mode === "create" ? data.year : undefined);
+            toast.success(mode === "create" ? "Registro criado com sucesso!" : "Alterações salvas!");
+        } catch (error: any) {
+            toast.error(error.message || "Erro ao salvar.");
+        }
+    };
+
+    const isCreateMode = mode === "create";
+
+    return (
+        <Dialog open={isOpen} onOpenChange={() => onClose()}>
+            <DialogContent className="!max-w-[1200px] w-[95vw] h-[85vh] flex flex-col p-0 overflow-hidden bg-slate-50 rounded-xl shadow-xl">
+                <DialogHeader className="px-6 py-4 bg-[#0D4F97] text-white shrink-0">
+                    <DialogTitle className="text-xl font-bold font-baloo">
+                        {isCreateMode ? "Novo Registro Anual" : "Edição de Saúde & Social"}
+                    </DialogTitle>
+                    <p className="text-blue-200 text-xs mt-0.5 opacity-90">
+                        {isCreateMode ? "Preencha os dados para iniciar um novo ano." : `Referência: ${currentYear}`}
+                    </p>
+                </DialogHeader>
+
+                <div className="flex-1 overflow-y-auto p-5 pb-24">
+                    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 h-full">
+                        <div className="bg-white p-5 rounded-xl shadow-sm border border-slate-200 h-fit">
+                            <h3 className="text-[#0D4F97] font-bold text-base mb-4 pb-2 border-b border-slate-100 flex items-center gap-2">
+                                <span className="bg-blue-50 p-1.5 rounded-lg text-[#0D4F97]"><FileText className="h-4 w-4" /></span>
+                                Dados Clínicos e Sociais
+                            </h3>
+                            <Form {...form}>
+                                <form id="health-form" onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+                                    
+                                    {isCreateMode && (
+                                        <FormField control={form.control} name="year" render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel className={`font-bold text-xs ${errors.year ? "text-red-500" : "text-slate-700"}`}>Ano de Referência</FormLabel>
+                                                <Select onValueChange={field.onChange} defaultValue={field.value}>
+                                                    <FormControl>
+                                                        <SelectTrigger className={`bg-slate-50 h-10 text-sm ${errors.year ? "border-red-500 ring-red-500" : "border-slate-200"}`}>
+                                                            <SelectValue placeholder="Selecione o ano" />
+                                                        </SelectTrigger>
+                                                    </FormControl>
+                                                    <SelectContent className="max-h-60">
+                                                        {availableYears.map(year => (
+                                                            <SelectItem key={year} value={year}>{year}</SelectItem>
+                                                        ))}
+                                                    </SelectContent>
+                                                </Select>
+                                                <FormMessage className="text-red-500 text-[10px]" />
+                                            </FormItem>
+                                        )} />
+                                    )}
+
+                                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                        <FormField control={form.control} name="bpc" render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel className="text-slate-700 font-bold text-xs">Recebe BPC?</FormLabel>
+                                                <Select onValueChange={field.onChange} value={field.value}>
+                                                    <FormControl><SelectTrigger className="bg-slate-50 border-slate-200 h-10 text-sm"><SelectValue placeholder="Selecione" /></SelectTrigger></FormControl>
+                                                    <SelectContent>
+                                                        <SelectItem value="true">Sim</SelectItem>
+                                                        <SelectItem value="false">Não</SelectItem>
+                                                    </SelectContent>
+                                                </Select>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )} />
+
+                                        <FormField control={form.control} name="familyIncome" render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel className={`font-bold text-xs ${errors.familyIncome ? "text-red-500" : "text-slate-700"}`}>
+                                                    Renda Familiar
+                                                </FormLabel>
+                                                <FormControl>
+                                                    <Input 
+                                                        {...field}
+                                                        className={`bg-slate-50 h-10 text-sm ${errors.familyIncome ? "border-red-500 focus-visible:ring-red-500" : "border-slate-200"}`} 
+                                                        placeholder="R$ 0,00" 
+                                                        value={field.value} 
+                                                        onChange={(e) => handleMoneyChange(e, field.onChange)} 
+                                                    />
+                                                </FormControl>
+                                                <FormMessage className="text-red-500 text-[10px]" />
+                                            </FormItem>
+                                        )} />
+                                    </div>
+
+                                    <div className="space-y-3">
+                                        <FormField control={form.control} name="diseases" render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel className={`font-bold text-xs ${errors.diseases ? "text-red-500" : "text-slate-700"}`}>Doenças</FormLabel>
+                                                <FormControl>
+                                                    <div className={errors.diseases ? "border-red-500 border rounded-md" : ""}>
+                                                        <StringMultiSelect value={field.value || ""} onChange={field.onChange} placeholder="Digite doenças..." />
+                                                    </div>
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )} />
+
+                                        <FormField control={form.control} name="allergies" render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel className={`font-bold text-xs ${errors.allergies ? "text-red-500" : "text-slate-700"}`}>Alergias</FormLabel>
+                                                <FormControl>
+                                                    <div className={errors.allergies ? "border-red-500 border rounded-md" : ""}>
+                                                        <StringMultiSelect value={field.value || ""} onChange={field.onChange} placeholder="Digite alergias..." />
+                                                    </div>
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )} />
+
+                                        <FormField control={form.control} name="continuousMedication" render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel className={`font-bold text-xs ${errors.continuousMedication ? "text-red-500" : "text-slate-700"}`}>Medicamentos</FormLabel>
+                                                <FormControl>
+                                                    <div className={errors.continuousMedication ? "border-red-500 border rounded-md" : ""}>
+                                                        <StringMultiSelect value={field.value || ""} onChange={field.onChange} placeholder="Digite medicamentos..." />
+                                                    </div>
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )} />
+
+                                        <FormField control={form.control} name="vaccines" render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel className={`font-bold text-xs ${errors.vaccines ? "text-red-500" : "text-slate-700"}`}>Vacinas</FormLabel>
+                                                <FormControl>
+                                                    <GenericDatabaseSelect value={field.value || []} onChange={field.onChange} endpoint="/apae-geral/api/vaccines" labelSingular="Vacina" labelKey="name" placeholder="Selecione vacinas..." />
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )} />
+                                    </div>
+                                    <div className="pt-1 space-y-3">
+                                        <FormField control={form.control} name="disorders" render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel className={`font-bold text-xs ${errors.disorders ? "text-red-500" : "text-slate-700"} mb-1.5 block`}>Transtornos</FormLabel>
+                                                <FormControl>
+                                                    <GenericDatabaseSelect value={field.value || []} onChange={field.onChange} endpoint="/apae-geral/api/disorders" labelSingular="Transtorno" labelKey="name" placeholder="Selecione transtornos..." />
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )} />
+                                        <FormField control={form.control} name="serviceTypes" render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel className={`font-bold text-xs ${errors.serviceTypes ? "text-red-500" : "text-slate-700"} mb-1.5 block`}>Tipos de Atendimento</FormLabel>
+                                                <FormControl>
+                                                    <GenericDatabaseSelect value={field.value || []} onChange={field.onChange} endpoint="/apae-geral/api/service-types" labelSingular="Tipo" placeholder="Selecione tipos..." labelKey="area" menuPlacement="top" />
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )} />
+                                    </div>
+                                </form>
+                            </Form>
+                        </div>
+                        <div className="flex flex-col h-full bg-white p-5 rounded-xl shadow-sm border border-slate-200">
+                            <h3 className="text-[#0D4F97] font-bold text-base mb-4 pb-2 border-b border-slate-100 flex items-center justify-between">
+                                <div className="flex items-center gap-2"><span className="bg-green-50 p-1.5 rounded-lg text-green-700"><FileText className="h-4 w-4" /></span>Documentação Digital</div>
+                                <Button variant="ghost" size="sm" onClick={fetchDocuments} disabled={isLoadingDocs}><RefreshCw className={`h-4 w-4 ${isLoadingDocs ? 'animate-spin' : ''}`} /></Button>
+                            </h3>
+                            <div className="flex-1 flex flex-col">
+                                {isCreateMode ? (
+                                    <div className="flex flex-col items-center justify-center h-full text-center p-8 opacity-60">
+                                        <FileText className="h-12 w-12 text-slate-300 mb-3" />
+                                        <p className="text-slate-500 font-medium text-sm">Documentos poderão ser anexados após a criação do registro.</p>
+                                    </div>
+                                ) : (
+                                    <>
+                                        <div className="bg-slate-50 p-5 rounded-xl border-2 border-dashed border-slate-300 mb-6 group">
+                                            <label className="text-xs font-bold text-slate-500 uppercase mb-3 block text-center tracking-widest group-hover:text-[#0D4F97]">Adicionar Novo Documento</label>
+                                            <div className="flex flex-col gap-3 max-w-sm mx-auto w-full">
+                                                <Select value={docType} onValueChange={setDocType}>
+                                                    <SelectTrigger className="w-full bg-white border-slate-200 h-10 text-sm"><SelectValue /></SelectTrigger>
+                                                    <SelectContent>{MEDICAL_DOC_TYPES.map(t => <SelectItem key={t.value} value={t.value}>{t.label}</SelectItem>)}</SelectContent>
+                                                </Select>
+                                                <input type="file" ref={fileInputRef} onChange={handleFileUpload} className="hidden" accept=".pdf,.jpg,.png,.jpeg" disabled={isUploading} />
+                                                <Button variant="outline" className="w-full bg-white text-[#0D4F97] border-[#0D4F97]/20 hover:bg-[#0D4F97] hover:text-white h-10 transition-all text-sm" onClick={() => fileInputRef.current?.click()} disabled={isUploading}>{isUploading ? <Loader2 className="mr-2 h-4 w-4 animate-spin"/> : <Upload className="mr-2 h-4 w-4"/>} Selecionar Arquivo</Button>
+                                            </div>
+                                        </div>
+                                        <div className="flex-1 overflow-y-auto max-h-[400px] pr-2">
+                                            <h4 className="text-[10px] font-bold text-slate-400 uppercase mb-3 tracking-widest">Arquivos Anexados ({documents.length})</h4>
+                                            <div className="space-y-2">
+                                                {documents.length === 0 ? (
+                                                    <div className="flex flex-col items-center justify-center h-32 text-slate-400 border-2 border-slate-100 rounded-xl bg-slate-50/50"><FileText className="h-8 w-8 mb-2 opacity-20" /><p className="text-xs font-medium opacity-60">Nenhum documento encontrado.</p></div>
+                                                ) : (
+                                                    documents.map((doc) => (
+                                                        <div key={doc.id} className="group flex items-center justify-between p-3 bg-white border border-slate-100 rounded-xl shadow-sm hover:border-[#0D4F97]/20 transition-all duration-200">
+                                                            <div className="flex items-center gap-3 overflow-hidden">
+                                                                <div className="bg-blue-50 p-2 rounded-lg group-hover:bg-[#0D4F97] group-hover:text-white transition-colors duration-300"><FileText className="h-4 w-4" /></div>
+                                                                <div className="flex flex-col min-w-0">
+                                                                    <span className="text-sm font-semibold truncate text-slate-700 group-hover:text-[#0D4F97] transition-colors" title={doc.name}>{doc.name}</span>
+                                                                    <span className="text-[10px] text-slate-400 font-bold uppercase tracking-wide mt-0.5">{docTypeTranslations[doc.type] || doc.type}</span>
+                                                                </div>
+                                                            </div>
+                                                            {doc.url && (<a href={doc.url} target="_blank" rel="noreferrer" className="p-2 text-slate-400 hover:text-[#0D4F97] hover:bg-blue-50 rounded-full transition-all"><ExternalLink className="h-4 w-4" /></a>)}
+                                                        </div>
+                                                    ))
+                                                )}
+                                            </div>
+                                        </div>
+                                    </>
+                                )}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <DialogFooter className="px-6 py-4 bg-white border-t border-slate-100 shrink-0 flex justify-end gap-3 z-10">
+                    <Button variant="ghost" onClick={() => onClose()} type="button" className="text-slate-500 h-10 px-5 text-sm">Cancelar</Button>
+                    <Button
+                        form="health-form"
+                        type="submit"
+                        disabled={isSubmitting}
+                        className="text-white bg-[#0D4F97] hover:bg-[#0b427d] h-10 px-6 rounded-lg font-bold transition-all text-sm disabled:opacity-70"
+                    >
+                        {isSubmitting ? <><Loader2 className="mr-2 h-4 w-4 animate-spin" /> Salvando...</> : (isCreateMode ? "Criar Registro" : "Salvar Alterações")}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/apps/apae/src/domains/patients/annual-registry/annual-registry.api.ts
+++ b/apps/apae/src/domains/patients/annual-registry/annual-registry.api.ts
@@ -1,0 +1,48 @@
+import type { DocumentDTO, FullPatientData } from "./annual-registry.types";
+
+const BASE_URL = "/apae-geral/api/patients";
+
+export async function fetchDocumentsApi(patientId: string, year: string): Promise<DocumentDTO[]> {
+  const response = await fetch(`${BASE_URL}/${patientId}/documents?category=MEDICAL&year=${year}`);
+  if (!response.ok) return [];
+  const data = await response.json().catch(() => []);
+  return Array.isArray(data) ? data : [];
+}
+
+export async function fetchPatientApi(patientId: string): Promise<FullPatientData | null> {
+  const response = await fetch(`${BASE_URL}/${patientId}`);
+  if (!response.ok) return null;
+  return response.json();
+}
+
+export async function uploadDocumentApi(patientId: string, formData: FormData): Promise<void> {
+  const response = await fetch(`${BASE_URL}/${patientId}/documents`, {
+    method: "POST",
+    body: formData,
+  });
+  if (!response.ok) throw new Error("Erro ao enviar documento.");
+}
+
+export async function createAnnualRegistryApi(patientId: string, payload: unknown): Promise<Response> {
+  return fetch(`${BASE_URL}/${patientId}/registro-anual`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function updateAnnualRegistryApi(patientId: string, registryId: string, payload: unknown): Promise<Response> {
+  return fetch(`${BASE_URL}/${patientId}/registro-anual/${registryId}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function updatePatientApi(patientId: string, payload: unknown): Promise<void> {
+  await fetch(`${BASE_URL}/${patientId}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+}

--- a/apps/apae/src/domains/patients/annual-registry/annual-registry.schema.ts
+++ b/apps/apae/src/domains/patients/annual-registry/annual-registry.schema.ts
@@ -1,0 +1,18 @@
+import * as z from "zod";
+
+export const annualRegistryFormSchema = z.object({
+  year: z.string().min(4, "Ano inválido"),
+  bpc: z.enum(["true", "false"]),
+  familyIncome: z.string().min(1, "A renda é obrigatória").refine((val) => {
+    const num = parseFloat(val.replace(/[^\d]/g, ""));
+    return num >= 20000;
+  }, "Mínimo R$ 200,00"),
+  diseases: z.string().min(1, "Informe as doenças ou 'Nenhuma'"),
+  continuousMedication: z.string().min(1, "Informe os medicamentos ou 'Nenhum'"),
+  allergies: z.string().min(1, "Informe as alergias ou 'Nenhuma'"),
+  vaccines: z.array(z.any()).min(1, "Selecione ao menos uma vacina"),
+  disorders: z.array(z.any()).min(1, "Selecione ao menos um transtorno"),
+  serviceTypes: z.array(z.any()).min(1, "Selecione ao menos um atendimento"),
+});
+
+export type AnnualRegistryFormValues = z.infer<typeof annualRegistryFormSchema>;

--- a/apps/apae/src/domains/patients/annual-registry/annual-registry.types.ts
+++ b/apps/apae/src/domains/patients/annual-registry/annual-registry.types.ts
@@ -1,0 +1,68 @@
+export interface DocumentDTO {
+  id: string;
+  name: string;
+  category: string;
+  type: string;
+  url: string;
+}
+
+export interface DisorderItem {
+  id?: string | number;
+  name?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface ServiceAreaItem {
+  id?: string | number;
+  area?: string;
+  name?: string;
+  label?: string;
+  value?: string;
+}
+
+export interface AnnualRegistry {
+  id?: string;
+  bpc: boolean | string;
+  familyIncome: number | string;
+  diseases: string;
+  continuousMedication: string;
+  medications?: string;
+  medicamentos?: string;
+  medication?: string;
+  disorders?: DisorderItem[];
+  serviceAreas?: ServiceAreaItem[];
+  serviceArea?: ServiceAreaItem[];
+  serviceTypes?: ServiceAreaItem[];
+}
+
+export interface FullPatientData {
+  vaccineNames?: { name: string }[] | string[];
+  allergies?: string;
+  additionals?: {
+    medications?: string;
+    diseases?: string;
+    [key: string]: unknown;
+  };
+  address?: Record<string, string | null | undefined>;
+  guardian?: Record<string, string | Record<string, string> | null | undefined>;
+  parents?: Array<Record<string, string | boolean>>;
+  nationality?: string;
+  birthplace?: string;
+  [key: string]: unknown;
+}
+
+export const MEDICAL_DOC_TYPES = [
+  { value: "MEDICAL_REPORT", label: "Laudo Médico" },
+  { value: "EXAMINATION", label: "Exame" },
+  { value: "REFERRAL", label: "Encaminhamento" },
+  { value: "OTHER", label: "Outro" },
+] as const;
+
+export const DOC_TYPE_TRANSLATIONS: Record<string, string> = {
+  MEDICAL_REPORT: "Laudo Médico",
+  EXAMINATION: "Exame",
+  REFERRAL: "Encaminhamento",
+  OTHER: "Outro",
+  VACCINE_CARD: "Cartão de Vacina",
+};

--- a/apps/apae/src/domains/patients/annual-registry/use-annual-registry-modal.ts
+++ b/apps/apae/src/domains/patients/annual-registry/use-annual-registry-modal.ts
@@ -1,0 +1,267 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { toast } from "react-toastify";
+import { annualRegistryFormSchema, type AnnualRegistryFormValues } from "./annual-registry.schema";
+import {
+  fetchDocumentsApi,
+  fetchPatientApi,
+  uploadDocumentApi,
+  createAnnualRegistryApi,
+  updateAnnualRegistryApi,
+  updatePatientApi,
+} from "./annual-registry.api";
+import type { DocumentDTO, FullPatientData, AnnualRegistry, ServiceAreaItem } from "./annual-registry.types";
+
+interface UseAnnualRegistryModalParams {
+  isOpen: boolean;
+  patientId: string;
+  currentYear: string;
+  initialData: AnnualRegistry | null;
+  mode: "create" | "edit";
+  onClose: (savedYear?: string) => void;
+}
+
+const currentYearInt = new Date().getFullYear();
+export const availableYears = Array.from({ length: 32 }, (_, i) =>
+  (currentYearInt + 1 - i).toString(),
+);
+
+function formatCurrencyForDisplay(value: number | string) {
+  if (!value) return "";
+  return Number(value).toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
+}
+
+function cleanCurrency(value: string) {
+  if (!value) return "0.00";
+  return value.replace(/[^\d,]/g, "").replace(",", ".");
+}
+
+function cleanPatientData(data: Record<string, unknown>) {
+  if (!data) return {};
+  const { documents, annualRegistry, createdAt, updatedAt, deleted, isDeleted, age, ...rest } = data;
+  return rest;
+}
+
+export function useAnnualRegistryModal({
+  isOpen,
+  patientId,
+  currentYear,
+  initialData,
+  mode,
+  onClose,
+}: UseAnnualRegistryModalParams) {
+  const [documents, setDocuments] = useState<DocumentDTO[]>([]);
+  const [isLoadingDocs, setIsLoadingDocs] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
+  const [docType, setDocType] = useState("MEDICAL_REPORT");
+  const [fullPatientData, setFullPatientData] = useState<FullPatientData | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const form = useForm<AnnualRegistryFormValues>({
+    resolver: zodResolver(annualRegistryFormSchema),
+    mode: "onChange",
+    defaultValues: {
+      year: currentYear || currentYearInt.toString(),
+      bpc: "false",
+      familyIncome: "",
+      diseases: "",
+      continuousMedication: "",
+      disorders: [],
+      allergies: "",
+      vaccines: [],
+      serviceTypes: [],
+    },
+  });
+
+  const loadDocuments = async () => {
+    setIsLoadingDocs(true);
+    try {
+      const data = await fetchDocumentsApi(patientId, currentYear);
+      setDocuments(data);
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsLoadingDocs(false);
+    }
+  };
+
+  const loadPatientData = async () => {
+    const data = await fetchPatientApi(patientId);
+    if (data) setFullPatientData(data);
+  };
+
+  useEffect(() => {
+    if (isOpen && patientId) {
+      if (mode === "edit") loadDocuments();
+      else setDocuments([]);
+      loadPatientData();
+    }
+  }, [isOpen, patientId, mode]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    if (mode === "edit" && initialData) {
+      const bpcString = initialData.bpc === true || String(initialData.bpc) === "true" ? "true" : "false";
+
+      const vaccineList = Array.isArray(fullPatientData?.vaccineNames)
+        ? fullPatientData.vaccineNames.map((v: unknown) => (typeof v === "string" ? { name: v } : v))
+        : [];
+
+      const sourceServiceAreas = initialData.serviceArea || initialData.serviceAreas || initialData.serviceTypes || [];
+      const serviceTypeList = Array.isArray(sourceServiceAreas)
+        ? sourceServiceAreas.map((s: ServiceAreaItem) => ({ id: s.id, area: s.area || s.name, name: s.name || s.area }))
+        : [];
+
+      const medicationValue =
+        initialData.continuousMedication ||
+        initialData.medications ||
+        initialData.medicamentos ||
+        "";
+
+      form.reset({
+        year: currentYear,
+        bpc: bpcString,
+        familyIncome: initialData.familyIncome ? formatCurrencyForDisplay(initialData.familyIncome) : "",
+        diseases: initialData.diseases ?? "",
+        continuousMedication: medicationValue,
+        allergies: fullPatientData?.allergies ?? "",
+        disorders: initialData.disorders || [],
+        vaccines: vaccineList,
+        serviceTypes: serviceTypeList,
+      });
+    } else if (mode === "create") {
+      const vaccineList = Array.isArray(fullPatientData?.vaccineNames)
+        ? fullPatientData.vaccineNames.map((v: unknown) => (typeof v === "string" ? { name: v } : v))
+        : [];
+
+      const existingMedication =
+        (fullPatientData?.additionals?.medications) ||
+        (fullPatientData as Record<string, unknown>)?.continuousMedication ||
+        "";
+
+      const existingDiseases =
+        (fullPatientData?.additionals?.diseases) ||
+        (fullPatientData as Record<string, unknown>)?.diseases ||
+        "";
+
+      form.reset({
+        year: currentYearInt.toString(),
+        bpc: "false",
+        familyIncome: "",
+        diseases: existingDiseases as string,
+        continuousMedication: existingMedication as string,
+        allergies: fullPatientData?.allergies ?? "",
+        disorders: [],
+        vaccines: vaccineList,
+        serviceTypes: [],
+      });
+    }
+  }, [initialData, fullPatientData, isOpen, mode, currentYear]);
+
+  const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setIsUploading(true);
+    const formData = new FormData();
+    formData.append("file", file);
+    formData.append("category", "MEDICAL");
+    formData.append("type", docType);
+    formData.append("year", currentYear);
+    try {
+      await uploadDocumentApi(patientId, formData);
+      toast.success("Documento anexado!");
+      await loadDocuments();
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    } catch {
+      toast.error("Erro ao enviar documento.");
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const handleMoneyChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+    onChange: (value: string) => void,
+  ) => {
+    const value = e.target.value.replace(/\D/g, "");
+    if (value === "") { onChange(""); return; }
+    onChange((parseFloat(value) / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" }));
+  };
+
+  const onSubmit = async (data: AnnualRegistryFormValues) => {
+    toast.dismiss();
+    try {
+      const registryId = initialData?.id;
+      const income = parseFloat(cleanCurrency(data.familyIncome));
+
+      const regPayload = {
+        bpc: data.bpc === "true",
+        familyIncome: income,
+        diseases: data.diseases || "Nenhuma",
+        continuousMedication: data.continuousMedication || "Nenhum",
+        medications: data.continuousMedication || "Nenhum",
+        medicamentos: data.continuousMedication || "Nenhum",
+        disorders: (data.disorders || []).map((d: Record<string, unknown>) => ({ name: d.name || d.label || d.value, id: d.id })),
+        serviceArea: (data.serviceTypes || []).map((s: Record<string, unknown>) => ({ id: s.id, area: s.area || s.name || s.label })),
+        serviceAreas: (data.serviceTypes || []).map((s: Record<string, unknown>) => ({ id: s.id, area: s.area || s.name || s.label })),
+        ano: parseInt(data.year),
+        year: parseInt(data.year),
+      };
+
+      let regRes: Response;
+      if (mode === "create") {
+        regRes = await createAnnualRegistryApi(patientId, regPayload);
+      } else {
+        if (!registryId) throw new Error("ID do registro não encontrado.");
+        regRes = await updateAnnualRegistryApi(patientId, registryId, regPayload);
+      }
+
+      if (!regRes.ok) {
+        const errorData = await regRes.json().catch(() => ({}));
+        const details = errorData.details || "";
+        const message = errorData.message || "";
+
+        if (regRes.status === 409 || details.includes("Conflito") || details.includes("já existe") || message.includes("já existe")) {
+          form.setError("year", { type: "manual", message: "Este ano já possui um registro cadastrado." });
+          throw new Error(`O ano ${data.year} já possui um registro. Escolha outro ano.`);
+        }
+        throw new Error("Erro ao salvar registro no servidor.");
+      }
+
+      if (fullPatientData) {
+        const vaccineList = (data.vaccines || []).map((v: Record<string, unknown>) => ({ name: v.name || v.label || v.value, id: v.id }));
+        const baseData = cleanPatientData(fullPatientData as Record<string, unknown>);
+        await updatePatientApi(patientId, {
+          ...baseData,
+          allergies: data.allergies || "Nenhuma",
+          vaccineNames: vaccineList,
+          continuousMedication: data.continuousMedication || "Nenhum",
+        });
+      }
+
+      onClose(mode === "create" ? data.year : undefined);
+      toast.success(mode === "create" ? "Registro criado com sucesso!" : "Alterações salvas!");
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : "Erro ao salvar.";
+      toast.error(message);
+    }
+  };
+
+  return {
+    form,
+    documents,
+    isLoadingDocs,
+    isUploading,
+    docType,
+    setDocType,
+    fileInputRef,
+    handleFileUpload,
+    handleMoneyChange,
+    onSubmit,
+    loadDocuments,
+  };
+}


### PR DESCRIPTION
Descrição:
O que foi feito
Movidos componentes específicos de domínio que estavam no escopo global para seus domínios corretos, seguindo a arquitetura de Vertical Slicing do projeto.
Componentes movidos:
Componente originalDestinosrc/components/AnnualRegistryEditModal.tsxsrc/domains/patients/annual-registry/annual-registry-edit-modal.tsxsrc/components/DocumentCategoriesCard.tsxsrc/domains/documents/shared/document-categories-card.tsxsrc/components/fileCard.tsxsrc/domains/documents/shared/file-card.tsxsrc/components/FileRestoreAlert.tsxsrc/domains/documents/shared/file-restore-alert.tsx
Imports atualizados

src/app/patients/[id]/page.tsx
src/app/patients/[id]/documents/[type]/page.tsx

Critérios de aceite atendidos

✅ Componentes movidos corretamente
✅ Imports atualizados
✅ Arquivos em kebab-case
✅ Componentes renderizando corretamente

Observações

Os arquivos originais em src/components/ foram mantidos intencionalmente pois podem ter outras dependências ainda não mapeadas.
TranstornosListItem.tsx não foi movido pois o equivalente disorder-list-item.tsx já foi criado na issue #731 e nenhum arquivo importa o original.
FileRestoreAlert não possui importadores ativos, foi movido preventivamente para o domínio correto.