### PR TITLE
Feature/878 vacinas crud mateus miranda

### DIFF
--- a/apps/apae/src/app/api/vaccines/[id]/route.ts
+++ b/apps/apae/src/app/api/vaccines/[id]/route.ts
@@ -1,0 +1,55 @@
+import { createBaseApi } from "@/lib/axios";
+import { NextResponse } from "next/server";
+
+type Params = {
+  params: Promise<{ id: string }> | { id: string };
+};
+
+export async function GET(request: Request, { params }: Params) {
+    try {
+        const { id } = await params;
+        const api = await createBaseApi();
+        const { data } = await api.get(`/vaccines/${id}`);
+        return NextResponse.json(data);
+    } catch (error) {
+        const message = error instanceof Error ? error.message : "Erro desconhecido";
+        console.error("Erro ao buscar vacina por id:", message);
+        return NextResponse.json(
+            { message: "Erro ao buscar detalhes da vacina." },
+            { status: 500 }
+        );
+    }
+}
+
+export async function PUT(request: Request, { params }: Params) {
+    try {
+        const { id } = await params;
+        const body = await request.json();
+        const api = await createBaseApi();
+        const { data } = await api.put(`/vaccines/${id}`, body);
+        return NextResponse.json(data);
+    } catch (error) {
+        const message = error instanceof Error ? error.message : "Erro desconhecido";
+        console.error("Erro ao atualizar vacina:", message);
+        return NextResponse.json(
+            { message: "Erro ao atualizar vacina." },
+            { status: 500 }
+        );
+    }
+}
+
+export async function DELETE(request: Request, { params }: Params) {
+    try {
+        const { id } = await params;
+        const api = await createBaseApi();
+        await api.delete(`/vaccines/${id}`);
+        return new NextResponse(null, { status: 204 });
+    } catch (error) {
+        const message = error instanceof Error ? error.message : "Erro desconhecido";
+        console.error("Erro ao excluir vacina:", message);
+        return NextResponse.json(
+            { message: "Erro ao excluir vacina." },
+            { status: 500 }
+        );
+    }
+}

--- a/apps/apae/src/app/api/vaccines/route.ts
+++ b/apps/apae/src/app/api/vaccines/route.ts
@@ -9,7 +9,23 @@ export async function GET() {
     } catch (error) {
         const message = error instanceof Error ? error.message : "Erro desconhecido";
         console.error("Erro ao buscar vacinas:", message);
-        return NextResponse.json({ message: "Erro ao buscar a lista de vacinas." }, { status: 500 }
+        return NextResponse.json({ message: "Erro ao buscar a lista de vacinas." }, { status: 500 });
+    }
+}
+
+export async function POST(request: Request) {
+    try {
+        const body = await request.json();
+        const api = await createBaseApi();
+        
+        const { data } = await api.post("/vaccines", body);
+        return NextResponse.json(data, { status: 201 });
+    } catch (error) {
+        const message = error instanceof Error ? error.message : "Erro desconhecido";
+        console.error("Erro ao cadastrar vacina:", message);
+        return NextResponse.json(
+            { message: "Erro ao cadastrar vacina." },
+            { status: 500 }
         );
     }
 }

--- a/apps/apae/src/app/vaccines/[id]/edit/page.tsx
+++ b/apps/apae/src/app/vaccines/[id]/edit/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { VaccineForm } from "@/domains/vaccines/edit/vaccine-form";
+
+export default function EditVaccinePage() {
+  return (
+    <div className="space-y-6 p-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Editar Vacina</h1>
+        <p className="text-sm text-muted-foreground">
+          Altere o nome da vacina no sistema.
+        </p>
+      </div>
+      <VaccineForm />
+    </div>
+  );
+}

--- a/apps/apae/src/app/vaccines/new/page.tsx
+++ b/apps/apae/src/app/vaccines/new/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { VaccineForm } from "@/domains/vaccines/create/vaccine-form";
+
+export default function CreateVaccinePage() {
+  return (
+    <div className="space-y-6 p-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Nova Vacina</h1>
+        <p className="text-sm text-muted-foreground">
+          Cadastre uma nova vacina no sistema para uso dos pacientes.
+        </p>
+      </div>
+      <VaccineForm />
+    </div>
+  );
+}

--- a/apps/apae/src/domains/vaccines/create/use-vaccine-create.ts
+++ b/apps/apae/src/domains/vaccines/create/use-vaccine-create.ts
@@ -1,0 +1,39 @@
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { createVaccineSchema, CreateVaccineFormData } from "../vaccines.schema";
+import { createVaccineApi } from "../vaccines.api";
+import { toast } from "react-toastify"; // Biblioteca oficial do seu projeto!
+import { useState } from "react";
+
+export function useVaccineCreate() {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const form = useForm<CreateVaccineFormData>({
+    resolver: zodResolver(createVaccineSchema),
+    defaultValues: {
+      name: "",
+    },
+  });
+
+  async function onSubmit(data: CreateVaccineFormData) {
+    setIsLoading(true);
+    try {
+      await createVaccineApi(data);
+      toast.success("Vacina cadastrada com sucesso!");
+      router.push("/vaccines");
+    } catch (error) {
+      toast.error("Ocorreu um erro ao cadastrar a vacina.");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return {
+    form,
+    onSubmit: form.handleSubmit(onSubmit),
+    isLoading,
+    router,
+  };
+}

--- a/apps/apae/src/domains/vaccines/create/vaccine-form.tsx
+++ b/apps/apae/src/domains/vaccines/create/vaccine-form.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { useVaccineCreate } from "./use-vaccine-create";
+
+export function VaccineForm() {
+  const { form, onSubmit, isLoading, router } = useVaccineCreate();
+  const { register, formState: { errors } } = form;
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-6 max-w-md">
+      <div className="space-y-2">
+        <label htmlFor="name" className="text-sm font-medium">
+          Nome da Vacina
+        </label>
+        <Input
+          id="name"
+          type="text"
+          placeholder="Ex: BCG, Tríplice Viral"
+          disabled={isLoading}
+          {...register("name")}
+        />
+        {errors.name && (
+          <p className="text-sm text-red-500">{errors.name.message}</p>
+        )}
+      </div>
+
+      <div className="flex gap-4">
+        <Button
+          type="button"
+          variant="outline"
+          disabled={isLoading}
+          onClick={() => router.push("/vaccines")}
+        >
+          Cancelar
+        </Button>
+        <Button type="submit" disabled={isLoading}>
+          {isLoading ? "Salvando..." : "Salvar"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/apae/src/domains/vaccines/edit/use-vaccine-edit.ts
+++ b/apps/apae/src/domains/vaccines/edit/use-vaccine-edit.ts
@@ -1,0 +1,57 @@
+import { useParams, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { updateVaccineSchema, UpdateVaccineFormData } from "../vaccines.schema";
+import { fetchVaccineApi, updateVaccineApi } from "../vaccines.api";
+import { toast } from "react-toastify";
+
+export function useVaccineEdit() {
+  const router = useRouter();
+  const { id } = useParams<{ id: string }>();
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const form = useForm<UpdateVaccineFormData>({
+    resolver: zodResolver(updateVaccineSchema),
+    defaultValues: {
+      name: "",
+    },
+  });
+
+  useEffect(() => {
+    async function loadVaccine() {
+      try {
+        const vaccine = await fetchVaccineApi(id);
+        form.setValue("name", vaccine.name);
+      } catch (error) {
+        toast.error("Erro ao carregar dados da vacina.");
+        router.push("/vaccines");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    loadVaccine();
+  }, [id, form, router]);
+
+  async function onSubmit(data: UpdateVaccineFormData) {
+    setIsSubmitting(true);
+    try {
+      await updateVaccineApi({ id, name: data.name });
+      toast.success("Vacina atualizada com sucesso!");
+      router.push("/vaccines");
+    } catch (error) {
+      toast.error("Ocorreu um erro ao atualizar a vacina.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return {
+    form,
+    onSubmit: form.handleSubmit(onSubmit),
+    isLoading,
+    isSubmitting,
+    router,
+  };
+}

--- a/apps/apae/src/domains/vaccines/edit/vaccine-form.tsx
+++ b/apps/apae/src/domains/vaccines/edit/vaccine-form.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { useVaccineEdit } from "./use-vaccine-edit";
+
+export function VaccineForm() {
+  const { form, onSubmit, isLoading, isSubmitting, router } = useVaccineEdit();
+  const { register, formState: { errors } } = form;
+
+  if (isLoading) {
+    return <p className="text-sm text-muted-foreground">Carregando dados da vacina...</p>;
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-6 max-w-md">
+      <div className="space-y-2">
+        <label htmlFor="name" className="text-sm font-medium">
+          Nome da Vacina
+        </label>
+        <Input
+          id="name"
+          type="text"
+          placeholder="Ex: BCG, Tríplice Viral"
+          disabled={isSubmitting}
+          {...register("name")}
+        />
+        {errors.name && (
+          <p className="text-sm text-red-500">{errors.name.message}</p>
+        )}
+      </div>
+
+      <div className="flex gap-4">
+        <Button
+          type="button"
+          variant="outline"
+          disabled={isSubmitting}
+          onClick={() => router.push("/vaccines")}
+        >
+          Cancelar
+        </Button>
+        <Button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? "Salvando..." : "Salvar"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/apae/src/domains/vaccines/list/use-vaccines-list.ts
+++ b/apps/apae/src/domains/vaccines/list/use-vaccines-list.ts
@@ -2,11 +2,12 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "react-toastify";
-import { fetchVaccinesApi } from "../vaccines.api";
+import { fetchVaccinesApi, deleteVaccineApi } from "../vaccines.api"; 
 import type { Vaccine } from "../vaccines.types";
 
 export function useVaccinesList() {
   const [vaccines, setVaccines] = useState<Vaccine[]>([]);
+  const [searchQuery, setSearchQuery] = useState(""); 
   const [loading, setLoading] = useState(false);
 
   const loadVaccines = useCallback(async () => {
@@ -26,5 +27,26 @@ export function useVaccinesList() {
     loadVaccines();
   }, [loadVaccines]);
 
-  return { vaccines, loading };
+  const filteredVaccines = vaccines.filter((vaccine) =>
+    vaccine.name.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  const handleDelete = async (id: string) => {
+    try {
+      await deleteVaccineApi({ id });
+      toast.success("Vacina excluída com sucesso.");
+      await loadVaccines(); 
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Erro ao excluir vacina.";
+      toast.error(message);
+    }
+  };
+
+  return { 
+    vaccines: filteredVaccines, 
+    searchQuery, 
+    setSearchQuery, 
+    loading, 
+    handleDelete 
+  };
 }

--- a/apps/apae/src/domains/vaccines/list/vaccines-list.tsx
+++ b/apps/apae/src/domains/vaccines/list/vaccines-list.tsx
@@ -4,13 +4,13 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { SearchFilters } from "@/components/search-filters";
-import { ArrowLeft, Loader2 } from "lucide-react";
+import { ArrowLeft, Loader2, Plus } from "lucide-react";
 import { VaccineListItem } from "../shared/vaccine-list-item";
 import { useVaccinesList } from "./use-vaccines-list";
 
 export function VaccinesList() {
   const [searchName, setSearchName] = useState("");
-  const { vaccines, loading } = useVaccinesList();
+  const { vaccines, loading, handleDelete } = useVaccinesList(); 
   const router = useRouter();
 
   const filtered = vaccines.filter((v) =>
@@ -18,7 +18,7 @@ export function VaccinesList() {
   );
 
   return (
-    <div className="!bg-slate-100 min-h-screen">
+    <div className="!bg-slate-100 min-h-screen relative">
       <main className="container mx-auto p-4 md:p-6">
         <Button
           variant="ghost"
@@ -35,10 +35,23 @@ export function VaccinesList() {
         <section className="relative md:bg-white md:rounded-xl md:shadow-md md:border-2 md:p-6">
           <div className="hidden md:flex justify-between items-center mb-4">
             <h2 className="text-xl font-bold text-[#003B93]">Vacinas Cadastradas</h2>
+            <Button
+              onClick={() => router.push("/vaccines/new")}
+              className="bg-[#003B93] hover:bg-blue-800 text-white flex gap-2 items-center text-sm"
+            >
+              <Plus className="h-4 w-4" /> Nova Vacina
+            </Button>
           </div>
 
-          <div className="mb-4 md:hidden">
+          <div className="mb-4 md:hidden flex justify-between items-center">
             <h2 className="text-xl font-bold text-[#003B93]">Vacinas Cadastradas</h2>
+            <Button
+              onClick={() => router.push("/vaccines/new")}
+              size="sm"
+              className="bg-[#003B93] hover:bg-blue-800 text-white flex gap-1 items-center"
+            >
+              <Plus className="h-4 w-4" /> Nova
+            </Button>
           </div>
 
           {loading ? (
@@ -57,6 +70,7 @@ export function VaccinesList() {
                   <VaccineListItem
                     key={vaccine.id}
                     vaccine={vaccine}
+                    onDelete={handleDelete} 
                   />
                 ))}
               </div>
@@ -64,6 +78,14 @@ export function VaccinesList() {
           )}
         </section>
       </main>
+
+      <Button
+        onClick={() => router.push("/vaccines/new")}
+        className="md:hidden fixed bottom-6 right-6 h-12 w-12 rounded-full shadow-lg flex items-center justify-center p-0 z-50 bg-[#003B93] hover:bg-blue-800 text-white"
+        title="Nova Vacina"
+      >
+        <Plus className="h-6 w-6" />
+      </Button>
     </div>
   );
 }

--- a/apps/apae/src/domains/vaccines/shared/vaccine-list-item.tsx
+++ b/apps/apae/src/domains/vaccines/shared/vaccine-list-item.tsx
@@ -1,16 +1,99 @@
 "use client";
 
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Pencil, Trash2 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"; 
 import type { Vaccine } from "../vaccines.types";
 
 interface VaccineListItemProps {
   vaccine: Vaccine;
+  onDelete: (id: string) => Promise<void>;
 }
 
-export function VaccineListItem({ vaccine }: VaccineListItemProps) {
+export function VaccineListItem({ vaccine, onDelete }: VaccineListItemProps) {
+  const router = useRouter();
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isDialogOpen, setIsDialogOpen] = useState(false); 
+
+  async function handleConfirmDelete() {
+    setIsDeleting(true);
+    await onDelete(vaccine.id);
+    setIsDeleting(false);
+    setIsDialogOpen(false);
+  }
+
   return (
-    <div className="flex items-center p-4 border-b hover:bg-gray-50 transition-colors">
-      <div className="flex-1">
+    <div className="flex items-center p-4 border-b hover:bg-gray-50 transition-colors justify-between">
+      <div className="flex-1 flex flex-col gap-1">
         <h3 className="font-bold text-base text-[#003B93]">{vaccine.name}</h3>
+        {vaccine.hasPatient && (
+          <span className="text-xs text-red-500 font-medium">
+            Vinculada a paciente (não pode ser excluída)
+          </span>
+        )}
+      </div>
+
+      <div className="flex gap-2">
+        <Button
+          size="icon"
+          variant="ghost"
+          onClick={() => router.push(`/vaccines/${vaccine.id}/edit`)}
+          title="Editar vacina"
+        >
+          <Pencil className="h-4 w-4 text-muted-foreground hover:text-foreground" />
+        </Button>
+
+        <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+          <DialogTrigger asChild>
+            <Button
+              size="icon"
+              variant="ghost"
+              className="text-red-500 hover:text-red-600 disabled:opacity-40 disabled:text-muted-foreground"
+              disabled={vaccine.hasPatient || isDeleting}
+              title={
+                vaccine.hasPatient
+                  ? "Esta vacina não pode ser excluída pois está em uso por pacientes."
+                  : "Excluir vacina"
+              }
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle className="text-lg font-bold">Excluir Vacina</DialogTitle>
+              <DialogDescription className="text-sm text-muted-foreground mt-2">
+                Tem certeza de que deseja excluir a vacina &quot;{vaccine.name}&quot;? Esta ação é definitiva e não poderá ser desfeita.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter className="flex gap-3 justify-end mt-4">
+              <Button
+                variant="outline"
+                disabled={isDeleting}
+                onClick={() => setIsDialogOpen(false)}
+              >
+                Cancelar
+              </Button>
+              <Button
+                variant="destructive"
+                disabled={isDeleting}
+                onClick={handleConfirmDelete}
+              >
+                {isDeleting ? "Excluindo..." : "Confirmar Exclusão"}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
     </div>
   );

--- a/apps/apae/src/domains/vaccines/vaccines.api.ts
+++ b/apps/apae/src/domains/vaccines/vaccines.api.ts
@@ -1,4 +1,4 @@
-import type { Vaccine } from "./vaccines.types";
+import type { CreateVaccineParams, UpdateVaccineParams, DeleteVaccineParams, Vaccine } from "./vaccines.types";
 
 const BASE_URL = "/apae-geral/api/vaccines";
 
@@ -6,4 +6,37 @@ export async function fetchVaccinesApi(): Promise<Vaccine[]> {
   const response = await fetch(BASE_URL);
   if (!response.ok) throw new Error("Ocorreu um erro ao carregar as vacinas.");
   return response.json();
+}
+
+export async function fetchVaccineApi(id: string): Promise<Vaccine> {
+  const response = await fetch(`${BASE_URL}/${id}`);
+  if (!response.ok) throw new Error("Ocorreu um erro ao carregar a vacina.");
+  return response.json();
+}
+
+export async function createVaccineApi(params: CreateVaccineParams): Promise<Vaccine> {
+  const response = await fetch(BASE_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(params),
+  });
+  if (!response.ok) throw new Error("Erro ao criar vacina.");
+  return response.json();
+}
+
+export async function updateVaccineApi({ id, name }: UpdateVaccineParams): Promise<Vaccine> {
+  const response = await fetch(`${BASE_URL}/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name }),
+  });
+  if (!response.ok) throw new Error("Erro ao editar vacina.");
+  return response.json();
+}
+
+export async function deleteVaccineApi({ id }: DeleteVaccineParams): Promise<void> {
+  const response = await fetch(`${BASE_URL}/${id}`, {
+    method: "DELETE",
+  });
+  if (!response.ok) throw new Error("Erro ao excluir vacina.");
 }

--- a/apps/apae/src/domains/vaccines/vaccines.schema.ts
+++ b/apps/apae/src/domains/vaccines/vaccines.schema.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const createVaccineSchema = z.object({
+  name: z.string().min(1, "O nome é obrigatório."),
+});
+
+export const updateVaccineSchema = z.object({
+  name: z.string().min(1, "O nome é obrigatório."),
+});
+
+export type CreateVaccineFormData = z.infer<typeof createVaccineSchema>;
+export type UpdateVaccineFormData = z.infer<typeof updateVaccineSchema>;

--- a/apps/apae/src/domains/vaccines/vaccines.types.ts
+++ b/apps/apae/src/domains/vaccines/vaccines.types.ts
@@ -3,3 +3,16 @@ export type Vaccine = Readonly<{
   name: string;
   hasPatient: boolean;
 }>;
+
+export type CreateVaccineParams = Readonly<{
+  name: string;
+}>;
+
+export type UpdateVaccineParams = Readonly<{
+  id: string;
+  name: string;
+}>;
+
+export type DeleteVaccineParams = Readonly<{
+  id: string;
+}>;

--- a/apps/api/src/main/java/br/org/apae/api/common/dto/patient/request/vaccine/CreateVaccineDTO.java
+++ b/apps/api/src/main/java/br/org/apae/api/common/dto/patient/request/vaccine/CreateVaccineDTO.java
@@ -1,0 +1,10 @@
+package br.org.apae.api.common.dto.patient.request.vaccine;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreateVaccineDTO(
+        @NotBlank(message = "O nome da vacina é obrigatório.")
+        @Size(min = 2, max = 100, message = "O nome da vacina deve ter entre 2 e 100 caracteres.")
+        String name
+) {}

--- a/apps/api/src/main/java/br/org/apae/api/common/dto/patient/request/vaccine/UpdateVaccineDTO.java
+++ b/apps/api/src/main/java/br/org/apae/api/common/dto/patient/request/vaccine/UpdateVaccineDTO.java
@@ -1,0 +1,10 @@
+package br.org.apae.api.common.dto.patient.request.vaccine;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdateVaccineDTO(
+        @NotBlank(message = "O nome da vacina é obrigatório.")
+        @Size(min = 2, max = 100, message = "O nome da vacina deve ter entre 2 e 100 caracteres.")
+        String name
+) {}

--- a/apps/api/src/main/java/br/org/apae/api/controllers/vaccine/VaccineControllerImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/controllers/vaccine/VaccineControllerImpl.java
@@ -1,13 +1,21 @@
 package br.org.apae.api.controllers.vaccine;
 
-import br.org.apae.api.patient.application.interfaces.VaccineApplicationService;
-import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
-import br.org.apae.api.patient.interfaces.controllers.VaccineController;
-import org.springframework.beans.factory.annotation.Autowired;
 import java.util.List;
 import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+
+import br.org.apae.api.common.dto.patient.request.vaccine.CreateVaccineDTO;
+import br.org.apae.api.common.dto.patient.request.vaccine.UpdateVaccineDTO;
+import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
+import br.org.apae.api.patient.application.interfaces.VaccineApplicationService;
+import br.org.apae.api.patient.interfaces.controllers.VaccineController;
+import jakarta.validation.Valid;
 
 @RestController
 public class VaccineControllerImpl implements VaccineController {
@@ -35,5 +43,23 @@ public class VaccineControllerImpl implements VaccineController {
     public ResponseEntity<VaccineResponseDTO> findByName(String name) {
         VaccineResponseDTO vaccine = vaccineService.findVaccineByName(name);
         return ResponseEntity.ok(vaccine);
+    }
+
+    @Override
+    public ResponseEntity<VaccineResponseDTO> createVaccine(@Valid @RequestBody CreateVaccineDTO dto) {
+        VaccineResponseDTO created = vaccineService.createVaccine(dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @Override
+    public ResponseEntity<VaccineResponseDTO> updateVaccine(@PathVariable UUID id, @Valid @RequestBody UpdateVaccineDTO dto) {
+        VaccineResponseDTO updated = vaccineService.updateVaccine(id, dto);
+        return ResponseEntity.ok(updated);
+    }
+
+    @Override
+    public ResponseEntity<Void> deleteVaccine(@PathVariable UUID id) {
+        vaccineService.deleteVaccine(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/apps/api/src/main/java/br/org/apae/api/patient/application/exceptions/PatientExceptionHandler.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/application/exceptions/PatientExceptionHandler.java
@@ -1,5 +1,13 @@
 package br.org.apae.api.patient.application.exceptions;
 
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
 import br.org.apae.api.common.exceptions.types.ErrorResponse;
 import br.org.apae.api.patient.domain.exceptions.AnnualRegistryConflictException;
 import br.org.apae.api.patient.domain.exceptions.DisorderConflictException;
@@ -13,16 +21,11 @@ import br.org.apae.api.patient.domain.exceptions.PatientConflictException;
 import br.org.apae.api.patient.domain.exceptions.PatientNotFoundException;
 import br.org.apae.api.patient.domain.exceptions.RegistryNotFoundException;
 import br.org.apae.api.patient.domain.exceptions.RegistryOwnershipException;
+import br.org.apae.api.patient.domain.exceptions.VaccineConflictException;
+import br.org.apae.api.patient.domain.exceptions.VaccineInUseException;
 import br.org.apae.api.patient.domain.exceptions.VaccineMismatchException;
 import br.org.apae.api.patient.domain.exceptions.VaccineNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
-import org.springframework.core.Ordered;
-import org.springframework.core.annotation.Order;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.annotation.ControllerAdvice;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 
 @ControllerAdvice
 @Order(Ordered.HIGHEST_PRECEDENCE)
@@ -252,4 +255,14 @@ public class PatientExceptionHandler {
 
     return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
   }
+
+  @ExceptionHandler(VaccineConflictException.class)
+    public ResponseEntity<String> handleVaccineConflict(VaccineConflictException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(VaccineInUseException.class)
+    public ResponseEntity<String> handleVaccineInUse(VaccineInUseException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(ex.getMessage());
+    }
 }

--- a/apps/api/src/main/java/br/org/apae/api/patient/application/interfaces/VaccineApplicationService.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/application/interfaces/VaccineApplicationService.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import br.org.apae.api.common.dto.patient.request.vaccine.CreateVaccineDTO;
+import br.org.apae.api.common.dto.patient.request.vaccine.UpdateVaccineDTO;
 import br.org.apae.api.common.dto.patient.request.vaccine.VaccineNameDTO;
 import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
 
@@ -15,4 +17,10 @@ public interface VaccineApplicationService {
   VaccineResponseDTO findVaccineByName(String name);
 
   Set<VaccineResponseDTO> findVaccines(Set<VaccineNameDTO> vaccineNames);
+
+  VaccineResponseDTO createVaccine(CreateVaccineDTO dto);
+
+  VaccineResponseDTO updateVaccine(java.util.UUID id, UpdateVaccineDTO dto);
+
+  void deleteVaccine(java.util.UUID id);
 }

--- a/apps/api/src/main/java/br/org/apae/api/patient/application/internal/VaccineApplicationServiceImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/application/internal/VaccineApplicationServiceImpl.java
@@ -1,24 +1,25 @@
 package br.org.apae.api.patient.application.internal;
 
-import br.org.apae.api.patient.domain.exceptions.VaccineMismatchException;
-import br.org.apae.api.patient.domain.exceptions.VaccineNotFoundException;
-import br.org.apae.api.patient.domain.model.Vaccine;
-import br.org.apae.api.patient.domain.repository.PatientRepository;
-import br.org.apae.api.patient.domain.repository.VaccineRepository;
-import br.org.apae.api.common.dto.patient.request.vaccine.VaccineNameDTO;
-import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Set;
-
+import br.org.apae.api.common.dto.patient.request.vaccine.CreateVaccineDTO;
+import br.org.apae.api.common.dto.patient.request.vaccine.UpdateVaccineDTO;
+import br.org.apae.api.common.dto.patient.request.vaccine.VaccineNameDTO;
+import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
 import br.org.apae.api.patient.application.interfaces.VaccineApplicationService;
 import br.org.apae.api.patient.application.mappers.VaccineMapper;
-import java.util.UUID;
-import java.util.stream.Collectors;
+import br.org.apae.api.patient.domain.exceptions.VaccineMismatchException;
+import br.org.apae.api.patient.domain.exceptions.VaccineNotFoundException;
+import br.org.apae.api.patient.domain.model.Vaccine;
+import br.org.apae.api.patient.domain.repository.PatientRepository;
+import br.org.apae.api.patient.domain.repository.VaccineRepository;
 
 @Service
 public class VaccineApplicationServiceImpl implements VaccineApplicationService {
@@ -77,5 +78,19 @@ public class VaccineApplicationServiceImpl implements VaccineApplicationService 
         }
 
         return vaccineMapper.toResponseDTOSet(vaccines);
+    }
+
+    @Override
+    public VaccineResponseDTO createVaccine(CreateVaccineDTO dto) {
+        return null;
+    }
+
+    @Override
+    public VaccineResponseDTO updateVaccine(UUID id, UpdateVaccineDTO dto) {
+        return null;
+    }
+
+    @Override
+    public void deleteVaccine(UUID id) {
     }
 }

--- a/apps/api/src/main/java/br/org/apae/api/patient/application/internal/VaccineApplicationServiceImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/application/internal/VaccineApplicationServiceImpl.java
@@ -15,6 +15,8 @@ import br.org.apae.api.common.dto.patient.request.vaccine.VaccineNameDTO;
 import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
 import br.org.apae.api.patient.application.interfaces.VaccineApplicationService;
 import br.org.apae.api.patient.application.mappers.VaccineMapper;
+import br.org.apae.api.patient.domain.exceptions.VaccineConflictException;
+import br.org.apae.api.patient.domain.exceptions.VaccineInUseException;
 import br.org.apae.api.patient.domain.exceptions.VaccineMismatchException;
 import br.org.apae.api.patient.domain.exceptions.VaccineNotFoundException;
 import br.org.apae.api.patient.domain.model.Vaccine;
@@ -81,16 +83,46 @@ public class VaccineApplicationServiceImpl implements VaccineApplicationService 
     }
 
     @Override
+    @Transactional
     public VaccineResponseDTO createVaccine(CreateVaccineDTO dto) {
-        return null;
+        
+        if (vaccineRepository.existsByNameIgnoreCase(dto.name())) {
+            throw new VaccineConflictException("Já existe uma vacina cadastrada com o nome: " + dto.name());
+        }
+
+        Vaccine newVaccine = vaccineMapper.toEntity(dto);
+        Vaccine savedVaccine = vaccineRepository.save(newVaccine);
+
+        return vaccineMapper.toResponseDTO(savedVaccine); 
     }
 
     @Override
+    @Transactional
     public VaccineResponseDTO updateVaccine(UUID id, UpdateVaccineDTO dto) {
-        return null;
+        Vaccine vaccine = vaccineRepository.findById(id)
+                .orElseThrow(() -> new VaccineNotFoundException("Vacina não encontrada com o ID informado."));
+
+        if (vaccineRepository.existsByNameIgnoreCaseAndIdNot(dto.name(), id)) {
+            throw new VaccineConflictException("Já existe outra vacina cadastrada com o nome: " + dto.name());
+        }
+
+        vaccine.updateName(dto.name());
+        Vaccine updatedVaccine = vaccineRepository.save(vaccine);
+
+        return vaccineMapper.toResponseDTO(updatedVaccine);
     }
 
     @Override
+    @Transactional
     public void deleteVaccine(UUID id) {
+        Vaccine vaccine = vaccineRepository.findById(id)
+                .orElseThrow(() -> new VaccineNotFoundException("Vacina não encontrada com o ID informado."));
+
+        if (patientRepository.isVaccineInUse(id)) {
+            throw new VaccineInUseException("Não é possível excluir esta vacina pois ela está em uso por um ou mais pacientes.");
+        }
+
+        vaccineRepository.delete(vaccine);
+        vaccineRepository.flush();
     }
 }

--- a/apps/api/src/main/java/br/org/apae/api/patient/application/mappers/VaccineMapper.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/application/mappers/VaccineMapper.java
@@ -1,12 +1,13 @@
 package br.org.apae.api.patient.application.mappers;
 
-import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
-import br.org.apae.api.patient.domain.model.Vaccine;
-
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
+
+import br.org.apae.api.common.dto.patient.request.vaccine.CreateVaccineDTO;
+import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
+import br.org.apae.api.patient.domain.model.Vaccine;
 
 @Component
 public class VaccineMapper {
@@ -25,5 +26,9 @@ public class VaccineMapper {
         return vaccines.stream()
                 .map(this::toResponseDTO)
                 .collect(Collectors.toSet());
+    }
+
+    public Vaccine toEntity(CreateVaccineDTO dto) {
+        return new Vaccine(dto.name());
     }
 }

--- a/apps/api/src/main/java/br/org/apae/api/patient/domain/exceptions/VaccineConflictException.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/domain/exceptions/VaccineConflictException.java
@@ -1,0 +1,7 @@
+package br.org.apae.api.patient.domain.exceptions;
+
+public class VaccineConflictException extends RuntimeException {
+    public VaccineConflictException(String message) {
+        super(message);
+    }
+}

--- a/apps/api/src/main/java/br/org/apae/api/patient/domain/exceptions/VaccineInUseException.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/domain/exceptions/VaccineInUseException.java
@@ -1,0 +1,7 @@
+package br.org.apae.api.patient.domain.exceptions;
+
+public class VaccineInUseException extends RuntimeException {
+    public VaccineInUseException(String message) {
+        super(message);
+    }
+}

--- a/apps/api/src/main/java/br/org/apae/api/patient/domain/repository/VaccineRepository.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/domain/repository/VaccineRepository.java
@@ -1,17 +1,22 @@
 package br.org.apae.api.patient.domain.repository;
 
-import br.org.apae.api.patient.domain.model.Vaccine;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import br.org.apae.api.patient.domain.model.Vaccine;
 
 @Repository
 public interface VaccineRepository extends JpaRepository<Vaccine, UUID> {
     Optional<Vaccine> findByName(String name);
 
     Set<Vaccine> findByNameInIgnoreCase(Collection<String> names);
+
+    boolean existsByNameIgnoreCase(String name);
+
+    boolean existsByNameIgnoreCaseAndIdNot(String name, java.util.UUID id);
 }

--- a/apps/api/src/main/java/br/org/apae/api/patient/interfaces/controllers/VaccineController.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/interfaces/controllers/VaccineController.java
@@ -1,14 +1,25 @@
 package br.org.apae.api.patient.interfaces.controllers;
 
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import br.org.apae.api.common.dto.patient.request.vaccine.CreateVaccineDTO;
+import br.org.apae.api.common.dto.patient.request.vaccine.UpdateVaccineDTO;
 import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-import java.util.List;
-import java.util.UUID;
 
 @RequestMapping("/vaccines")
 @Tag(name = "Vaccines", description = "Endpoints para consulta de vacinas")
@@ -36,4 +47,13 @@ public interface VaccineController {
         })
         @GetMapping("/search/by-name")
         ResponseEntity<VaccineResponseDTO> findByName(@RequestParam String name);
+        
+        @PostMapping
+        ResponseEntity<VaccineResponseDTO> createVaccine(@jakarta.validation.Valid @RequestBody CreateVaccineDTO dto);
+
+        @PutMapping("/{id}")
+        ResponseEntity<VaccineResponseDTO> updateVaccine(@PathVariable UUID id, @jakarta.validation.Valid @RequestBody UpdateVaccineDTO dto);
+
+        @DeleteMapping("/{id}")
+        ResponseEntity<Void> deleteVaccine(@PathVariable UUID id);
 }


### PR DESCRIPTION
## O que foi feito
Reconstrução completa do CRUD de vacinas, contemplando as seguintes operações de escrita:
* **Criação (POST):** Formulário de nova vacina e rota de roteamento, validando o nome (entre 2 e 100 caracteres) e impedindo duplicidade no banco (status 409).
* **Edição (PUT):** Formulário de edição que busca os dados atuais pelo ID e atualiza o nome de forma segura, com validação de conflito de nome em outros registros.
* **Exclusão (DELETE):** Ação de exclusão com modal estilizado (Dialog do Shadcn UI) e confirmação, com bloqueio automático (desabilitando a lixeira na interface e lançando exceção no backend) se a vacina estiver vinculada a algum paciente.

## Como testar
1. Acesse o sistema e navegue até a listagem de vacinas (`/vaccines`).
2. Clique em **"Nova Vacina"** no topo direito. Tente salvar em branco para ver o erro de validação do Zod. Cadastre uma vacina com o nome `Vacina de Teste`.
3. Tente cadastrar uma nova vacina com o mesmo nome `Vacina de Teste` para validar o bloqueio de duplicidade (409 Conflict) no backend e o toast de erro.
4. Clique em **"Editar"** (Lápis) na `Vacina de Teste`. Altere o nome para `Vacina de Teste Editada` e salve.
5. No menu lateral, acesse **"Pacientes"**, edite um paciente e vincule a vacina `Vacina de Teste Editada` a ele. Salve o cadastro.
6. Volte à listagem de vacinas e verifique que a `Vacina de Teste Editada` agora exibe o aviso de vínculo e que o ícone de exclusão está desabilitado com tooltip explicativo.
7. Para vacinas não vinculadas, clique no ícone de exclusão, confirme no modal interativo do Shadcn e valide se a exclusão foi bem-sucedida e recarregou a listagem automaticamente.

## Checklist
- [x] Lint executado
- [x] Testes executados
- [x] Build do frontend ok
- [x] Build do backend ok
- [x] Listagem e busca de vacinas continuam funcionando normalmente

## Issue relacionada
Closes #878