### PR TITLE
feat: implementa criação, edição e exclusão de vacinas.

### DIFF
--- a/apps/apae/src/app/api/vaccines/[id]/route.ts
+++ b/apps/apae/src/app/api/vaccines/[id]/route.ts
@@ -1,0 +1,50 @@
+import { createBaseApi } from "@/lib/axios";
+import { NextResponse } from "next/server";
+import { AxiosError } from "axios";
+
+interface Params {
+    params: Promise<{ id: string }>;
+}
+
+export async function GET(request: Request, { params }: Params) {
+    try {
+        const { id } = await params;
+        const api = await createBaseApi();
+        const { data } = await api.get(`/vaccines/${id}`);
+        return NextResponse.json(data);
+    } catch (error) {
+        if (error instanceof AxiosError) {
+            return new NextResponse(JSON.stringify(error.response?.data || { message: error.message }), { status: error.response?.status || 500 });
+        }
+        return new NextResponse(JSON.stringify({ message: "Erro ao buscar dados." }), { status: 500 });
+    }
+}
+
+export async function PUT(request: Request, { params }: Params) {
+    try {
+        const { id } = await params;
+        const body = await request.json();
+        const api = await createBaseApi();
+        const { data } = await api.put(`/vaccines/${id}`, body);
+        return NextResponse.json(data);
+    } catch (error) {
+        if (error instanceof AxiosError) {
+            return new NextResponse(JSON.stringify(error.response?.data || { message: error.message }), { status: error.response?.status || 500 });
+        }
+        return new NextResponse(JSON.stringify({ message: "Erro ao atualizar dados." }), { status: 500 });
+    }
+}
+
+export async function DELETE(request: Request, { params }: Params) {
+    try {
+        const { id } = await params;
+        const api = await createBaseApi();
+        const { data } = await api.delete(`/vaccines/${id}`);
+        return NextResponse.json(data);
+    } catch (error) {
+        if (error instanceof AxiosError) {
+            return new NextResponse(JSON.stringify(error.response?.data || { message: error.message }), { status: error.response?.status || 500 });
+        }
+        return new NextResponse(JSON.stringify({ message: "Erro ao excluir dados." }), { status: 500 });
+    }
+}

--- a/apps/apae/src/app/api/vaccines/route.ts
+++ b/apps/apae/src/app/api/vaccines/route.ts
@@ -1,5 +1,24 @@
 import { createBaseApi } from "@/lib/axios";
 import { NextResponse } from "next/server";
+import { AxiosError } from "axios";
+
+export async function POST(request: Request) {
+    try {
+        const body = await request.json();
+        const api = await createBaseApi();
+        const { data } = await api.post("/vaccines", body);
+
+        return NextResponse.json(data, { status: 201 });
+    } catch (error) {
+        if (error instanceof AxiosError) {
+            return new NextResponse(
+                JSON.stringify(error.response?.data || { message: error.message }), { status: error.response?.status || 500 }
+            );
+        }
+
+        return new NextResponse(JSON.stringify({ message: "Erro inesperado ao criar vacina" }), { status: 500 });
+    }
+}
 
 export async function GET() {
     try {

--- a/apps/apae/src/app/patients/create/additional/page.tsx
+++ b/apps/apae/src/app/patients/create/additional/page.tsx
@@ -37,9 +37,10 @@ import { useFetchServiceAreas } from "@/hooks/service-area/use-fetch-service-are
 
 import { CreateCareDialog } from "@/domains/patients/components/dialogs/CreateCareDialog";
 import { CreateDisorderDialog } from "@/domains/patients/components/dialogs/CreateDisorderDialog";
+import { CreateVaccineDialog } from "@/domains/patients/components/dialogs/CreateVaccineDialog";
 
 export default function MembersRegisterAdditionalsPage() {
-  const [modal, setModal] = useState<"disorder" | "care" | null>(
+  const [modal, setModal] = useState<"disorder" | "vaccine" | "care" | null>(
     null,
   );
   const [refreshKey, setRefreshKey] = useState(0);
@@ -137,6 +138,20 @@ export default function MembersRegisterAdditionalsPage() {
           }
         }}
       />
+      <CreateVaccineDialog
+        open={modal === "vaccine"}
+        onOpenChange={(value: boolean) => setModal(value ? "vaccine" : null)}
+        onSuccess={(newName: string) => {
+          const currentValues = form.getValues("vaccines") || [];
+          if (!currentValues.includes(newName)) {
+            form.setValue("vaccines", [...currentValues, newName], {
+              shouldDirty: true,
+              shouldValidate: true,
+            });
+            setRefreshKey((k) => k + 1);
+          }
+        }}
+      />
       <Form {...form}>
         <MembersRegisterForm
           title={
@@ -204,6 +219,7 @@ export default function MembersRegisterAdditionalsPage() {
                           .map((val: string) => ({ label: val, value: val })),
                       ]}
                       onValueChange={field.onChange}
+                      onCreate={() => setModal("vaccine")}
                       placeholder="Selecione as vacinas"
                       hideSelectAll={true}
                     />

--- a/apps/apae/src/app/vaccines/[id]/edit/page.tsx
+++ b/apps/apae/src/app/vaccines/[id]/edit/page.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { VaccineEditForm } from "@/domains/vaccines/edit/vaccine-form";
+
+export default function EditVaccinePage() {
+  const params = useParams();
+  const id = typeof params.id === "string" ? params.id : "";
+  return <VaccineEditForm id={id} />;
+}

--- a/apps/apae/src/app/vaccines/new/page.tsx
+++ b/apps/apae/src/app/vaccines/new/page.tsx
@@ -1,0 +1,5 @@
+import { VaccineCreateForm } from "@/domains/vaccines/create/vaccine-form";
+
+export default function NewVaccinePage() {
+  return <VaccineCreateForm />;
+}

--- a/apps/apae/src/domains/patients/components/dialogs/CreateVaccineDialog.tsx
+++ b/apps/apae/src/domains/patients/components/dialogs/CreateVaccineDialog.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import z from "zod";
+import { useVaccinesContext } from "@/hooks/use-vaccines";
+import { CreateVaccine } from "@/schemas/vaccine-schemas";
+
+export type DialogProps = Readonly<{
+  open: boolean;
+  onOpenChange: (value: boolean) => void;
+  onSuccess?: (name: string) => void;
+}>;
+
+export function CreateVaccineDialog({ open, onOpenChange, onSuccess }: DialogProps) {
+  const { createVaccine } = useVaccinesContext();
+  const form = useForm<z.infer<typeof CreateVaccine>>({
+    resolver: zodResolver(CreateVaccine),
+    defaultValues: { name: "" },
+  });
+
+  const onSubmit = async (data: z.infer<typeof CreateVaccine>) => {
+    await createVaccine(data);
+    onOpenChange(false);
+    onSuccess?.(data.name);
+    form.reset();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Nova Vacina</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Nome da Vacina</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Ex: Hepatite B" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button variant="outline" type="button" onClick={() => onOpenChange(false)}>
+                Cancelar
+              </Button>
+              <Button type="submit" disabled={form.formState.isSubmitting}>
+                Salvar
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/apae/src/domains/vaccines/create/use-vaccine-create.ts
+++ b/apps/apae/src/domains/vaccines/create/use-vaccine-create.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "react-toastify";
+import { createVaccineApi } from "../vaccines.api";
+import type { CreateVaccineParams } from "../vaccines.types";
+
+export function useVaccineCreate() {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const router = useRouter();
+
+  const createVaccine = async (params: CreateVaccineParams) => {
+    try {
+      setIsSubmitting(true);
+      await createVaccineApi(params);
+      toast.success("Vacina criada com sucesso.");
+      router.push("/vaccines");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Erro ao criar vacina.";
+      toast.error(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return { createVaccine, isSubmitting };
+}

--- a/apps/apae/src/domains/vaccines/create/vaccine-form.tsx
+++ b/apps/apae/src/domains/vaccines/create/vaccine-form.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ArrowLeft } from "lucide-react";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { createVaccineSchema, type CreateVaccineFormData } from "../vaccines.schema";
+import { useVaccineCreate } from "./use-vaccine-create";
+
+export function VaccineCreateForm() {
+  const router = useRouter();
+  const { createVaccine, isSubmitting } = useVaccineCreate();
+
+  const form = useForm<CreateVaccineFormData>({
+    resolver: zodResolver(createVaccineSchema),
+    mode: "onChange",
+    defaultValues: { name: "" },
+  });
+
+  const onSubmit = async (data: CreateVaccineFormData) => {
+    await createVaccine(data);
+  };
+
+  return (
+    <div className="!bg-slate-100 min-h-screen">
+      <main className="container mx-auto p-4 md:p-6">
+        <div className="bg-white rounded-xl shadow-md border-2 p-6 mb-4">
+          <Button variant="ghost" onClick={() => router.back()} className="mb-4 text-sm text-[#003B93] hover:bg-blue-50">
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Voltar
+          </Button>
+
+          <h1 className="text-2xl font-bold mb-6 text-[#003B93]">Nova Vacina</h1>
+
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel className="font-semibold text-[#003B93]">Nome da Vacina</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Ex: Hepatite B" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <div className="flex justify-end gap-2 pt-4">
+                <Button type="button" variant="outline" onClick={() => router.back()}>Cancelar</Button>
+                <Button type="submit" disabled={isSubmitting} className="!bg-[#0D4F97] !hover:bg-[#0b427d] text-white">
+                  {isSubmitting ? "Salvando..." : "Salvar"}
+                </Button>
+              </div>
+            </form>
+          </Form>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/apae/src/domains/vaccines/edit/use-vaccine-edit.ts
+++ b/apps/apae/src/domains/vaccines/edit/use-vaccine-edit.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "react-toastify";
+import { fetchVaccineApi, updateVaccineApi } from "../vaccines.api";
+import type { Vaccine, UpdateVaccineParams } from "../vaccines.types";
+
+export function useVaccineEdit(id: string) {
+  const [vaccine, setVaccine] = useState<Vaccine | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!id) return;
+    const load = async () => {
+      try {
+        const data = await fetchVaccineApi(id);
+        setVaccine(data);
+      } catch {
+        toast.error("Erro ao carregar a vacina.");
+        router.push("/vaccines");
+      }
+    };
+    load();
+  }, [id, router]);
+
+  const updateVaccine = async (params: UpdateVaccineParams) => {
+    try {
+      setIsSubmitting(true);
+      await updateVaccineApi(params);
+      toast.success("Vacina atualizada com sucesso.");
+      router.push("/vaccines");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Erro ao atualizar vacina.";
+      toast.error(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return { vaccine, updateVaccine, isSubmitting };
+}

--- a/apps/apae/src/domains/vaccines/edit/vaccine-form.tsx
+++ b/apps/apae/src/domains/vaccines/edit/vaccine-form.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ArrowLeft, Loader2 } from "lucide-react";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { updateVaccineSchema, type UpdateVaccineFormData } from "../vaccines.schema";
+import { useVaccineEdit } from "./use-vaccine-edit";
+
+interface VaccineEditFormProps {
+  id: string;
+}
+
+export function VaccineEditForm({ id }: VaccineEditFormProps) {
+  const router = useRouter();
+  const { vaccine, updateVaccine, isSubmitting } = useVaccineEdit(id);
+
+  const form = useForm<UpdateVaccineFormData>({
+    resolver: zodResolver(updateVaccineSchema),
+    mode: "onChange",
+    defaultValues: { name: "" },
+  });
+
+  useEffect(() => {
+    if (vaccine) form.reset({ name: vaccine.name });
+  }, [vaccine, form]);
+
+  const onSubmit = async (data: UpdateVaccineFormData) => {
+    await updateVaccine({ id, name: data.name });
+  };
+
+  if (!vaccine) {
+    return (
+      <div className="flex justify-center items-center p-10">
+        <Loader2 className="h-8 w-8 animate-spin text-gray-500" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="!bg-slate-100 min-h-screen">
+      <main className="container mx-auto p-4 md:p-6">
+        <div className="bg-white rounded-xl shadow-md border-2 p-6 mb-4">
+          <Button variant="ghost" onClick={() => router.back()} className="mb-4 text-sm text-[#003B93] hover:bg-blue-50">
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Voltar
+          </Button>
+
+          <h1 className="text-2xl font-bold mb-6 text-[#003B93]">Editar Vacina</h1>
+
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel className="font-semibold text-[#003B93]">Nome da Vacina</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Ex: Hepatite B" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <div className="flex justify-end gap-2 pt-4">
+                <Button type="button" variant="outline" onClick={() => router.back()}>Cancelar</Button>
+                <Button type="submit" disabled={isSubmitting} className="!bg-[#0D4F97] !hover:bg-[#0b427d] text-white">
+                  {isSubmitting ? "Atualizando..." : "Atualizar"}
+                </Button>
+              </div>
+            </form>
+          </Form>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/apae/src/domains/vaccines/list/use-vaccines-list.ts
+++ b/apps/apae/src/domains/vaccines/list/use-vaccines-list.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "react-toastify";
-import { fetchVaccinesApi } from "../vaccines.api";
+import { fetchVaccinesApi, deleteVaccineApi } from "../vaccines.api";
 import type { Vaccine } from "../vaccines.types";
 
 export function useVaccinesList() {
@@ -22,9 +22,20 @@ export function useVaccinesList() {
     }
   }, []);
 
+  const deleteVaccine = useCallback(async (id: string) => {
+    try {
+      await deleteVaccineApi({ id });
+      toast.success("Vacina excluída com sucesso.");
+      await loadVaccines();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Erro ao excluir vacina.";
+      toast.error(message);
+    }
+  }, [loadVaccines]);
+
   useEffect(() => {
     loadVaccines();
   }, [loadVaccines]);
 
-  return { vaccines, loading };
+  return { vaccines, loading, deleteVaccine };
 }

--- a/apps/apae/src/domains/vaccines/list/vaccines-list.tsx
+++ b/apps/apae/src/domains/vaccines/list/vaccines-list.tsx
@@ -1,16 +1,17 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { SearchFilters } from "@/components/search-filters";
-import { ArrowLeft, Loader2 } from "lucide-react";
+import { ArrowLeft, Loader2, Plus } from "lucide-react";
 import { VaccineListItem } from "../shared/vaccine-list-item";
 import { useVaccinesList } from "./use-vaccines-list";
 
 export function VaccinesList() {
   const [searchName, setSearchName] = useState("");
-  const { vaccines, loading } = useVaccinesList();
+  const { vaccines, loading, deleteVaccine } = useVaccinesList();
   const router = useRouter();
 
   const filtered = vaccines.filter((v) =>
@@ -35,6 +36,9 @@ export function VaccinesList() {
         <section className="relative md:bg-white md:rounded-xl md:shadow-md md:border-2 md:p-6">
           <div className="hidden md:flex justify-between items-center mb-4">
             <h2 className="text-xl font-bold text-[#003B93]">Vacinas Cadastradas</h2>
+            <Button asChild className="!bg-[#0D4F97] !hover:bg-[#0b427d] text-white">
+              <Link href="/vaccines/new">Adicionar</Link>
+            </Button>
           </div>
 
           <div className="mb-4 md:hidden">
@@ -57,6 +61,8 @@ export function VaccinesList() {
                   <VaccineListItem
                     key={vaccine.id}
                     vaccine={vaccine}
+                    onEdit={() => router.push(`/vaccines/${vaccine.id}/edit`)}
+                    onDelete={() => deleteVaccine(vaccine.id)}
                   />
                 ))}
               </div>
@@ -64,6 +70,16 @@ export function VaccinesList() {
           )}
         </section>
       </main>
+
+      <Button
+        asChild
+        className="fixed bottom-6 right-6 h-[53px] w-[53px] rounded-full shadow-lg md:hidden bg-[#0D4F97] hover:bg-[#0b427d]"
+      >
+        <Link href="/vaccines/new">
+          <Plus className="h-7 w-7" />
+          <span className="sr-only">Adicionar Vacina</span>
+        </Link>
+      </Button>
     </div>
   );
 }

--- a/apps/apae/src/domains/vaccines/shared/vaccine-list-item.tsx
+++ b/apps/apae/src/domains/vaccines/shared/vaccine-list-item.tsx
@@ -1,16 +1,65 @@
 "use client";
 
+import { Button } from "@/components/ui/button";
+import { ConfirmModal } from "@/components/ui/confirm-modal";
+import { Edit, Trash2 } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@radix-ui/react-tooltip";
 import type { Vaccine } from "../vaccines.types";
 
 interface VaccineListItemProps {
   vaccine: Vaccine;
+  onEdit: () => void;
+  onDelete: () => void;
 }
 
-export function VaccineListItem({ vaccine }: VaccineListItemProps) {
+export function VaccineListItem({ vaccine, onEdit, onDelete }: VaccineListItemProps) {
   return (
-    <div className="flex items-center p-4 border-b hover:bg-gray-50 transition-colors">
+    <div className="flex items-center justify-between p-4 border-b hover:bg-gray-50 transition-colors">
       <div className="flex-1">
         <h3 className="font-bold text-base text-[#003B93]">{vaccine.name}</h3>
+      </div>
+      <div className="flex items-center gap-2 ml-4">
+        <Button variant="outline" size="icon" className="h-8 w-8" onClick={onEdit} aria-label="Editar">
+          <Edit className="h-4 w-4" />
+        </Button>
+
+        {vaccine.hasPatient ? (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="cursor-not-allowed">
+                  <Button variant="outline" size="icon" disabled className="opacity-50 pointer-events-none h-8 w-8">
+                    <Trash2 className="h-4 w-4 text-red-500" />
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="top" className="bg-slate-800 text-white p-2 rounded shadow-lg">
+                <p>Não é possível excluir uma vacina associada a um paciente!</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ) : (
+          <ConfirmModal
+            title="Tem certeza?"
+            description={
+              <>
+                Essa ação não pode ser desfeita. Isso irá excluir permanentemente a vacina{" "}
+                <strong>{vaccine.name}</strong>.
+              </>
+            }
+            onConfirm={onDelete}
+            trigger={
+              <Button variant="outline" size="icon" className="h-8 w-8 hover:bg-red-50">
+                <Trash2 className="h-4 w-4 text-red-500" />
+              </Button>
+            }
+          />
+        )}
       </div>
     </div>
   );

--- a/apps/apae/src/domains/vaccines/vaccines.api.ts
+++ b/apps/apae/src/domains/vaccines/vaccines.api.ts
@@ -1,4 +1,4 @@
-import type { Vaccine } from "./vaccines.types";
+import type { Vaccine, CreateVaccineParams, UpdateVaccineParams, DeleteVaccineParams } from "./vaccines.types";
 
 const BASE_URL = "/apae-geral/api/vaccines";
 
@@ -6,4 +6,39 @@ export async function fetchVaccinesApi(): Promise<Vaccine[]> {
   const response = await fetch(BASE_URL);
   if (!response.ok) throw new Error("Ocorreu um erro ao carregar as vacinas.");
   return response.json();
+}
+
+export async function fetchVaccineApi(id: string): Promise<Vaccine> {
+  const response = await fetch(`${BASE_URL}/${id}`);
+  if (!response.ok) throw new Error("Ocorreu um erro ao carregar a vacina.");
+  return response.json();
+}
+
+export async function createVaccineApi(params: CreateVaccineParams): Promise<void> {
+  const response = await fetch(BASE_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(params),
+  });
+  if (!response.ok) throw new Error("Ocorreu um erro ao criar a vacina.");
+}
+
+export async function updateVaccineApi(params: UpdateVaccineParams): Promise<void> {
+  const { id, ...body } = params;
+  const response = await fetch(`${BASE_URL}/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) throw new Error("Ocorreu um erro ao atualizar a vacina.");
+}
+
+export async function deleteVaccineApi(params: DeleteVaccineParams): Promise<void> {
+  const response = await fetch(`${BASE_URL}/${params.id}`, {
+    method: "DELETE",
+  });
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => null);
+    throw new Error(errorData?.message || "Ocorreu um erro ao excluir a vacina.");
+  }
 }

--- a/apps/apae/src/domains/vaccines/vaccines.schema.ts
+++ b/apps/apae/src/domains/vaccines/vaccines.schema.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const createVaccineSchema = z.object({
+  name: z.string().min(1, "O nome é obrigatório."),
+});
+
+export const updateVaccineSchema = z.object({
+  name: z.string().min(1, "O nome é obrigatório."),
+});
+
+export type CreateVaccineFormData = z.infer<typeof createVaccineSchema>;
+export type UpdateVaccineFormData = z.infer<typeof updateVaccineSchema>;

--- a/apps/apae/src/domains/vaccines/vaccines.types.ts
+++ b/apps/apae/src/domains/vaccines/vaccines.types.ts
@@ -3,3 +3,16 @@ export type Vaccine = Readonly<{
   name: string;
   hasPatient: boolean;
 }>;
+
+export type CreateVaccineParams = Readonly<{
+  name: string;
+}>;
+
+export type UpdateVaccineParams = Readonly<{
+  id: string;
+  name: string;
+}>;
+
+export type DeleteVaccineParams = Readonly<{
+  id: string;
+}>;

--- a/apps/apae/src/hooks/use-vaccines.tsx
+++ b/apps/apae/src/hooks/use-vaccines.tsx
@@ -14,14 +14,61 @@ type Vaccine = Readonly<{
     hasPatient: boolean;
 }>;
 
+type CreateVaccineParams = Readonly<{
+    name: string;
+}>;
+
+type Feedback = Readonly<{
+  message: string;
+  success: boolean;
+  error: boolean;
+}>;
+
 interface VaccinesContextData {
     loading: boolean;
+    feedback: Feedback;
     vaccines: Vaccine[];
+    createVaccine: (params: CreateVaccineParams) => Promise<void>;
 }
 
 const VaccinesContext = createContext<VaccinesContextData | undefined>(
     undefined,
 );
+
+type WithFeedbackMessages = {
+    success: string;
+};
+
+function withFeedback<TArgs extends readonly unknown[], TReturn>(
+    fn: (...args: TArgs) => Promise<TReturn>,
+    setLoading: (loading: boolean) => void,
+    setFeedback: (feedback: Feedback) => void,
+    messages: WithFeedbackMessages,
+) {
+  return async (...args: TArgs): Promise<TReturn> => {
+    setLoading(true);
+    try {
+      const result = await fn(...args);
+      setFeedback({
+        message: messages.success,
+        success: true,
+        error: false,
+      });
+      return result;
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Erro desconhecido.";
+      setFeedback({
+        message,
+        success: false,
+        error: true,
+      });
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  };
+}
 
 function VaccinesProvider({
   children,
@@ -29,6 +76,11 @@ function VaccinesProvider({
   children: React.ReactNode;
 }>) {
   const [loading, setLoading] = useState<boolean>(false);
+  const [feedback, setFeedback] = useState<Feedback>({
+    message: "",
+    success: false,
+    error: false,
+  });
   const [vaccines, setVaccines] = useState<Vaccine[]>([]);
 
   const fetchVaccines = useCallback(async () => {
@@ -47,6 +99,33 @@ function VaccinesProvider({
     }
   }, []);
 
+  const createVaccine = useCallback(
+    async (params: CreateVaccineParams) => {
+      return withFeedback(
+        async (currentParams: CreateVaccineParams): Promise<void> => {
+          const response = await fetch("/apae-geral/api/vaccines", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(currentParams),
+          });
+
+          if (!response.ok) {
+            const errorData = await response.json().catch(() => null);
+            throw new Error(
+              errorData?.message || "Ocorreu um erro ao criar vacina.",
+            );
+          }
+
+          await fetchVaccines();
+        },
+        setLoading,
+        setFeedback,
+        { success: "Vacina criada com sucesso." },
+      )(params);
+    },
+    [fetchVaccines],
+  );
+
   useEffect(() => {
     fetchVaccines();
   }, [fetchVaccines]);
@@ -55,7 +134,9 @@ function VaccinesProvider({
     <VaccinesContext.Provider
       value={{
         loading,
+        feedback,
         vaccines,
+        createVaccine,
       }}
     >
       {children}
@@ -75,5 +156,7 @@ function useVaccinesContext() {
 
 export type {
   Vaccine,
+  Feedback,
+  CreateVaccineParams,
 };
 export { useVaccinesContext, VaccinesProvider };

--- a/apps/apae/src/schemas/vaccine-schemas.ts
+++ b/apps/apae/src/schemas/vaccine-schemas.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const CreateVaccine = z.object({
+  name: z.string().min(1, "O nome é obrigatório."),
+});
+
+export const UpdateVaccine = z.object({
+  name: z.string().min(1, "O nome é obrigatório."),
+});

--- a/apps/api/src/main/java/br/org/apae/api/common/dto/patient/request/vaccine/CreateVaccineDTO.java
+++ b/apps/api/src/main/java/br/org/apae/api/common/dto/patient/request/vaccine/CreateVaccineDTO.java
@@ -1,0 +1,11 @@
+package br.org.apae.api.common.dto.patient.request.vaccine;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreateVaccineDTO(
+
+        @NotBlank(message = "O nome da vacina é obrigatório.") @Size(min = 2, max = 100, message = "O nome da vacina deve ter entre 2 e 100 caracteres.") String name
+
+) {
+}

--- a/apps/api/src/main/java/br/org/apae/api/common/dto/patient/request/vaccine/UpdateVaccineDTO.java
+++ b/apps/api/src/main/java/br/org/apae/api/common/dto/patient/request/vaccine/UpdateVaccineDTO.java
@@ -1,0 +1,11 @@
+package br.org.apae.api.common.dto.patient.request.vaccine;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdateVaccineDTO(
+
+        @NotBlank(message = "O nome da vacina é obrigatório.") @Size(min = 2, max = 100, message = "O nome da vacina deve ter entre 2 e 100 caracteres.") String name
+
+) {
+}

--- a/apps/api/src/main/java/br/org/apae/api/controllers/vaccine/VaccineControllerImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/controllers/vaccine/VaccineControllerImpl.java
@@ -1,11 +1,14 @@
 package br.org.apae.api.controllers.vaccine;
 
 import br.org.apae.api.patient.application.interfaces.VaccineApplicationService;
+import br.org.apae.api.common.dto.patient.request.vaccine.CreateVaccineDTO;
+import br.org.apae.api.common.dto.patient.request.vaccine.UpdateVaccineDTO;
 import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
 import br.org.apae.api.patient.interfaces.controllers.VaccineController;
 import org.springframework.beans.factory.annotation.Autowired;
 import java.util.List;
 import java.util.UUID;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,6 +20,12 @@ public class VaccineControllerImpl implements VaccineController {
     @Autowired
     public VaccineControllerImpl(VaccineApplicationService vaccineService) {
         this.vaccineService = vaccineService;
+    }
+
+    @Override
+    public ResponseEntity<VaccineResponseDTO> createVaccine(CreateVaccineDTO vaccineDTO) {
+        VaccineResponseDTO createdVaccine = vaccineService.createVaccine(vaccineDTO);
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdVaccine);
     }
 
     @Override
@@ -35,5 +44,17 @@ public class VaccineControllerImpl implements VaccineController {
     public ResponseEntity<VaccineResponseDTO> findByName(String name) {
         VaccineResponseDTO vaccine = vaccineService.findVaccineByName(name);
         return ResponseEntity.ok(vaccine);
+    }
+
+    @Override
+    public ResponseEntity<VaccineResponseDTO> updateVaccine(UUID id, UpdateVaccineDTO vaccineDTO) {
+        VaccineResponseDTO updatedVaccine = vaccineService.updateVaccine(id, vaccineDTO);
+        return ResponseEntity.ok(updatedVaccine);
+    }
+
+    @Override
+    public ResponseEntity<Void> deleteVaccine(UUID id) {
+        vaccineService.deleteVaccine(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/apps/api/src/main/java/br/org/apae/api/patient/application/exceptions/PatientExceptionHandler.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/application/exceptions/PatientExceptionHandler.java
@@ -13,6 +13,8 @@ import br.org.apae.api.patient.domain.exceptions.PatientConflictException;
 import br.org.apae.api.patient.domain.exceptions.PatientNotFoundException;
 import br.org.apae.api.patient.domain.exceptions.RegistryNotFoundException;
 import br.org.apae.api.patient.domain.exceptions.RegistryOwnershipException;
+import br.org.apae.api.patient.domain.exceptions.VaccineConflictException;
+import br.org.apae.api.patient.domain.exceptions.VaccineInUseException;
 import br.org.apae.api.patient.domain.exceptions.VaccineMismatchException;
 import br.org.apae.api.patient.domain.exceptions.VaccineNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -146,6 +148,36 @@ public class PatientExceptionHandler {
     );
 
     return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(VaccineConflictException.class)
+  public ResponseEntity<ErrorResponse> handleVaccineConflict(
+          VaccineConflictException ex,
+          HttpServletRequest request
+  ) {
+    ErrorResponse error = new ErrorResponse(
+            HttpStatus.CONFLICT.value(),
+            HttpStatus.CONFLICT.getReasonPhrase(),
+            ex.getMessage(),
+            request.getRequestURI()
+    );
+
+    return new ResponseEntity<>(error, HttpStatus.CONFLICT);
+  }
+
+  @ExceptionHandler(VaccineInUseException.class)
+  public ResponseEntity<ErrorResponse> handleVaccineInUse(
+          VaccineInUseException ex,
+          HttpServletRequest request
+  ) {
+    ErrorResponse error = new ErrorResponse(
+            HttpStatus.CONFLICT.value(),
+            HttpStatus.CONFLICT.getReasonPhrase(),
+            ex.getMessage(),
+            request.getRequestURI()
+    );
+
+    return new ResponseEntity<>(error, HttpStatus.CONFLICT);
   }
 
   @ExceptionHandler(DisorderConflictException.class)

--- a/apps/api/src/main/java/br/org/apae/api/patient/application/interfaces/VaccineApplicationService.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/application/interfaces/VaccineApplicationService.java
@@ -4,10 +4,14 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import br.org.apae.api.common.dto.patient.request.vaccine.CreateVaccineDTO;
+import br.org.apae.api.common.dto.patient.request.vaccine.UpdateVaccineDTO;
 import br.org.apae.api.common.dto.patient.request.vaccine.VaccineNameDTO;
 import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
 
 public interface VaccineApplicationService {
+  VaccineResponseDTO createVaccine(CreateVaccineDTO dto);
+
   VaccineResponseDTO findVaccineById(UUID id);
 
   List<VaccineResponseDTO> findAllVaccines();
@@ -15,4 +19,8 @@ public interface VaccineApplicationService {
   VaccineResponseDTO findVaccineByName(String name);
 
   Set<VaccineResponseDTO> findVaccines(Set<VaccineNameDTO> vaccineNames);
+
+  VaccineResponseDTO updateVaccine(UUID id, UpdateVaccineDTO dto);
+
+  void deleteVaccine(UUID id);
 }

--- a/apps/api/src/main/java/br/org/apae/api/patient/application/internal/VaccineApplicationServiceImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/application/internal/VaccineApplicationServiceImpl.java
@@ -1,18 +1,24 @@
 package br.org.apae.api.patient.application.internal;
 
+import br.org.apae.api.patient.domain.exceptions.VaccineConflictException;
+import br.org.apae.api.patient.domain.exceptions.VaccineInUseException;
 import br.org.apae.api.patient.domain.exceptions.VaccineMismatchException;
 import br.org.apae.api.patient.domain.exceptions.VaccineNotFoundException;
 import br.org.apae.api.patient.domain.model.Vaccine;
 import br.org.apae.api.patient.domain.repository.PatientRepository;
 import br.org.apae.api.patient.domain.repository.VaccineRepository;
+import br.org.apae.api.common.dto.patient.request.vaccine.CreateVaccineDTO;
+import br.org.apae.api.common.dto.patient.request.vaccine.UpdateVaccineDTO;
 import br.org.apae.api.common.dto.patient.request.vaccine.VaccineNameDTO;
 import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import br.org.apae.api.patient.application.interfaces.VaccineApplicationService;
@@ -32,6 +38,21 @@ public class VaccineApplicationServiceImpl implements VaccineApplicationService 
         this.vaccineRepository = vaccineRepository;
         this.vaccineMapper = vaccineMapper;
         this.patientRepository = patientRepository;
+    }
+
+    @Override
+    @Transactional
+    public VaccineResponseDTO createVaccine(CreateVaccineDTO dto) {
+        Optional<Vaccine> existingVaccine = vaccineRepository.findByName(dto.name());
+
+        if (existingVaccine.isPresent()) {
+            throw new VaccineConflictException(dto.name());
+        }
+
+        Vaccine newVaccine = vaccineMapper.toEntity(dto);
+        Vaccine vaccineSaved = vaccineRepository.save(newVaccine);
+
+        return vaccineMapper.toResponseDTO(vaccineSaved);
     }
 
     @Override
@@ -77,5 +98,40 @@ public class VaccineApplicationServiceImpl implements VaccineApplicationService 
         }
 
         return vaccineMapper.toResponseDTOSet(vaccines);
+    }
+
+    @Override
+    @Transactional
+    public VaccineResponseDTO updateVaccine(UUID id, UpdateVaccineDTO dto) {
+        Vaccine vaccineToUpdate = vaccineRepository.findById(id)
+                .orElseThrow(VaccineNotFoundException::new);
+
+        if (vaccineRepository.existsByNameIgnoreCaseAndIdNot(dto.name(), id)) {
+            throw new VaccineConflictException(dto.name());
+        }
+
+        vaccineToUpdate.updateName(dto.name());
+        Vaccine vaccineUpdated = vaccineRepository.save(vaccineToUpdate);
+
+        return vaccineMapper.toResponseDTO(vaccineUpdated);
+    }
+
+    @Override
+    @Transactional
+    public void deleteVaccine(UUID id) {
+        if (!vaccineRepository.existsById(id)) {
+            throw new VaccineNotFoundException();
+        }
+
+        if (patientRepository.isVaccineInUse(id)) {
+            throw new VaccineInUseException();
+        }
+
+        try {
+            vaccineRepository.deleteById(id);
+            vaccineRepository.flush();
+        } catch (DataIntegrityViolationException e) {
+            throw new VaccineInUseException();
+        }
     }
 }

--- a/apps/api/src/main/java/br/org/apae/api/patient/application/mappers/VaccineMapper.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/application/mappers/VaccineMapper.java
@@ -1,5 +1,6 @@
 package br.org.apae.api.patient.application.mappers;
 
+import br.org.apae.api.common.dto.patient.request.vaccine.CreateVaccineDTO;
 import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
 import br.org.apae.api.patient.domain.model.Vaccine;
 
@@ -10,6 +11,10 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class VaccineMapper {
+
+    public Vaccine toEntity(CreateVaccineDTO dto) {
+        return new Vaccine(dto.name());
+    }
 
     public Set<Vaccine> toEntitySetFromResponse(Set<VaccineResponseDTO> responseDTOs) {
         return responseDTOs.stream()

--- a/apps/api/src/main/java/br/org/apae/api/patient/domain/exceptions/VaccineConflictException.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/domain/exceptions/VaccineConflictException.java
@@ -1,0 +1,13 @@
+package br.org.apae.api.patient.domain.exceptions;
+
+public class VaccineConflictException extends RuntimeException {
+    private static final String MESSAGE = "Vacina já existe.";
+
+    public VaccineConflictException() {
+        super(MESSAGE);
+    }
+
+    public VaccineConflictException(String name) {
+        super("Já existe uma vacina com o nome: " + name);
+    }
+}

--- a/apps/api/src/main/java/br/org/apae/api/patient/domain/exceptions/VaccineInUseException.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/domain/exceptions/VaccineInUseException.java
@@ -1,0 +1,9 @@
+package br.org.apae.api.patient.domain.exceptions;
+
+public class VaccineInUseException extends RuntimeException {
+    private static final String MESSAGE = "Não é possível excluir esta vacina, pois ela está vinculada a um ou mais pacientes.";
+
+    public VaccineInUseException() {
+        super(MESSAGE);
+    }
+}

--- a/apps/api/src/main/java/br/org/apae/api/patient/domain/repository/VaccineRepository.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/domain/repository/VaccineRepository.java
@@ -14,4 +14,6 @@ public interface VaccineRepository extends JpaRepository<Vaccine, UUID> {
     Optional<Vaccine> findByName(String name);
 
     Set<Vaccine> findByNameInIgnoreCase(Collection<String> names);
+
+    boolean existsByNameIgnoreCaseAndIdNot(String name, UUID id);
 }

--- a/apps/api/src/main/java/br/org/apae/api/patient/interfaces/controllers/VaccineController.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/interfaces/controllers/VaccineController.java
@@ -1,18 +1,30 @@
 package br.org.apae.api.patient.interfaces.controllers;
 
+import br.org.apae.api.common.dto.patient.request.vaccine.CreateVaccineDTO;
+import br.org.apae.api.common.dto.patient.request.vaccine.UpdateVaccineDTO;
 import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.UUID;
 
 @RequestMapping("/vaccines")
-@Tag(name = "Vaccines", description = "Endpoints para consulta de vacinas")
+@Tag(name = "Vaccines", description = "Endpoints para gerenciamento de vacinas")
 public interface VaccineController {
+
+        @Operation(summary = "Cadastrar uma nova vacina", description = "Cria uma nova vacina no sistema.")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "201", description = "Vacina cadastrada com sucesso"),
+                        @ApiResponse(responseCode = "400", description = "Dados inválidos fornecidos"),
+                        @ApiResponse(responseCode = "409", description = "Já existe uma vacina com este nome")
+        })
+        @PostMapping
+        ResponseEntity<VaccineResponseDTO> createVaccine(@RequestBody @Valid CreateVaccineDTO vaccineDTO);
 
         @Operation(summary = "Buscar vacina por ID", description = "Retorna os dados de uma vacina específica pelo seu ID.")
         @ApiResponses(value = {
@@ -36,4 +48,24 @@ public interface VaccineController {
         })
         @GetMapping("/search/by-name")
         ResponseEntity<VaccineResponseDTO> findByName(@RequestParam String name);
+
+        @Operation(summary = "Atualizar uma vacina", description = "Atualiza os dados de uma vacina existente a partir do seu ID.")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "Vacina atualizada com sucesso"),
+                        @ApiResponse(responseCode = "400", description = "Dados inválidos fornecidos"),
+                        @ApiResponse(responseCode = "404", description = "Vacina não encontrada"),
+                        @ApiResponse(responseCode = "409", description = "O nome informado já está em uso por outra vacina")
+        })
+        @PutMapping("/{id}")
+        ResponseEntity<VaccineResponseDTO> updateVaccine(@PathVariable UUID id,
+                        @RequestBody @Valid UpdateVaccineDTO vaccineDTO);
+
+        @Operation(summary = "Excluir uma vacina", description = "Remove uma vacina do sistema a partir do seu ID.")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "204", description = "Vacina excluída com sucesso"),
+                        @ApiResponse(responseCode = "404", description = "Vacina não encontrada"),
+                        @ApiResponse(responseCode = "409", description = "Vacina está vinculada a um paciente")
+        })
+        @DeleteMapping("/{id}")
+        ResponseEntity<Void> deleteVaccine(@PathVariable UUID id);
 }

--- a/apps/api/src/test/java/br/org/apae/api/controllers/vaccine/VaccineControllerTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/vaccine/VaccineControllerTest.java
@@ -3,11 +3,16 @@ package br.org.apae.api.controllers.vaccine;
 import br.org.apae.api.auth.application.internal.UserService;
 import br.org.apae.api.auth.infrastructure.security.JwtProvider;
 import br.org.apae.api.auth.infrastructure.security.SecurityConfiguration;
+import br.org.apae.api.common.dto.patient.request.vaccine.CreateVaccineDTO;
+import br.org.apae.api.common.dto.patient.request.vaccine.UpdateVaccineDTO;
 import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
 import br.org.apae.api.common.exceptions.handler.GlobalExceptionHandler;
 import br.org.apae.api.helpers.AuthTestHelper;
 import br.org.apae.api.patient.application.interfaces.VaccineApplicationService;
+import br.org.apae.api.patient.domain.exceptions.VaccineConflictException;
+import br.org.apae.api.patient.domain.exceptions.VaccineInUseException;
 import br.org.apae.api.patient.domain.exceptions.VaccineNotFoundException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,6 +61,9 @@ public class VaccineControllerTest {
  @Autowired
  private MockMvc mockMvc;
 
+ @Autowired
+ private ObjectMapper objectMapper;
+
  @MockitoBean
  private VaccineApplicationService vaccineService;
 
@@ -75,6 +83,56 @@ public class VaccineControllerTest {
  @AfterEach
  void tearDown() {
   Mockito.reset(vaccineService, jwtProvider, userService);
+ }
+
+ @Nested
+ @DisplayName("Cenários de Criação (POST)")
+ class Criacao {
+  @Test
+  @DisplayName("Deve criar vacina com sucesso (201)")
+  void shouldCreateVaccineSuccess() throws Exception {
+   CreateVaccineDTO requestDto = new CreateVaccineDTO("BCG");
+   UUID idGerado = UUID.randomUUID();
+   VaccineResponseDTO responseDto = new VaccineResponseDTO(idGerado, requestDto.name(), false);
+
+   when(vaccineService.createVaccine(requestDto)).thenReturn(responseDto);
+
+   mockMvc.perform(post(BASE_URL).header("Authorization", AuthTestHelper.bearerToken())
+       .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(requestDto)).accept(MediaType.APPLICATION_JSON))
+     .andExpect(status().isCreated())
+     .andExpect(jsonPath("$.id").value(idGerado.toString()))
+     .andExpect(jsonPath("$.name").value(requestDto.name()));
+  }
+
+  @Test
+  @DisplayName("Deve retornar Conflict (409) ao tentar criar vacina com nome duplicado")
+  void shouldReturnConflictWhenCreateVaccineWithDuplicateName() throws Exception {
+   CreateVaccineDTO requestDto = new CreateVaccineDTO("Vacina Duplicada");
+
+   when(vaccineService.createVaccine(requestDto)).thenThrow(new VaccineConflictException(requestDto.name()));
+
+   mockMvc.perform(post(BASE_URL).header("Authorization", AuthTestHelper.bearerToken())
+       .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(requestDto)).accept(MediaType.APPLICATION_JSON))
+     .andExpect(status().isConflict());
+  }
+
+  @Test
+  @DisplayName("Deve retornar BadRequest (400) ao tentar criar vacina com nome nulo")
+  void shouldReturnBadRequestWhenCreateVaccineWithNullName() throws Exception {
+   CreateVaccineDTO requestDto = new CreateVaccineDTO(null);
+   mockMvc.perform(post(BASE_URL).header("Authorization", AuthTestHelper.bearerToken())
+       .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(requestDto)).accept(MediaType.APPLICATION_JSON))
+     .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("Deve retornar BadRequest (400) ao tentar criar vacina com nome em branco")
+  void shouldReturnBadRequestWhenCreateVaccineWithBlankName() throws Exception {
+   CreateVaccineDTO requestDto = new CreateVaccineDTO("");
+   mockMvc.perform(post(BASE_URL).header("Authorization", AuthTestHelper.bearerToken())
+       .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(requestDto)).accept(MediaType.APPLICATION_JSON))
+     .andExpect(status().isBadRequest());
+  }
  }
 
  @Nested
@@ -134,6 +192,102 @@ public class VaccineControllerTest {
    when(vaccineService.findVaccineByName(name)).thenThrow(new VaccineNotFoundException(name));
    mockMvc.perform(get(BASE_URL + "/search/by-name").header("Authorization", AuthTestHelper.bearerToken()).param("name", name).accept(MediaType.APPLICATION_JSON))
      .andExpect(status().isNotFound());
+  }
+ }
+
+ @Nested
+ @DisplayName("Cenários de Atualização (PUT)")
+ class Atualizacao {
+  @Test
+  @DisplayName("Deve atualizar vacina com sucesso (200)")
+  void shouldUpdateVaccineSuccess() throws Exception {
+   UUID id = UUID.randomUUID();
+   UpdateVaccineDTO updateDto = new UpdateVaccineDTO("Vacina Atualizada");
+   VaccineResponseDTO responseDto = new VaccineResponseDTO(id, updateDto.name(), false);
+
+   when(vaccineService.updateVaccine(id, updateDto)).thenReturn(responseDto);
+
+   mockMvc.perform(put(BASE_URL + "/{id}", id).header("Authorization", AuthTestHelper.bearerToken())
+       .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(updateDto)).accept(MediaType.APPLICATION_JSON))
+     .andExpect(status().isOk())
+     .andExpect(jsonPath("$.name").value(updateDto.name()));
+  }
+
+  @Test
+  @DisplayName("Deve retornar NotFound (404) ao tentar atualizar vacina inexistente")
+  void shouldReturnNotFoundWhenUpdateVaccineNonExistent() throws Exception {
+   UUID id = UUID.randomUUID();
+   UpdateVaccineDTO updateDto = new UpdateVaccineDTO("Nome qualquer");
+
+   when(vaccineService.updateVaccine(id, updateDto)).thenThrow(new VaccineNotFoundException());
+
+   mockMvc.perform(put(BASE_URL + "/{id}", id).header("Authorization", AuthTestHelper.bearerToken())
+       .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(updateDto)).accept(MediaType.APPLICATION_JSON))
+     .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("Deve retornar Conflict (409) ao tentar atualizar vacina gerando nome duplicado")
+  void shouldReturnConflictWhenUpdateVaccineWithDuplicateName() throws Exception {
+   UUID id = UUID.randomUUID();
+   UpdateVaccineDTO updateDto = new UpdateVaccineDTO("Nome Já Existe");
+
+   when(vaccineService.updateVaccine(id, updateDto)).thenThrow(new VaccineConflictException(updateDto.name()));
+
+   mockMvc.perform(put(BASE_URL + "/{id}", id).header("Authorization", AuthTestHelper.bearerToken())
+       .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(updateDto)).accept(MediaType.APPLICATION_JSON))
+     .andExpect(status().isConflict());
+  }
+
+  @Test
+  @DisplayName("Deve retornar BadRequest (400) ao tentar atualizar vacina com nome nulo")
+  void shouldReturnBadRequestWhenUpdateVaccineWithNullName() throws Exception {
+   UUID id = UUID.randomUUID();
+   UpdateVaccineDTO updateDto = new UpdateVaccineDTO(null);
+   mockMvc.perform(put(BASE_URL + "/{id}", id).header("Authorization", AuthTestHelper.bearerToken())
+       .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(updateDto)).accept(MediaType.APPLICATION_JSON))
+     .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("Deve retornar BadRequest (400) ao tentar atualizar vacina com nome em branco")
+  void shouldReturnBadRequestWhenUpdateVaccineWithBlankName() throws Exception {
+   UUID id = UUID.randomUUID();
+   UpdateVaccineDTO updateDto = new UpdateVaccineDTO("");
+   mockMvc.perform(put(BASE_URL + "/{id}", id).header("Authorization", AuthTestHelper.bearerToken())
+       .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(updateDto)).accept(MediaType.APPLICATION_JSON))
+     .andExpect(status().isBadRequest());
+  }
+ }
+
+ @Nested
+ @DisplayName("Cenários de Exclusão (DELETE)")
+ class Exclusao {
+  @Test
+  @DisplayName("Deve deletar vacina com sucesso (204)")
+  void shouldRemoveVaccineSuccess() throws Exception {
+   UUID id = UUID.randomUUID();
+   mockMvc.perform(delete(BASE_URL + "/{id}", id).header("Authorization", AuthTestHelper.bearerToken()))
+     .andExpect(status().isNoContent());
+   verify(vaccineService).deleteVaccine(id);
+  }
+
+  @Test
+  @DisplayName("Deve retornar NotFound (404) ao tentar deletar vacina inexistente")
+  void shouldReturnNotFoundWhenDeleteVaccineNonExistent() throws Exception {
+   UUID id = UUID.randomUUID();
+   doThrow(new VaccineNotFoundException()).when(vaccineService).deleteVaccine(id);
+   mockMvc.perform(delete(BASE_URL + "/{id}", id).header("Authorization", AuthTestHelper.bearerToken()))
+     .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("Deve retornar Conflict (409) ao tentar deletar vacina vinculada a paciente")
+  void shouldReturnConflictWhenDeleteVaccineInUse() throws Exception {
+   UUID id = UUID.randomUUID();
+   doThrow(new VaccineInUseException()).when(vaccineService).deleteVaccine(id);
+   mockMvc.perform(delete(BASE_URL + "/{id}", id).header("Authorization", AuthTestHelper.bearerToken()))
+     .andExpect(status().isConflict());
   }
  }
 


### PR DESCRIPTION
# O que mudou?

As funcionalidades de escrita do módulo de vacinas (criar, editar, excluir) haviam sido removidas propositalmente da branch de treinamento para servir de exercício. Este PR reconstrói o CRUD completo seguindo o guia `docs/docs-vaccines/REBUILD_VACCINES_CRUD.md`, usando o domínio de transtornos (`disorders`) como referência de arquitetura. A listagem, a busca por nome e a entidade `Vaccine` não foram alteradas.

## Tarefas Relacionadas

* Issue: https://github.com/IFPBEsp/APAE/issues/874
* Outras dependências: nenhuma

## Mudanças Realizadas

* **Backend**: recriados `CreateVaccineDTO`/`UpdateVaccineDTO`, exceções `VaccineConflictException`/`VaccineInUseException` (ambas mapeadas para `409 CONFLICT`), método `existsByNameIgnoreCaseAndIdNot` no repositório, e os endpoints `POST /vaccines`, `PUT /vaccines/{id}` e `DELETE /vaccines/{id}` no service e controller.
* **Backend (testes)**: adicionados casos de teste para criação, atualização e exclusão (sucesso, nome duplicado, validação, não encontrado, vacina em uso) em `VaccineControllerTest`.
* **Frontend**: reconstruído o domínio `domains/vaccines` (formulários de criação/edição, listagem com ações de editar/excluir, confirmação de exclusão e bloqueio quando a vacina está vinculada a um paciente), páginas `/vaccines/new` e `/vaccines/[id]/edit`, e as rotas proxy `POST /api/vaccines` e `GET/PUT/DELETE /api/vaccines/[id]`.
* **Frontend**: restaurada a criação rápida de vacina no cadastro de paciente (`CreateVaccineDialog` + integração no formulário de informações adicionais).

## Evidências: 

Estão comentadas na issue.