### PR TITLE
fix(test): corrige HealthProfessionalControllerTest e destrava os testes (#893)

### DIFF
--- a/apps/api/src/test/java/br/org/apae/api/controllers/professional/HealthProfessionalControllerTest.java
+++ b/apps/api/src/test/java/br/org/apae/api/controllers/professional/HealthProfessionalControllerTest.java
@@ -1,5 +1,5 @@
 package br.org.apae.api.controllers.professional;
-
+import org.springframework.web.multipart.MultipartFile;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -89,21 +89,56 @@ class HealthProfessionalControllerTest {
  @DisplayName("Cenários de Criação (POST)")
  class Criacao {
   @Test
-  @DisplayName("Deve criar profissional com sucesso (201)")
+  @DisplayName("Deve criar profissional sem foto com sucesso (201)")
   void shouldCreateProfessionalSuccessfully() throws Exception {
    var request = HealthProfessionalMockDto.createHealthProfessionalRequest();
    var response = HealthProfessionalMockDto.createProfessionalResponse1();
 
-   Mockito.when(service.createProfessional(any(CreateHealthProfessionalDTO.class), any(CreateProfessionalDocumentsDTO.class))).thenReturn(response);
+   Mockito.when(service.createProfessional(
+           any(CreateHealthProfessionalDTO.class),
+           any(CreateProfessionalDocumentsDTO.class),
+           any(MultipartFile.class)
+   )).thenReturn(response);
 
    var professionalPart = new MockMultipartFile("professional", "", MediaType.APPLICATION_JSON_VALUE, objectMapper.writeValueAsBytes(request));
 
-   mockMvc.perform(multipart("/professionals").file(professionalPart).file(HealthProfessionalMockDto.volunteerAgreementFile())
-       .file(HealthProfessionalMockDto.curriculumFile()).file(HealthProfessionalMockDto.attachmentAnyFile())
-       .header("Authorization", AuthTestHelper.bearerToken()).contentType(MediaType.MULTIPART_FORM_DATA))
-     .andExpect(status().isCreated());
+   mockMvc.perform(multipart("/professionals")
+                   .file(professionalPart)
+                   .file(HealthProfessionalMockDto.volunteerAgreementFile())
+                   .file(HealthProfessionalMockDto.curriculumFile())
+                   .file(HealthProfessionalMockDto.attachmentAnyFile())
+                   .header("Authorization", AuthTestHelper.bearerToken())
+                   .contentType(MediaType.MULTIPART_FORM_DATA))
+           .andExpect(status().isCreated());
 
-   Mockito.verify(service).createProfessional(any(), any());
+   Mockito.verify(service).createProfessional(any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("Deve criar profissional com foto com sucesso (201)")
+  void shouldCreateProfessionalWithPhotoSuccessfully() throws Exception {
+   var request = HealthProfessionalMockDto.createHealthProfessionalRequest();
+   var response = HealthProfessionalMockDto.createProfessionalResponse1();
+
+   Mockito.when(service.createProfessional(
+           any(CreateHealthProfessionalDTO.class),
+           any(CreateProfessionalDocumentsDTO.class),
+           any(MultipartFile.class)
+   )).thenReturn(response);
+
+   var professionalPart = new MockMultipartFile("professional", "", MediaType.APPLICATION_JSON_VALUE, objectMapper.writeValueAsBytes(request));
+
+   mockMvc.perform(multipart("/professionals")
+                   .file(professionalPart)
+                   .file(HealthProfessionalMockDto.volunteerAgreementFile())
+                   .file(HealthProfessionalMockDto.curriculumFile())
+                   .file(HealthProfessionalMockDto.attachmentAnyFile())
+                   .file(HealthProfessionalMockDto.profilePhoto())
+                   .header("Authorization", AuthTestHelper.bearerToken())
+                   .contentType(MediaType.MULTIPART_FORM_DATA))
+           .andExpect(status().isCreated());
+
+   Mockito.verify(service).createProfessional(any(), any(), any());
   }
  }
 

--- a/apps/api/src/test/java/br/org/apae/api/mocks/professional/HealthProfessionalMockDto.java
+++ b/apps/api/src/test/java/br/org/apae/api/mocks/professional/HealthProfessionalMockDto.java
@@ -133,4 +133,12 @@ public final class HealthProfessionalMockDto {
             createProfessionalResponse2()
         );
     }
+    public static MockMultipartFile profilePhoto() {
+        return new MockMultipartFile(
+                "profilePhoto",
+                "profile-photo.jpg",
+                org.springframework.http.MediaType.IMAGE_JPEG_VALUE,
+                "fake-image-content".getBytes()
+        );
+    }
 }


### PR DESCRIPTION
## O que foi feito
- Atualizados os stubs e verificações no `HealthProfessionalControllerTest` (linhas 97 e 106) para incluir o parâmetro faltante `MultipartFile`.
- Criado o helper centralizado `profilePhoto()` na fixture `HealthProfessionalMockDto`.
- Adicionado novo cenário de teste (`shouldCreateProfessionalWithPhotoSuccessfully`) cobrindo a criação com envio de foto de perfil.
- Mantido o cenário de teste existente sem foto, validando que o campo é opcional (`required = false`).
- Destravada a compilação do Maven e a execução dos testes do backend.

## Issue relacionada
Closes #893

## Como testar
1. No terminal, entrar na pasta da API:
   ```bash
   cd apps/api
   ```
2. Executar a suíte de testes:
   ```bash
   ./mvnw test
   ```
3. Validar que a compilação passa com sucesso e os 251 testes são executados sem falhas:

```text
[INFO] Results:
[INFO] 
[INFO] Tests run: 251, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
```

## Checklist
- [x] Testes executados
- [x] Build do backend ok
- [x] Nenhum arquivo de `src/main` alterado
- [x] Nenhum teste desabilitado ou removido

## Evidências
<img width="653" height="213" alt="image" src="https://github.com/user-attachments/assets/f836e7db-8420-4c52-ba65-18a3eb14508b" />
