### PR TITLE
[Feature] Rota para buscar agendamentos por profissionais

### DIFF
--- a/apps/api/src/main/java/br/org/apae/api/appointment/application/interfaces/AppointmentApplicationService.java
+++ b/apps/api/src/main/java/br/org/apae/api/appointment/application/interfaces/AppointmentApplicationService.java
@@ -44,4 +44,6 @@ public interface AppointmentApplicationService {
   Page<TodayAppointmentsResponseDTO> listAppointmentForToday(LocalDate date, Pageable pageable);
 
   TodayAppointmentsResponseDTO findGeneratedAppointmentById(UUID id);
+
+  List<GeneratedAppointmentResponseDTO> listGeneratedByProfessional(UUID professionalId);
 }

--- a/apps/api/src/main/java/br/org/apae/api/appointment/application/internal/AppointmentApplicationServiceImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/appointment/application/internal/AppointmentApplicationServiceImpl.java
@@ -538,4 +538,12 @@ public class AppointmentApplicationServiceImpl implements AppointmentApplication
             }
         }
     }
+
+    @Override
+    public List<GeneratedAppointmentResponseDTO> listGeneratedByProfessional(UUID professionalId) {
+        return generatedRepo.findByAppointmentProfessionalId(professionalId)
+                .stream()
+                .map(mapper::toGeneratedResponse)
+                .toList();
+    }
 }

--- a/apps/api/src/main/java/br/org/apae/api/appointment/domain/repository/GeneratedAppointmentRepository.java
+++ b/apps/api/src/main/java/br/org/apae/api/appointment/domain/repository/GeneratedAppointmentRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import java.util.List;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -49,4 +50,6 @@ public interface GeneratedAppointmentRepository extends JpaRepository<GeneratedA
         @Param("date") LocalDate date,
         @Param("excludeAppointmentId") UUID excludeAppointmentId
     );
+
+    List<GeneratedAppointment> findByAppointmentProfessionalId(UUID professionalId);
 }

--- a/apps/api/src/main/java/br/org/apae/api/appointment/interfaces/controllers/AppointmentController.java
+++ b/apps/api/src/main/java/br/org/apae/api/appointment/interfaces/controllers/AppointmentController.java
@@ -1,7 +1,6 @@
 package br.org.apae.api.appointment.interfaces.controllers;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.UUID;
 
@@ -13,11 +12,8 @@ import org.springframework.web.bind.annotation.*;
 import br.org.apae.api.common.dto.appointment.request.appointment.*;
 import br.org.apae.api.common.dto.appointment.response.appointment.*;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
+import java.util.List;
 
 @RequestMapping("/appointments")
 public interface AppointmentController {
@@ -82,4 +78,11 @@ public interface AppointmentController {
   @Operation(summary = "Buscar agendamento gerado por ID")
   @GetMapping("/today/{id}")
   ResponseEntity<TodayAppointmentsResponseDTO> getTodayAppointmentById(@PathVariable UUID id);
+
+  @Operation(
+        summary = "Listar agendamentos gerados por profissional", 
+        description = "Retorna todos os agendamentos gerados vinculados a um profissional específico. Ideal para integrações."
+  )
+  @GetMapping("/professional/{professionalId}/generated")
+  ResponseEntity<List<GeneratedAppointmentResponseDTO>> listGeneratedByProfessional(@PathVariable UUID professionalId);
 }

--- a/apps/api/src/main/java/br/org/apae/api/auth/infrastructure/security/JwtProvider.java
+++ b/apps/api/src/main/java/br/org/apae/api/auth/infrastructure/security/JwtProvider.java
@@ -22,8 +22,8 @@ public class JwtProvider implements TokenProvider {
   @Value("${app.token.secret}")
   private String secret;
 
-  @Value("app.token.issuer")
-  private static String ISSUER;
+  @Value("${app.token.issuer}")  
+  private String ISSUER;         
 
   private Instant genExpirationDate() {
     return LocalDateTime.now().plusHours(24).toInstant(ZoneOffset.of("-03:00"));

--- a/apps/api/src/main/java/br/org/apae/api/controllers/appointment/AppointmentControllerImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/controllers/appointment/AppointmentControllerImpl.java
@@ -3,6 +3,7 @@ package br.org.apae.api.controllers.appointment;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.UUID;
+import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -87,5 +88,11 @@ public class AppointmentControllerImpl implements AppointmentController {
   @Override
   public ResponseEntity<TodayAppointmentsResponseDTO> getTodayAppointmentById(UUID id) {
     return ResponseEntity.ok(service.findGeneratedAppointmentById(id));
+  }
+
+  @Override
+  public ResponseEntity<List<GeneratedAppointmentResponseDTO>> listGeneratedByProfessional(UUID professionalId) {
+      List<GeneratedAppointmentResponseDTO> response = service.listGeneratedByProfessional(professionalId);
+      return ResponseEntity.ok(response);
   }
 }

--- a/apps/api/src/main/resources/application.yaml
+++ b/apps/api/src/main/resources/application.yaml
@@ -56,6 +56,7 @@ logging:
 app:
   token:
     secret: ${JWT_SECRET}
+    issuer: apae-api
   frontend:
     reset-password-url: ${APP_FRONTEND_RESET_PASSWORD_URL:http://localhost:3000/apae-geral/auth/reset-password}
 


### PR DESCRIPTION
# O que mudou?

Adição do endpoint para listar agendamentos gerados por profissional e correção do sistema de autenticação JWT que impedia requisições autenticadas de funcionarem corretamente.

## Tarefas relacionadas:
https://github.com/IFPBEsp/APAE-atendimento/issues/318#event-26769970135

## Mudanças Realizadas

* Criado endpoint GET /appointments/professional/{professionalId}/generated para listar todos os agendamentos gerados vinculados a um profissional específico
* Corrigida injeção do issuer no JwtProvider — campo ISSUER era static, o que impedia o @Value de funcionar, resultando em null e causando falha na validação do token (erro 403)
* Adicionada propriedade app.token.issuer no application.yaml, que estava ausente e impedia a inicialização da aplicação

## Evidências

<img width="2638" height="1352" alt="image" src="https://github.com/user-attachments/assets/0d0832c9-ffe1-4fd5-89fa-4fa243343d59" />
