### PR TITLE
[TREINAMENTO] CRUD de Vacinas — João Victor Lucena

### DIFF
--- a/apps/apae/src/app/api/vaccines/[id]/route.ts
+++ b/apps/apae/src/app/api/vaccines/[id]/route.ts
@@ -1,0 +1,66 @@
+import { createBaseApi } from "@/lib/axios";
+import { NextResponse } from "next/server";
+import { AxiosError } from "axios";
+import { updateVaccineSchema } from "@/domains/vaccines/vaccines.schema";
+
+interface IParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function GET(request: Request, { params }: IParams) {
+  try {
+    const { id } = await params;
+    const api = await createBaseApi();
+    const { data } = await api.get(`/vaccines/${id}`);
+    return NextResponse.json(data);
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      return new NextResponse(
+        JSON.stringify(error.response?.data || { message: error.message }),
+        { status: error.response?.status || 500 }
+      );
+    }
+    return new NextResponse(JSON.stringify({ message: "Erro ao buscar vacina." }), { status: 500 });
+  }
+}
+
+export async function PUT(request: Request, { params }: IParams) {
+  try {
+    const { id } = await params;
+    const body = await request.json();
+
+    const validation = updateVaccineSchema.safeParse(body);
+    if (!validation.success) {
+      return NextResponse.json({ errors: validation.error.flatten() }, { status: 400 });
+    }
+
+    const api = await createBaseApi();
+    const { data } = await api.put(`/vaccines/${id}`, validation.data);
+    return NextResponse.json(data);
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      return new NextResponse(
+        JSON.stringify(error.response?.data || { message: error.message }),
+        { status: error.response?.status || 500 }
+      );
+    }
+    return new NextResponse(JSON.stringify({ message: "Erro ao atualizar vacina." }), { status: 500 });
+  }
+}
+
+export async function DELETE(request: Request, { params }: IParams) {
+  try {
+    const { id } = await params;
+    const api = await createBaseApi();
+    await api.delete(`/vaccines/${id}`);
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      return new NextResponse(
+        JSON.stringify(error.response?.data || { message: error.message }),
+        { status: error.response?.status || 500 }
+      );
+    }
+    return new NextResponse(JSON.stringify({ message: "Erro ao excluir vacina." }), { status: 500 });
+  }
+}

--- a/apps/apae/src/app/api/vaccines/route.ts
+++ b/apps/apae/src/app/api/vaccines/route.ts
@@ -1,15 +1,50 @@
 import { createBaseApi } from "@/lib/axios";
 import { NextResponse } from "next/server";
+import { AxiosError } from "axios";
+import { createVaccineSchema } from "@/domains/vaccines/vaccines.schema";
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+
+    const validation = createVaccineSchema.safeParse(body);
+    if (!validation.success) {
+      return new NextResponse(
+        JSON.stringify({
+          message: "Dados inválidos.",
+          errors: validation.error.flatten().fieldErrors,
+        }),
+        { status: 400 }
+      );
+    }
+
+    const api = await createBaseApi();
+    const { data } = await api.post("/vaccines", validation.data);
+    return NextResponse.json(data, { status: 201 });
+
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      return new NextResponse(
+        JSON.stringify(error.response?.data || { message: error.message }),
+        { status: error.response?.status || 500 }
+      );
+    }
+    return new NextResponse(JSON.stringify({ message: "Erro inesperado ao criar vacina." }), { status: 500 });
+  }
+}
 
 export async function GET() {
-    try {
-        const api = await createBaseApi();
-        const { data } = await api.get("/vaccines");
-        return NextResponse.json(data);
-    } catch (error) {
-        const message = error instanceof Error ? error.message : "Erro desconhecido";
-        console.error("Erro ao buscar vacinas:", message);
-        return NextResponse.json({ message: "Erro ao buscar a lista de vacinas." }, { status: 500 }
-        );
+  try {
+    const api = await createBaseApi();
+    const { data } = await api.get("/vaccines");
+    return NextResponse.json(data);
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      return new NextResponse(
+        JSON.stringify(error.response?.data || { message: error.message }),
+        { status: error.response?.status || 500 }
+      );
     }
+    return new NextResponse(JSON.stringify({ message: "Erro ao buscar a lista de vacinas." }), { status: 500 });
+  }
 }

--- a/apps/apae/src/app/vaccines/[id]/edit/page.tsx
+++ b/apps/apae/src/app/vaccines/[id]/edit/page.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { VaccineEditForm } from "@/domains/vaccines/edit/vaccine-form";
+
+export default function EditVaccinePage() {
+  const params = useParams();
+  const id = typeof params.id === "string" ? params.id : "";
+  return <VaccineEditForm id={id} />;
+}

--- a/apps/apae/src/app/vaccines/new/page.tsx
+++ b/apps/apae/src/app/vaccines/new/page.tsx
@@ -1,0 +1,5 @@
+import { VaccineCreateForm } from "@/domains/vaccines/create/vaccine-form";
+
+export default function NewVaccinePage() {
+  return <VaccineCreateForm />;
+}

--- a/apps/apae/src/domains/vaccines/create/use-vaccine-create.ts
+++ b/apps/apae/src/domains/vaccines/create/use-vaccine-create.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "react-toastify";
+import { createVaccineApi } from "../vaccines.api";
+import type { CreateVaccineParams } from "../vaccines.types";
+
+export function useVaccineCreate() {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const router = useRouter();
+
+  const createVaccine = async (params: CreateVaccineParams) => {
+    try {
+      setIsSubmitting(true);
+      await createVaccineApi(params);
+      toast.success("Vacina criada com sucesso.");
+      router.push("/vaccines");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Erro ao criar vacina.";
+      toast.error(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return { createVaccine, isSubmitting };
+}

--- a/apps/apae/src/domains/vaccines/create/vaccine-form.tsx
+++ b/apps/apae/src/domains/vaccines/create/vaccine-form.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ArrowLeft } from "lucide-react";
+import { capitalizeFirst } from "@/lib/formats";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { createVaccineSchema, type CreateVaccineFormData } from "../vaccines.schema";
+import { useVaccineCreate } from "./use-vaccine-create";
+
+export function VaccineCreateForm() {
+  const router = useRouter();
+  const { createVaccine, isSubmitting } = useVaccineCreate();
+
+  const form = useForm<CreateVaccineFormData>({
+    resolver: zodResolver(createVaccineSchema),
+    mode: "onChange",
+    defaultValues: { name: "" },
+  });
+
+  const onSubmit = async (data: CreateVaccineFormData) => {
+    await createVaccine(data);
+  };
+
+  return (
+    <div className="!bg-slate-100 min-h-screen">
+      <main className="container mx-auto p-4 md:p-6">
+        <div className="bg-white rounded-xl shadow-md border-2 p-6 mb-4">
+          <Button variant="ghost" onClick={() => router.back()} className="mb-4 text-sm text-[#003B93] hover:bg-blue-50">
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Voltar
+          </Button>
+
+          <h1 className="text-2xl font-bold mb-6 text-[#003B93]">Nova Vacina</h1>
+
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel className="font-semibold text-[#003B93]">Nome da Vacina</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="Ex: Hepatite B"
+                        {...field}
+                        onChange={(e) => field.onChange(capitalizeFirst(e.target.value))}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <div className="flex justify-end gap-2 pt-4">
+                <Button type="button" variant="outline" onClick={() => router.back()}>Cancelar</Button>
+                <Button type="submit" disabled={isSubmitting} className="!bg-[#0D4F97] !hover:bg-[#0b427d] text-white">
+                  {isSubmitting ? "Salvando..." : "Salvar"}
+                </Button>
+              </div>
+            </form>
+          </Form>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/apae/src/domains/vaccines/edit/use-vaccine-edit.ts
+++ b/apps/apae/src/domains/vaccines/edit/use-vaccine-edit.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "react-toastify";
+import { fetchVaccineApi, updateVaccineApi } from "../vaccines.api";
+import type { Vaccine, UpdateVaccineParams } from "../vaccines.types";
+
+export function useVaccineEdit(id: string) {
+  const [vaccine, setVaccine] = useState<Vaccine | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!id) return;
+    const load = async () => {
+      try {
+        const data = await fetchVaccineApi(id);
+        setVaccine(data);
+      } catch {
+        toast.error("Erro ao carregar a vacina.");
+        router.push("/vaccines");
+      }
+    };
+    load();
+  }, [id, router]);
+
+  const updateVaccine = async (params: UpdateVaccineParams) => {
+    try {
+      setIsSubmitting(true);
+      await updateVaccineApi(params);
+      toast.success("Vacina atualizada com sucesso.");
+      router.push("/vaccines");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Erro ao atualizar vacina.";
+      toast.error(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return { vaccine, updateVaccine, isSubmitting };
+}

--- a/apps/apae/src/domains/vaccines/edit/vaccine-form.tsx
+++ b/apps/apae/src/domains/vaccines/edit/vaccine-form.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ArrowLeft, Loader2 } from "lucide-react";
+import { capitalizeFirst } from "@/lib/formats";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { updateVaccineSchema, type UpdateVaccineFormData } from "../vaccines.schema";
+import { useVaccineEdit } from "./use-vaccine-edit";
+
+interface VaccineEditFormProps {
+  id: string;
+}
+
+export function VaccineEditForm({ id }: VaccineEditFormProps) {
+  const router = useRouter();
+  const { vaccine, updateVaccine, isSubmitting } = useVaccineEdit(id);
+
+  const form = useForm<UpdateVaccineFormData>({
+    resolver: zodResolver(updateVaccineSchema),
+    mode: "onChange",
+    defaultValues: { name: "" },
+  });
+
+  useEffect(() => {
+    if (vaccine) form.reset({ name: vaccine.name });
+  }, [vaccine, form]);
+
+  const onSubmit = async (data: UpdateVaccineFormData) => {
+    await updateVaccine({ id, name: data.name });
+  };
+
+  if (!vaccine) {
+    return (
+      <div className="flex justify-center items-center p-10">
+        <Loader2 className="h-8 w-8 animate-spin text-gray-500" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="!bg-slate-100 min-h-screen">
+      <main className="container mx-auto p-4 md:p-6">
+        <div className="bg-white rounded-xl shadow-md border-2 p-6 mb-4">
+          <Button variant="ghost" onClick={() => router.back()} className="mb-4 text-sm text-[#003B93] hover:bg-blue-50">
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Voltar
+          </Button>
+
+          <h1 className="text-2xl font-bold mb-6 text-[#003B93]">Editar Vacina</h1>
+
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel className="font-semibold text-[#003B93]">Nome da Vacina</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="Ex: Hepatite B"
+                        {...field}
+                        onChange={(e) => field.onChange(capitalizeFirst(e.target.value))}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <div className="flex justify-end gap-2 pt-4">
+                <Button type="button" variant="outline" onClick={() => router.back()}>Cancelar</Button>
+                <Button type="submit" disabled={isSubmitting} className="!bg-[#0D4F97] !hover:bg-[#0b427d] text-white">
+                  {isSubmitting ? "Atualizando..." : "Atualizar"}
+                </Button>
+              </div>
+            </form>
+          </Form>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/apae/src/domains/vaccines/list/use-vaccines-list.ts
+++ b/apps/apae/src/domains/vaccines/list/use-vaccines-list.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "react-toastify";
-import { fetchVaccinesApi } from "../vaccines.api";
+import { fetchVaccinesApi, deleteVaccineApi } from "../vaccines.api";
 import type { Vaccine } from "../vaccines.types";
 
 export function useVaccinesList() {
@@ -22,9 +22,21 @@ export function useVaccinesList() {
     }
   }, []);
 
+  const deleteVaccine = useCallback(async (id: string) => {
+    try {
+      await deleteVaccineApi({ id });
+      toast.success("Vacina excluída com sucesso.");
+      await loadVaccines();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Erro ao excluir vacina.";
+      toast.error(message);
+    }
+  }, [loadVaccines]);
+
   useEffect(() => {
     loadVaccines();
   }, [loadVaccines]);
 
-  return { vaccines, loading };
+  return { vaccines, loading, deleteVaccine };
 }
+

--- a/apps/apae/src/domains/vaccines/list/vaccines-list.tsx
+++ b/apps/apae/src/domains/vaccines/list/vaccines-list.tsx
@@ -1,16 +1,17 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { SearchFilters } from "@/components/search-filters";
-import { ArrowLeft, Loader2 } from "lucide-react";
+import { ArrowLeft, Loader2, Plus } from "lucide-react";
 import { VaccineListItem } from "../shared/vaccine-list-item";
 import { useVaccinesList } from "./use-vaccines-list";
 
 export function VaccinesList() {
   const [searchName, setSearchName] = useState("");
-  const { vaccines, loading } = useVaccinesList();
+  const { vaccines, loading, deleteVaccine } = useVaccinesList();
   const router = useRouter();
 
   const filtered = vaccines.filter((v) =>
@@ -23,7 +24,7 @@ export function VaccinesList() {
         <Button
           variant="ghost"
           onClick={() => router.push("/patients")}
-          className="mb-4 text-sm text-[#003B93] hover:bg-blue-50" 
+          className="mb-4 text-sm text-[#003B93] hover:bg-blue-50"
         >
           <ArrowLeft className="h-4 w-4 mr-2"/>
             Voltar
@@ -35,6 +36,9 @@ export function VaccinesList() {
         <section className="relative md:bg-white md:rounded-xl md:shadow-md md:border-2 md:p-6">
           <div className="hidden md:flex justify-between items-center mb-4">
             <h2 className="text-xl font-bold text-[#003B93]">Vacinas Cadastradas</h2>
+            <Button asChild className="!bg-[#0D4F97] !hover:bg-[#0b427d] text-white">
+              <Link href="/vaccines/new">Adicionar</Link>
+            </Button>
           </div>
 
           <div className="mb-4 md:hidden">
@@ -57,6 +61,8 @@ export function VaccinesList() {
                   <VaccineListItem
                     key={vaccine.id}
                     vaccine={vaccine}
+                    onEdit={() => router.push(`/vaccines/${vaccine.id}/edit`)}
+                    onDelete={() => deleteVaccine(vaccine.id)}
                   />
                 ))}
               </div>
@@ -64,6 +70,17 @@ export function VaccinesList() {
           )}
         </section>
       </main>
+
+      <Button
+        asChild
+        className="fixed bottom-6 right-6 h-[53px] w-[53px] rounded-full shadow-lg md:hidden bg-[#0D4F97] hover:bg-[#0b427d]"
+      >
+        <Link href="/vaccines/new">
+          <Plus className="h-7 w-7" />
+          <span className="sr-only">Adicionar Vacina</span>
+        </Link>
+      </Button>
     </div>
   );
 }
+

--- a/apps/apae/src/domains/vaccines/shared/vaccine-list-item.tsx
+++ b/apps/apae/src/domains/vaccines/shared/vaccine-list-item.tsx
@@ -1,17 +1,67 @@
 "use client";
 
+import { Button } from "@/components/ui/button";
+import { ConfirmModal } from "@/components/ui/confirm-modal";
+import { Edit, Trash2 } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@radix-ui/react-tooltip";
 import type { Vaccine } from "../vaccines.types";
 
 interface VaccineListItemProps {
   vaccine: Vaccine;
+  onEdit: () => void;
+  onDelete: () => void;
 }
 
-export function VaccineListItem({ vaccine }: VaccineListItemProps) {
+export function VaccineListItem({ vaccine, onEdit, onDelete }: VaccineListItemProps) {
   return (
-    <div className="flex items-center p-4 border-b hover:bg-gray-50 transition-colors">
+    <div className="flex items-center justify-between p-4 border-b hover:bg-gray-50 transition-colors">
       <div className="flex-1">
         <h3 className="font-bold text-base text-[#003B93]">{vaccine.name}</h3>
+      </div>
+      <div className="flex items-center gap-2 ml-4">
+        <Button variant="outline" size="icon" className="h-8 w-8" onClick={onEdit} aria-label="Editar">
+          <Edit className="h-4 w-4" />
+        </Button>
+
+        {vaccine.hasPatient ? (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="cursor-not-allowed">
+                  <Button variant="outline" size="icon" disabled className="opacity-50 pointer-events-none h-8 w-8">
+                    <Trash2 className="h-4 w-4 text-red-500" />
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="top" className="bg-slate-800 text-white p-2 rounded shadow-lg">
+                <p>Não é possível excluir uma vacina associada a um paciente!</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ) : (
+          <ConfirmModal
+            title="Tem certeza?"
+            description={
+              <>
+                Essa ação não pode ser desfeita. Isso irá excluir permanentemente a vacina{" "}
+                <strong>{vaccine.name}</strong>.
+              </>
+            }
+            onConfirm={onDelete}
+            trigger={
+              <Button variant="outline" size="icon" className="h-8 w-8 hover:bg-red-50">
+                <Trash2 className="h-4 w-4 text-red-500" />
+              </Button>
+            }
+          />
+        )}
       </div>
     </div>
   );
 }
+

--- a/apps/apae/src/domains/vaccines/vaccines.api.ts
+++ b/apps/apae/src/domains/vaccines/vaccines.api.ts
@@ -1,4 +1,4 @@
-import type { Vaccine } from "./vaccines.types";
+import type { Vaccine, CreateVaccineParams, UpdateVaccineParams, DeleteVaccineParams } from "./vaccines.types";
 
 const BASE_URL = "/apae-geral/api/vaccines";
 
@@ -6,4 +6,39 @@ export async function fetchVaccinesApi(): Promise<Vaccine[]> {
   const response = await fetch(BASE_URL);
   if (!response.ok) throw new Error("Ocorreu um erro ao carregar as vacinas.");
   return response.json();
+}
+
+export async function fetchVaccineApi(id: string): Promise<Vaccine> {
+  const response = await fetch(`${BASE_URL}/${id}`);
+  if (!response.ok) throw new Error("Ocorreu um erro ao carregar a vacina.");
+  return response.json();
+}
+
+export async function createVaccineApi(params: CreateVaccineParams): Promise<void> {
+  const response = await fetch(BASE_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(params),
+  });
+  if (!response.ok) throw new Error("Ocorreu um erro ao criar a vacina.");
+}
+
+export async function updateVaccineApi(params: UpdateVaccineParams): Promise<void> {
+  const { id, ...body } = params;
+  const response = await fetch(`${BASE_URL}/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) throw new Error("Ocorreu um erro ao atualizar a vacina.");
+}
+
+export async function deleteVaccineApi(params: DeleteVaccineParams): Promise<void> {
+  const response = await fetch(`${BASE_URL}/${params.id}`, {
+    method: "DELETE",
+  });
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => null);
+    throw new Error(errorData?.message || "Ocorreu um erro ao excluir a vacina.");
+  }
 }

--- a/apps/apae/src/domains/vaccines/vaccines.schema.ts
+++ b/apps/apae/src/domains/vaccines/vaccines.schema.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+export const vaccineSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  hasPatient: z.boolean(),
+});
+
+export const createVaccineSchema = z.object({
+  name: z
+    .string()
+    .min(2, "O nome deve ter no mínimo 2 caracteres.")
+    .max(100, "O nome deve ter no máximo 100 caracteres."),
+});
+
+export const updateVaccineSchema = z.object({
+  name: z
+    .string()
+    .min(2, "O nome deve ter no mínimo 2 caracteres.")
+    .max(100, "O nome deve ter no máximo 100 caracteres."),
+});
+
+export type CreateVaccineFormData = z.infer<typeof createVaccineSchema>;
+export type UpdateVaccineFormData = z.infer<typeof updateVaccineSchema>;

--- a/apps/apae/src/domains/vaccines/vaccines.types.ts
+++ b/apps/apae/src/domains/vaccines/vaccines.types.ts
@@ -3,3 +3,16 @@ export type Vaccine = Readonly<{
   name: string;
   hasPatient: boolean;
 }>;
+
+export type CreateVaccineParams = Readonly<{
+  name: string;
+}>;
+
+export type UpdateVaccineParams = Readonly<{
+  id: string;
+  name: string;
+}>;
+
+export type DeleteVaccineParams = Readonly<{
+  id: string;
+}>;

--- a/apps/api/src/main/java/br/org/apae/api/common/dto/patient/request/vaccine/UpdateVaccineDTO.java
+++ b/apps/api/src/main/java/br/org/apae/api/common/dto/patient/request/vaccine/UpdateVaccineDTO.java
@@ -1,0 +1,11 @@
+package br.org.apae.api.common.dto.patient.request.vaccine;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdateVaccineDTO(
+        @NotBlank(message = "O nome da vacina é obrigatório.")
+        @Size(min = 2, max = 100, message = "O nome da vacina deve ter entre 2 e 100 caracteres.")
+        String name
+) {
+}

--- a/apps/api/src/main/java/br/org/apae/api/controllers/vaccine/VaccineControllerImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/controllers/vaccine/VaccineControllerImpl.java
@@ -1,9 +1,12 @@
 package br.org.apae.api.controllers.vaccine;
 
 import br.org.apae.api.patient.application.interfaces.VaccineApplicationService;
+import br.org.apae.api.common.dto.patient.request.vaccine.UpdateVaccineDTO;
+import br.org.apae.api.common.dto.patient.request.vaccine.VaccineNameDTO;
 import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
 import br.org.apae.api.patient.interfaces.controllers.VaccineController;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +20,12 @@ public class VaccineControllerImpl implements VaccineController {
     @Autowired
     public VaccineControllerImpl(VaccineApplicationService vaccineService) {
         this.vaccineService = vaccineService;
+    }
+
+    @Override
+    public ResponseEntity<VaccineResponseDTO> createVaccine(VaccineNameDTO dto) {
+        VaccineResponseDTO vaccine = vaccineService.createVaccine(dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(vaccine);
     }
 
     @Override
@@ -36,4 +45,17 @@ public class VaccineControllerImpl implements VaccineController {
         VaccineResponseDTO vaccine = vaccineService.findVaccineByName(name);
         return ResponseEntity.ok(vaccine);
     }
+
+    @Override
+    public ResponseEntity<VaccineResponseDTO> updateVaccine(UUID id, UpdateVaccineDTO dto) {
+        VaccineResponseDTO vaccine = vaccineService.updateVaccine(id, dto);
+        return ResponseEntity.ok(vaccine);
+    }
+
+    @Override
+    public ResponseEntity<Void> deleteVaccine(UUID id) {
+        vaccineService.deleteVaccine(id);
+        return ResponseEntity.noContent().build();
+    }
 }
+

--- a/apps/api/src/main/java/br/org/apae/api/patient/application/exceptions/PatientExceptionHandler.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/application/exceptions/PatientExceptionHandler.java
@@ -13,6 +13,8 @@ import br.org.apae.api.patient.domain.exceptions.PatientConflictException;
 import br.org.apae.api.patient.domain.exceptions.PatientNotFoundException;
 import br.org.apae.api.patient.domain.exceptions.RegistryNotFoundException;
 import br.org.apae.api.patient.domain.exceptions.RegistryOwnershipException;
+import br.org.apae.api.patient.domain.exceptions.VaccineConflictException;
+import br.org.apae.api.patient.domain.exceptions.VaccineInUseException;
 import br.org.apae.api.patient.domain.exceptions.VaccineMismatchException;
 import br.org.apae.api.patient.domain.exceptions.VaccineNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -131,6 +133,36 @@ public class PatientExceptionHandler {
     );
 
     return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(VaccineConflictException.class)
+  public ResponseEntity<ErrorResponse> handleVaccineConflict(
+          VaccineConflictException ex,
+          HttpServletRequest request
+  ) {
+    ErrorResponse error = new ErrorResponse(
+            HttpStatus.CONFLICT.value(),
+            HttpStatus.CONFLICT.getReasonPhrase(),
+            ex.getMessage(),
+            request.getRequestURI()
+    );
+
+    return new ResponseEntity<>(error, HttpStatus.CONFLICT);
+  }
+
+  @ExceptionHandler(VaccineInUseException.class)
+  public ResponseEntity<ErrorResponse> handleVaccineInUse(
+          VaccineInUseException ex,
+          HttpServletRequest request
+  ) {
+    ErrorResponse error = new ErrorResponse(
+            HttpStatus.BAD_REQUEST.value(),
+            HttpStatus.BAD_REQUEST.getReasonPhrase(),
+            ex.getMessage(),
+            request.getRequestURI()
+    );
+
+    return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
   }
 
   @ExceptionHandler(VaccineMismatchException.class)

--- a/apps/api/src/main/java/br/org/apae/api/patient/application/interfaces/VaccineApplicationService.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/application/interfaces/VaccineApplicationService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import br.org.apae.api.common.dto.patient.request.vaccine.UpdateVaccineDTO;
 import br.org.apae.api.common.dto.patient.request.vaccine.VaccineNameDTO;
 import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
 
@@ -15,4 +16,10 @@ public interface VaccineApplicationService {
   VaccineResponseDTO findVaccineByName(String name);
 
   Set<VaccineResponseDTO> findVaccines(Set<VaccineNameDTO> vaccineNames);
+
+  VaccineResponseDTO createVaccine(VaccineNameDTO dto);
+
+  VaccineResponseDTO updateVaccine(UUID id, UpdateVaccineDTO dto);
+
+  void deleteVaccine(UUID id);
 }

--- a/apps/api/src/main/java/br/org/apae/api/patient/application/internal/VaccineApplicationServiceImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/application/internal/VaccineApplicationServiceImpl.java
@@ -1,10 +1,13 @@
 package br.org.apae.api.patient.application.internal;
 
+import br.org.apae.api.patient.domain.exceptions.VaccineConflictException;
+import br.org.apae.api.patient.domain.exceptions.VaccineInUseException;
 import br.org.apae.api.patient.domain.exceptions.VaccineMismatchException;
 import br.org.apae.api.patient.domain.exceptions.VaccineNotFoundException;
 import br.org.apae.api.patient.domain.model.Vaccine;
 import br.org.apae.api.patient.domain.repository.PatientRepository;
 import br.org.apae.api.patient.domain.repository.VaccineRepository;
+import br.org.apae.api.common.dto.patient.request.vaccine.UpdateVaccineDTO;
 import br.org.apae.api.common.dto.patient.request.vaccine.VaccineNameDTO;
 import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
 
@@ -77,5 +80,49 @@ public class VaccineApplicationServiceImpl implements VaccineApplicationService 
         }
 
         return vaccineMapper.toResponseDTOSet(vaccines);
+    }
+
+    @Override
+    @Transactional
+    public VaccineResponseDTO createVaccine(VaccineNameDTO dto) {
+        vaccineRepository.findByName(dto.name()).ifPresent(existing -> {
+            throw new VaccineConflictException(dto.name());
+        });
+
+        Vaccine vaccine = new Vaccine(dto.name());
+        Vaccine saved = vaccineRepository.save(vaccine);
+
+        return vaccineMapper.toResponseDTO(saved);
+    }
+
+    @Override
+    @Transactional
+    public VaccineResponseDTO updateVaccine(UUID id, UpdateVaccineDTO dto) {
+        Vaccine vaccine = vaccineRepository.findById(id)
+                .orElseThrow(VaccineNotFoundException::new);
+
+        vaccineRepository.findByName(dto.name()).ifPresent(existing -> {
+            if (!existing.getId().equals(id)) {
+                throw new VaccineConflictException(dto.name());
+            }
+        });
+
+        vaccine.updateName(dto.name());
+        Vaccine saved = vaccineRepository.save(vaccine);
+
+        return vaccineMapper.toResponseDTO(saved);
+    }
+
+    @Override
+    @Transactional
+    public void deleteVaccine(UUID id) {
+        Vaccine vaccine = vaccineRepository.findById(id)
+                .orElseThrow(VaccineNotFoundException::new);
+
+        if (patientRepository.isVaccineInUse(id)) {
+            throw new VaccineInUseException();
+        }
+
+        vaccineRepository.delete(vaccine);
     }
 }

--- a/apps/api/src/main/java/br/org/apae/api/patient/domain/exceptions/VaccineConflictException.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/domain/exceptions/VaccineConflictException.java
@@ -1,0 +1,13 @@
+package br.org.apae.api.patient.domain.exceptions;
+
+public class VaccineConflictException extends RuntimeException {
+    private static final String MESSAGE = "Vacina já existe.";
+
+    public VaccineConflictException() {
+        super(MESSAGE);
+    }
+
+    public VaccineConflictException(String name) {
+        super("Já existe uma vacina com o nome: " + name);
+    }
+}

--- a/apps/api/src/main/java/br/org/apae/api/patient/domain/exceptions/VaccineInUseException.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/domain/exceptions/VaccineInUseException.java
@@ -1,0 +1,13 @@
+package br.org.apae.api.patient.domain.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class VaccineInUseException extends RuntimeException {
+    private static final String MESSAGE = "Não é possível excluir esta vacina, pois ela está vinculada a um ou mais pacientes.";
+
+    public VaccineInUseException() {
+        super(MESSAGE);
+    }
+}

--- a/apps/api/src/main/java/br/org/apae/api/patient/interfaces/controllers/VaccineController.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/interfaces/controllers/VaccineController.java
@@ -1,18 +1,32 @@
 package br.org.apae.api.patient.interfaces.controllers;
 
+import br.org.apae.api.common.dto.patient.request.vaccine.UpdateVaccineDTO;
+import br.org.apae.api.common.dto.patient.request.vaccine.VaccineNameDTO;
 import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.UUID;
 
 @RequestMapping("/vaccines")
-@Tag(name = "Vaccines", description = "Endpoints para consulta de vacinas")
+@Tag(name = "Vaccines", description = "Endpoints para gerenciamento de vacinas")
 public interface VaccineController {
+
+        @Operation(summary = "Cadastrar vacina", description = "Cria uma nova vacina no sistema. Falha se o nome já existir.")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "201", description = "Vacina criada com sucesso", content = @Content(schema = @Schema(implementation = VaccineResponseDTO.class))),
+                        @ApiResponse(responseCode = "400", description = "Dados inválidos", content = @Content),
+                        @ApiResponse(responseCode = "409", description = "Conflito: já existe uma vacina com este nome", content = @Content)
+        })
+        @PostMapping
+        ResponseEntity<VaccineResponseDTO> createVaccine(@RequestBody @Valid VaccineNameDTO dto);
 
         @Operation(summary = "Buscar vacina por ID", description = "Retorna os dados de uma vacina específica pelo seu ID.")
         @ApiResponses(value = {
@@ -36,4 +50,24 @@ public interface VaccineController {
         })
         @GetMapping("/search/by-name")
         ResponseEntity<VaccineResponseDTO> findByName(@RequestParam String name);
+
+        @Operation(summary = "Atualizar vacina", description = "Atualiza o nome de uma vacina existente.")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "Vacina atualizada com sucesso", content = @Content(schema = @Schema(implementation = VaccineResponseDTO.class))),
+                        @ApiResponse(responseCode = "400", description = "Dados inválidos", content = @Content),
+                        @ApiResponse(responseCode = "404", description = "Vacina não encontrada", content = @Content),
+                        @ApiResponse(responseCode = "409", description = "Conflito: já existe uma vacina com este nome", content = @Content)
+        })
+        @PutMapping("/{id}")
+        ResponseEntity<VaccineResponseDTO> updateVaccine(@PathVariable UUID id, @RequestBody @Valid UpdateVaccineDTO dto);
+
+        @Operation(summary = "Excluir vacina", description = "Remove uma vacina pelo seu ID. Falha se ela estiver vinculada a algum paciente.")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "204", description = "Vacina excluída com sucesso", content = @Content),
+                        @ApiResponse(responseCode = "400", description = "Vacina vinculada a pacientes e não pode ser excluída", content = @Content),
+                        @ApiResponse(responseCode = "404", description = "Vacina não encontrada", content = @Content)
+        })
+        @DeleteMapping("/{id}")
+        ResponseEntity<Void> deleteVaccine(@PathVariable UUID id);
 }
+


### PR DESCRIPTION
# O que mudou?

Implementação das operações de escrita (Create, Update, Delete) do módulo de vacinas, completando o CRUD.

## Tarefas Relacionadas

Closes #879 

## Mudanças Realizadas

* Criação dos endpoints `POST`, `PUT` e `DELETE` no `VaccineController` e `VaccineApplicationService` (Backend).
* Adição de validações de negócio: bloqueio de nomes duplicados (`409 Conflict`) e bloqueio de exclusão de vacinas em uso por pacientes (`400 Bad Request`).
* Criação das páginas `/vaccines/new` e `/vaccines/[id]/edit` no Frontend (Next.js) utilizando formulários validados com Zod.
* Atualização da listagem (`/vaccines`) com botão "Adicionar", ações individuais de Editar/Excluir e modais de confirmação.

## Como testar
1. Acessar `/apae-geral/vaccines` e testar a criação de uma nova vacina.
2. Tentar criar uma vacina com o mesmo nome para validar a tratativa de erro.
3. Editar o nome de uma vacina recém-criada.
4. Tentar excluir uma vacina antiga que já possua pacientes vinculados (o botão deve informar o bloqueio).
5. Excluir a vacina de teste criada no passo 1.

## Checklist
- [x] Lint executado
- [x] Testes executados (*Nota: `mvn test` falha devido a erro pré-existente em `HealthProfessionalControllerTest`, validado como fora do escopo*)
- [x] Build do frontend ok
- [x] Build do backend ok
- [x] Listagem e busca de vacinas continuam funcionando normalmente
