### PR TITLE
[TREINAMENTO] CRUD de Vacinas - Valdênio Pantaleão

### DIFF
--- a/.scripts/run-app.sh
+++ b/.scripts/run-app.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+export JAVA_HOME="/usr/lib/jvm/java-21-openjdk-amd64"
+export PATH="$JAVA_HOME/bin:$PATH"
+
 MODE=${1:-both}
 FRONTEND_TARGET=${2:-apae}
 

--- a/.scripts/run-app.sh
+++ b/.scripts/run-app.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-export JAVA_HOME="/usr/lib/jvm/java-21-openjdk-amd64"
-export PATH="$JAVA_HOME/bin:$PATH"
-
 MODE=${1:-both}
 FRONTEND_TARGET=${2:-apae}
 

--- a/apps/apae/src/app/api/vaccines/[id]/route.ts
+++ b/apps/apae/src/app/api/vaccines/[id]/route.ts
@@ -1,4 +1,5 @@
 import { createBaseApi } from "@/lib/axios";
+import { isAxiosError } from "axios";
 
 type Params = {
     params: Promise<{
@@ -13,6 +14,13 @@ export async function GET(request: Request, { params }: Params) {
         const { data } = await api.get(`/vaccines/${id}`);
         return Response.json(data);
     } catch (error) {
+        if (isAxiosError(error) && error.response) {
+            return Response.json(
+                error.response.data ?? { message: "Erro ao buscar vacina." },
+                { status: error.response.status }
+            );
+        }
+        console.error("Erro ao buscar vacina:", error);
         return Response.json({ message: "Erro ao buscar vacina." }, { status: 500 });
     }
 }
@@ -25,6 +33,13 @@ export async function PUT(request: Request, { params }: Params) {
         const { data } = await api.put(`/vaccines/${id}`, body);
         return Response.json(data);
     } catch (error) {
+        if (isAxiosError(error) && error.response) {
+            return Response.json(
+                error.response.data ?? { message: "Erro ao atualizar vacina." },
+                { status: error.response.status }
+            );
+        }
+        console.error("Erro ao atualizar vacina:", error);
         return Response.json({ message: "Erro ao atualizar vacina." }, { status: 500 });
     }
 }
@@ -36,6 +51,13 @@ export async function DELETE(request: Request, { params }: Params) {
         await api.delete(`/vaccines/${id}`);
         return new Response(null, { status: 204 });
     } catch (error) {
+        if (isAxiosError(error) && error.response) {
+            return Response.json(
+                error.response.data ?? { message: "Erro ao excluir vacina." },
+                { status: error.response.status }
+            );
+        }
+        console.error("Erro ao excluir vacina:", error);
         return Response.json({ message: "Erro ao excluir vacina." }, { status: 500 });
     }
 }

--- a/apps/apae/src/app/api/vaccines/[id]/route.ts
+++ b/apps/apae/src/app/api/vaccines/[id]/route.ts
@@ -1,0 +1,41 @@
+import { createBaseApi } from "@/lib/axios";
+
+type Params = {
+    params: Promise<{
+        id: string;
+    }>;
+};
+
+export async function GET(request: Request, { params }: Params) {
+    try {
+        const { id } = await params;
+        const api = await createBaseApi();
+        const { data } = await api.get(`/vaccines/${id}`);
+        return Response.json(data);
+    } catch (error) {
+        return Response.json({ message: "Erro ao buscar vacina." }, { status: 500 });
+    }
+}
+
+export async function PUT(request: Request, { params }: Params) {
+    try {
+        const { id } = await params;
+        const body = await request.json();
+        const api = await createBaseApi();
+        const { data } = await api.put(`/vaccines/${id}`, body);
+        return Response.json(data);
+    } catch (error) {
+        return Response.json({ message: "Erro ao atualizar vacina." }, { status: 500 });
+    }
+}
+
+export async function DELETE(request: Request, { params }: Params) {
+    try {
+        const { id } = await params;
+        const api = await createBaseApi();
+        await api.delete(`/vaccines/${id}`);
+        return new Response(null, { status: 204 });
+    } catch (error) {
+        return Response.json({ message: "Erro ao excluir vacina." }, { status: 500 });
+    }
+}

--- a/apps/apae/src/app/api/vaccines/route.ts
+++ b/apps/apae/src/app/api/vaccines/route.ts
@@ -13,3 +13,19 @@ export async function GET() {
         );
     }
 }
+
+export async function POST(request: Request) {
+    try {
+        const body = await request.json();
+        const api = await createBaseApi();
+        const { data } = await api.post("/vaccines", body);
+        return Response.json(data, { status: 201 });
+    } catch (error) {
+        const message = error instanceof Error ? error.message : "Erro desconhecido";
+        console.error("Erro ao criar vacina:", message);
+        return Response.json(
+            { message: "Erro ao criar vacina." },
+            { status: 500 }
+        );
+    }
+}

--- a/apps/apae/src/app/api/vaccines/route.ts
+++ b/apps/apae/src/app/api/vaccines/route.ts
@@ -1,5 +1,6 @@
 import { createBaseApi } from "@/lib/axios";
 import { NextResponse } from "next/server";
+import { isAxiosError } from "axios";
 
 export async function GET() {
     try {
@@ -7,10 +8,14 @@ export async function GET() {
         const { data } = await api.get("/vaccines");
         return NextResponse.json(data);
     } catch (error) {
-        const message = error instanceof Error ? error.message : "Erro desconhecido";
-        console.error("Erro ao buscar vacinas:", message);
-        return NextResponse.json({ message: "Erro ao buscar a lista de vacinas." }, { status: 500 }
-        );
+        if (isAxiosError(error) && error.response) {
+            return NextResponse.json(
+                error.response.data ?? { message: "Erro ao buscar a lista de vacinas." },
+                { status: error.response.status }
+            );
+        }
+        console.error("Erro ao buscar vacinas:", error);
+        return NextResponse.json({ message: "Erro ao buscar a lista de vacinas." }, { status: 500 });
     }
 }
 
@@ -21,11 +26,13 @@ export async function POST(request: Request) {
         const { data } = await api.post("/vaccines", body);
         return Response.json(data, { status: 201 });
     } catch (error) {
-        const message = error instanceof Error ? error.message : "Erro desconhecido";
-        console.error("Erro ao criar vacina:", message);
-        return Response.json(
-            { message: "Erro ao criar vacina." },
-            { status: 500 }
-        );
+        if (isAxiosError(error) && error.response) {
+            return Response.json(
+                error.response.data ?? { message: "Erro ao criar vacina." },
+                { status: error.response.status }
+            );
+        }
+        console.error("Erro ao criar vacina:", error);
+        return Response.json({ message: "Erro ao criar vacina." }, { status: 500 });
     }
 }

--- a/apps/apae/src/app/vaccines/[id]/edit/page.tsx
+++ b/apps/apae/src/app/vaccines/[id]/edit/page.tsx
@@ -1,0 +1,16 @@
+import { VaccineEditForm } from "@/domains/vaccines/edit/vaccine-form";
+
+interface EditVaccinePageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function EditVaccinePage({ params }: EditVaccinePageProps) {
+  const { id } = await params;
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-6">Editar Vacina</h1>
+      <VaccineEditForm id={id} />
+    </div>
+  );
+}

--- a/apps/apae/src/app/vaccines/new/page.tsx
+++ b/apps/apae/src/app/vaccines/new/page.tsx
@@ -1,0 +1,10 @@
+import { VaccineCreateForm } from "@/domains/vaccines/create/vaccine-form";
+
+export default function NewVaccinePage() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-6">Cadastrar Nova Vacina</h1>
+      <VaccineCreateForm />
+    </div>
+  );
+}

--- a/apps/apae/src/domains/vaccines/create/use-vaccine-create.ts
+++ b/apps/apae/src/domains/vaccines/create/use-vaccine-create.ts
@@ -1,0 +1,34 @@
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "react-toastify";
+import { createVaccineApi } from "../vaccines.api";
+import { CreateVaccineFormData } from "../vaccines.schema";
+
+export function useVaccineCreate() {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleCreate(data: CreateVaccineFormData) {
+    try {
+      setIsLoading(true);
+      setError(null);
+      await createVaccineApi(data);
+      toast.success("Vacina criada com sucesso!");
+      router.push("/vaccines");
+      router.refresh();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Erro ao criar vacina.";
+      setError(message);
+      toast.error(message);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return {
+    handleCreate,
+    isLoading,
+    error,
+  };
+}

--- a/apps/apae/src/domains/vaccines/create/vaccine-form.tsx
+++ b/apps/apae/src/domains/vaccines/create/vaccine-form.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { createVaccineSchema, CreateVaccineFormData } from "../vaccines.schema";
+import { useVaccineCreate } from "./use-vaccine-create";
+import Link from "next/link";
+
+export function VaccineCreateForm() {
+  const { handleCreate, isLoading, error } = useVaccineCreate();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<CreateVaccineFormData>({
+    resolver: zodResolver(createVaccineSchema),
+  });
+
+  return (
+    <form onSubmit={handleSubmit(handleCreate)} className="space-y-4 max-w-md">
+      {error && (
+        <div className="p-3 bg-red-100 text-red-700 rounded-md text-sm">
+          {error}
+        </div>
+      )}
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          Nome da Vacina *
+        </label>
+        <input
+          type="text"
+          {...register("name")}
+          className="w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder="Ex: BCG, Tríplice Viral"
+        />
+        {errors.name && (
+          <p className="text-red-500 text-xs mt-1">{errors.name.message}</p>
+        )}
+      </div>
+
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50"
+        >
+          {isLoading ? "Salvando..." : "Salvar Vacina"}
+        </button>
+
+        <Link
+          href="/vaccines"
+          className="px-4 py-2 bg-gray-200 text-gray-800 rounded-md hover:bg-gray-300"
+        >
+          Cancelar
+        </Link>
+      </div>
+    </form>
+  );
+}

--- a/apps/apae/src/domains/vaccines/edit/use-vaccine-edit.ts
+++ b/apps/apae/src/domains/vaccines/edit/use-vaccine-edit.ts
@@ -1,0 +1,56 @@
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "react-toastify";
+import { fetchVaccineApi, updateVaccineApi } from "../vaccines.api";
+import { UpdateVaccineFormData } from "../vaccines.schema";
+
+export function useVaccineEdit(id: string) {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [defaultName, setDefaultName] = useState<string>("");
+
+  useEffect(() => {
+    async function loadVaccine() {
+      try {
+        setIsLoading(true);
+        const vaccine = await fetchVaccineApi(id);
+        setDefaultName(vaccine.name);
+      } catch (err) {
+        setError("Erro ao carregar dados da vacina.");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    if (id) {
+      loadVaccine();
+    }
+  }, [id]);
+
+  async function handleUpdate(data: UpdateVaccineFormData) {
+    try {
+      setIsSaving(true);
+      setError(null);
+      await updateVaccineApi({ id, name: data.name });
+      toast.success("Vacina atualizada com sucesso!");
+      router.push("/vaccines");
+      router.refresh();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Erro ao atualizar vacina.";
+      setError(message);
+      toast.error(message);
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return {
+    defaultName,
+    handleUpdate,
+    isLoading,
+    isSaving,
+    error,
+  };
+}

--- a/apps/apae/src/domains/vaccines/edit/vaccine-form.tsx
+++ b/apps/apae/src/domains/vaccines/edit/vaccine-form.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { updateVaccineSchema, UpdateVaccineFormData } from "../vaccines.schema";
+import { useVaccineEdit } from "./use-vaccine-edit";
+import Link from "next/link";
+import { useEffect } from "react";
+
+type Props = {
+  id: string;
+};
+
+export function VaccineEditForm({ id }: Props) {
+  const { defaultName, handleUpdate, isLoading, isSaving, error } =
+    useVaccineEdit(id);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<UpdateVaccineFormData>({
+    resolver: zodResolver(updateVaccineSchema),
+  });
+
+  useEffect(() => {
+    if (defaultName) {
+      reset({ name: defaultName });
+    }
+  }, [defaultName, reset]);
+
+  if (isLoading) {
+    return <div className="p-4 text-gray-500">Carregando dados da vacina...</div>;
+  }
+
+  return (
+    <form onSubmit={handleSubmit(handleUpdate)} className="space-y-4 max-w-md">
+      {error && (
+        <div className="p-3 bg-red-100 text-red-700 rounded-md text-sm">
+          {error}
+        </div>
+      )}
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          Nome da Vacina *
+        </label>
+        <input
+          type="text"
+          {...register("name")}
+          className="w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder="Ex: BCG, Tríplice Viral"
+        />
+        {errors.name && (
+          <p className="text-red-500 text-xs mt-1">{errors.name.message}</p>
+        )}
+      </div>
+
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          disabled={isSaving}
+          className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50"
+        >
+          {isSaving ? "Salvando..." : "Atualizar Vacina"}
+        </button>
+
+        <Link
+          href="/vaccines"
+          className="px-4 py-2 bg-gray-200 text-gray-800 rounded-md hover:bg-gray-300"
+        >
+          Cancelar
+        </Link>
+      </div>
+    </form>
+  );
+}

--- a/apps/apae/src/domains/vaccines/list/use-vaccines-list.ts
+++ b/apps/apae/src/domains/vaccines/list/use-vaccines-list.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "react-toastify";
-import { fetchVaccinesApi } from "../vaccines.api";
+import { fetchVaccinesApi, deleteVaccineApi } from "../vaccines.api";
 import type { Vaccine } from "../vaccines.types";
 
 export function useVaccinesList() {
@@ -26,5 +26,19 @@ export function useVaccinesList() {
     loadVaccines();
   }, [loadVaccines]);
 
-  return { vaccines, loading };
+  const handleDelete = useCallback(async (id: string) => {
+    try {
+      setLoading(true);
+      await deleteVaccineApi({ id });
+      toast.success("Vacina excluída com sucesso!");
+      await loadVaccines();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Erro ao excluir vacina.";
+      toast.error(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadVaccines]);
+
+  return { vaccines, loading, handleDelete, reloadVaccines: loadVaccines };
 }

--- a/apps/apae/src/domains/vaccines/list/vaccines-list.tsx
+++ b/apps/apae/src/domains/vaccines/list/vaccines-list.tsx
@@ -4,13 +4,15 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { SearchFilters } from "@/components/search-filters";
-import { ArrowLeft, Loader2 } from "lucide-react";
+import { ArrowLeft, Loader2, Plus } from "lucide-react";
 import { VaccineListItem } from "../shared/vaccine-list-item";
 import { useVaccinesList } from "./use-vaccines-list";
+import type { Vaccine } from "../vaccines.types";
 
 export function VaccinesList() {
   const [searchName, setSearchName] = useState("");
-  const { vaccines, loading } = useVaccinesList();
+  const [selectedVaccineToDelete, setSelectedVaccineToDelete] = useState<Vaccine | null>(null);
+  const { vaccines, loading, handleDelete } = useVaccinesList();
   const router = useRouter();
 
   const filtered = vaccines.filter((v) =>
@@ -35,10 +37,25 @@ export function VaccinesList() {
         <section className="relative md:bg-white md:rounded-xl md:shadow-md md:border-2 md:p-6">
           <div className="hidden md:flex justify-between items-center mb-4">
             <h2 className="text-xl font-bold text-[#003B93]">Vacinas Cadastradas</h2>
+            <Button
+              onClick={() => router.push("/vaccines/new")}
+              className="bg-[#003B93] hover:bg-blue-800 text-white font-medium"
+            >
+              <Plus className="h-4 w-4 mr-2" />
+              Cadastrar Vacina
+            </Button>
           </div>
 
-          <div className="mb-4 md:hidden">
+          <div className="mb-4 md:hidden flex justify-between items-center">
             <h2 className="text-xl font-bold text-[#003B93]">Vacinas Cadastradas</h2>
+            <Button
+              onClick={() => router.push("/vaccines/new")}
+              size="sm"
+              className="bg-[#003B93] hover:bg-blue-800 text-white text-xs font-medium"
+            >
+              <Plus className="h-3 w-3 mr-1" />
+              Cadastrar
+            </Button>
           </div>
 
           {loading ? (
@@ -57,6 +74,7 @@ export function VaccinesList() {
                   <VaccineListItem
                     key={vaccine.id}
                     vaccine={vaccine}
+                    onDelete={() => setSelectedVaccineToDelete(vaccine)}
                   />
                 ))}
               </div>
@@ -64,6 +82,41 @@ export function VaccinesList() {
           )}
         </section>
       </main>
+
+      {/* Modal de Confirmação de Exclusão (idêntico ao vídeo) */}
+      {selectedVaccineToDelete && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="bg-white rounded-xl shadow-lg max-w-md w-full p-6 space-y-4 animate-in fade-in zoom-in duration-200">
+            <h3 className="text-lg font-bold text-gray-900">Tem certeza?</h3>
+            <p className="text-sm text-gray-600">
+              Essa ação não pode ser desfeita. Isso irá excluir permanentemente a vacina{" "}
+              <span className="font-semibold text-gray-900">{selectedVaccineToDelete.name}</span>.
+            </p>
+
+            <div className="flex justify-end gap-3 pt-2">
+              <button
+                type="button"
+                onClick={() => setSelectedVaccineToDelete(null)}
+                className="px-4 py-2 border rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-100 transition-colors"
+              >
+                Cancelar
+              </button>
+
+              <button
+                type="button"
+                onClick={async () => {
+                  const vaccine = selectedVaccineToDelete;
+                  setSelectedVaccineToDelete(null);
+                  await handleDelete(vaccine.id);
+                }}
+                className="px-4 py-2 bg-[#003B93] hover:bg-blue-800 text-white text-sm font-medium rounded-lg transition-colors"
+              >
+                Confirmar
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/apae/src/domains/vaccines/shared/vaccine-list-item.tsx
+++ b/apps/apae/src/domains/vaccines/shared/vaccine-list-item.tsx
@@ -1,16 +1,45 @@
 "use client";
 
+import Link from "next/link";
 import type { Vaccine } from "../vaccines.types";
 
 interface VaccineListItemProps {
   vaccine: Vaccine;
+  onDelete?: (id: string) => void;
 }
 
-export function VaccineListItem({ vaccine }: VaccineListItemProps) {
+export function VaccineListItem({ vaccine, onDelete }: VaccineListItemProps) {
   return (
-    <div className="flex items-center p-4 border-b hover:bg-gray-50 transition-colors">
+    <div className="flex items-center justify-between p-4 border-b hover:bg-gray-50 transition-colors">
       <div className="flex-1">
         <h3 className="font-bold text-base text-[#003B93]">{vaccine.name}</h3>
+        {vaccine.hasPatient && (
+          <span className="text-xs text-amber-700 bg-amber-50 px-2 py-0.5 rounded mt-1 inline-block font-normal">
+            Vinculada a paciente
+          </span>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Link
+          href={`/vaccines/${vaccine.id}/edit`}
+          className="px-3 py-1 text-sm font-medium text-[#003B93] bg-blue-50 rounded hover:bg-blue-100 transition-colors"
+        >
+          Editar
+        </Link>
+
+        <button
+          onClick={() => onDelete?.(vaccine.id)}
+          disabled={vaccine.hasPatient}
+          title={
+            vaccine.hasPatient
+              ? "Não é possível excluir vacina vinculada a paciente"
+              : "Excluir vacina"
+          }
+          className="px-3 py-1 text-sm font-medium text-red-600 bg-red-50 rounded hover:bg-red-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+        >
+          Excluir
+        </button>
       </div>
     </div>
   );

--- a/apps/apae/src/domains/vaccines/vaccines.api.ts
+++ b/apps/apae/src/domains/vaccines/vaccines.api.ts
@@ -1,9 +1,71 @@
-import type { Vaccine } from "./vaccines.types";
+import {
+  Vaccine,
+  CreateVaccineParams,
+  UpdateVaccineParams,
+  DeleteVaccineParams,
+} from "./vaccines.types";
 
 const BASE_URL = "/apae-geral/api/vaccines";
 
 export async function fetchVaccinesApi(): Promise<Vaccine[]> {
   const response = await fetch(BASE_URL);
-  if (!response.ok) throw new Error("Ocorreu um erro ao carregar as vacinas.");
+  if (!response.ok) {
+    throw new Error("Erro ao buscar vacinas.");
+  }
   return response.json();
+}
+
+export async function fetchVaccineApi(id: string): Promise<Vaccine> {
+  const response = await fetch(`${BASE_URL}/${id}`);
+  if (!response.ok) {
+    throw new Error("Erro ao buscar dados da vacina.");
+  }
+  return response.json();
+}
+
+export async function createVaccineApi(
+  params: CreateVaccineParams
+): Promise<Vaccine> {
+  const response = await fetch(BASE_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(params),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(errorData.detail || errorData.message || "Erro ao criar vacina.");
+  }
+
+  return response.json();
+}
+
+export async function updateVaccineApi(
+  params: UpdateVaccineParams
+): Promise<Vaccine> {
+  const response = await fetch(`${BASE_URL}/${params.id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: params.name }),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(errorData.detail || errorData.message || "Erro ao atualizar vacina.");
+  }
+
+  return response.json();
+}
+
+export async function deleteVaccineApi(
+  params: DeleteVaccineParams
+): Promise<void> {
+  const response = await fetch(`${BASE_URL}/${params.id}`, {
+    method: "DELETE",
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(errorData.detail || errorData.message || "Erro ao excluir vacina.");
+  }
 }

--- a/apps/apae/src/domains/vaccines/vaccines.schema.ts
+++ b/apps/apae/src/domains/vaccines/vaccines.schema.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const createVaccineSchema = z.object({
+  name: z.string().min(1, "O nome é obrigatório."),
+});
+
+export const updateVaccineSchema = z.object({
+  name: z.string().min(1, "O nome é obrigatório."),
+});
+
+export type CreateVaccineFormData = z.infer<typeof createVaccineSchema>;
+export type UpdateVaccineFormData = z.infer<typeof updateVaccineSchema>;

--- a/apps/apae/src/domains/vaccines/vaccines.schema.ts
+++ b/apps/apae/src/domains/vaccines/vaccines.schema.ts
@@ -1,11 +1,17 @@
 import { z } from "zod";
 
 export const createVaccineSchema = z.object({
-  name: z.string().min(1, "O nome é obrigatório."),
+  name: z
+    .string()
+    .min(2, "O nome deve ter entre 2 e 100 caracteres.")
+    .max(100, "O nome deve ter entre 2 e 100 caracteres."),
 });
 
 export const updateVaccineSchema = z.object({
-  name: z.string().min(1, "O nome é obrigatório."),
+  name: z
+    .string()
+    .min(2, "O nome deve ter entre 2 e 100 caracteres.")
+    .max(100, "O nome deve ter entre 2 e 100 caracteres."),
 });
 
 export type CreateVaccineFormData = z.infer<typeof createVaccineSchema>;

--- a/apps/apae/src/domains/vaccines/vaccines.types.ts
+++ b/apps/apae/src/domains/vaccines/vaccines.types.ts
@@ -3,3 +3,16 @@ export type Vaccine = Readonly<{
   name: string;
   hasPatient: boolean;
 }>;
+
+export type CreateVaccineParams = Readonly<{
+  name: string;
+}>;
+
+export type UpdateVaccineParams = Readonly<{
+  id: string;
+  name: string;
+}>;
+
+export type DeleteVaccineParams = Readonly<{
+  id: string;
+}>;

--- a/apps/api/src/main/java/br/org/apae/api/common/dto/patient/request/vaccine/CreateVaccineDTO.java
+++ b/apps/api/src/main/java/br/org/apae/api/common/dto/patient/request/vaccine/CreateVaccineDTO.java
@@ -1,0 +1,9 @@
+package br.org.apae.api.common.dto.patient.request.vaccine;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreateVaccineDTO(
+        @NotBlank(message = "O nome da vacina é obrigatório.")
+        @Size(min = 2, max = 100, message = "O nome da vacina deve ter entre 2 e 100 caracteres.")
+        String name
+) {}

--- a/apps/api/src/main/java/br/org/apae/api/common/dto/patient/request/vaccine/UpdateVaccineDTO.java
+++ b/apps/api/src/main/java/br/org/apae/api/common/dto/patient/request/vaccine/UpdateVaccineDTO.java
@@ -1,0 +1,10 @@
+package br.org.apae.api.common.dto.patient.request.vaccine;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdateVaccineDTO(
+        @NotBlank(message = "O nome da vacina é obrigatório.")
+        @Size(min = 2, max = 100, message = "O nome da vacina deve ter entre 2 e 100 caracteres.")
+        String name
+) {}

--- a/apps/api/src/main/java/br/org/apae/api/controllers/vaccine/VaccineControllerImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/controllers/vaccine/VaccineControllerImpl.java
@@ -1,11 +1,16 @@
 package br.org.apae.api.controllers.vaccine;
 
+import br.org.apae.api.common.dto.patient.request.vaccine.CreateVaccineDTO;
+import br.org.apae.api.common.dto.patient.request.vaccine.UpdateVaccineDTO;
 import br.org.apae.api.patient.application.interfaces.VaccineApplicationService;
 import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
 import br.org.apae.api.patient.interfaces.controllers.VaccineController;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import java.util.List;
 import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -35,5 +40,23 @@ public class VaccineControllerImpl implements VaccineController {
     public ResponseEntity<VaccineResponseDTO> findByName(String name) {
         VaccineResponseDTO vaccine = vaccineService.findVaccineByName(name);
         return ResponseEntity.ok(vaccine);
+    }
+
+    @Override
+    public ResponseEntity<VaccineResponseDTO> create(@Valid CreateVaccineDTO dto) {
+        VaccineResponseDTO vaccine = vaccineService.createVaccine(dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(vaccine);
+    }
+
+    @Override
+    public ResponseEntity<VaccineResponseDTO> update(UUID id, @Valid UpdateVaccineDTO dto) {
+        VaccineResponseDTO vaccine = vaccineService.updateVaccine(id, dto);
+        return ResponseEntity.ok(vaccine);
+    }
+
+    @Override
+    public ResponseEntity<Void> delete(UUID id) {
+        vaccineService.deleteVaccine(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/apps/api/src/main/java/br/org/apae/api/patient/application/exceptions/PatientExceptionHandler.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/application/exceptions/PatientExceptionHandler.java
@@ -1,24 +1,12 @@
 package br.org.apae.api.patient.application.exceptions;
 
 import br.org.apae.api.common.exceptions.types.ErrorResponse;
-import br.org.apae.api.patient.domain.exceptions.AnnualRegistryConflictException;
-import br.org.apae.api.patient.domain.exceptions.DisorderConflictException;
-import br.org.apae.api.patient.domain.exceptions.DisorderMismatchException;
-import br.org.apae.api.patient.domain.exceptions.DisorderNotFoundException;
-import br.org.apae.api.patient.domain.exceptions.GuardianNotFoundException;
-import br.org.apae.api.patient.domain.exceptions.InvalidDataException;
-import br.org.apae.api.patient.domain.exceptions.ParentMismatchException;
-import br.org.apae.api.patient.domain.exceptions.ParentNotFoundException;
-import br.org.apae.api.patient.domain.exceptions.PatientConflictException;
-import br.org.apae.api.patient.domain.exceptions.PatientNotFoundException;
-import br.org.apae.api.patient.domain.exceptions.RegistryNotFoundException;
-import br.org.apae.api.patient.domain.exceptions.RegistryOwnershipException;
-import br.org.apae.api.patient.domain.exceptions.VaccineMismatchException;
-import br.org.apae.api.patient.domain.exceptions.VaccineNotFoundException;
+import br.org.apae.api.patient.domain.exceptions.*;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -251,5 +239,18 @@ public class PatientExceptionHandler {
     );
 
     return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+  }
+  @ExceptionHandler(VaccineConflictException.class)
+  public ResponseEntity<ProblemDetail> handleVaccineConflictException(VaccineConflictException ex) {
+    ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, ex.getMessage());
+    problemDetail.setTitle("Conflito de Vacina");
+    return ResponseEntity.status(HttpStatus.CONFLICT).body(problemDetail);
+  }
+
+  @ExceptionHandler(VaccineInUseException.class)
+  public ResponseEntity<ProblemDetail> handleVaccineInUseException(VaccineInUseException ex) {
+    ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, ex.getMessage());
+    problemDetail.setTitle("Vacina em Uso");
+    return ResponseEntity.status(HttpStatus.CONFLICT).body(problemDetail);
   }
 }

--- a/apps/api/src/main/java/br/org/apae/api/patient/application/interfaces/VaccineApplicationService.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/application/interfaces/VaccineApplicationService.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import br.org.apae.api.common.dto.patient.request.vaccine.CreateVaccineDTO;
+import br.org.apae.api.common.dto.patient.request.vaccine.UpdateVaccineDTO;
 import br.org.apae.api.common.dto.patient.request.vaccine.VaccineNameDTO;
 import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
 
@@ -15,4 +17,10 @@ public interface VaccineApplicationService {
   VaccineResponseDTO findVaccineByName(String name);
 
   Set<VaccineResponseDTO> findVaccines(Set<VaccineNameDTO> vaccineNames);
+
+  VaccineResponseDTO createVaccine(CreateVaccineDTO dto);
+
+  VaccineResponseDTO updateVaccine(UUID id, UpdateVaccineDTO dto);
+
+  void deleteVaccine(UUID id);
 }

--- a/apps/api/src/main/java/br/org/apae/api/patient/application/internal/VaccineApplicationServiceImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/application/internal/VaccineApplicationServiceImpl.java
@@ -1,5 +1,9 @@
 package br.org.apae.api.patient.application.internal;
 
+import br.org.apae.api.common.dto.patient.request.vaccine.CreateVaccineDTO;
+import br.org.apae.api.common.dto.patient.request.vaccine.UpdateVaccineDTO;
+import br.org.apae.api.patient.domain.exceptions.VaccineConflictException;
+import br.org.apae.api.patient.domain.exceptions.VaccineInUseException;
 import br.org.apae.api.patient.domain.exceptions.VaccineMismatchException;
 import br.org.apae.api.patient.domain.exceptions.VaccineNotFoundException;
 import br.org.apae.api.patient.domain.model.Vaccine;
@@ -77,5 +81,48 @@ public class VaccineApplicationServiceImpl implements VaccineApplicationService 
         }
 
         return vaccineMapper.toResponseDTOSet(vaccines);
+    }
+    @Override
+    @Transactional
+    public VaccineResponseDTO createVaccine(CreateVaccineDTO dto) {
+        if (vaccineRepository.existsByNameIgnoreCase(dto.name())) {
+            throw new VaccineConflictException();
+        }
+
+        Vaccine vaccine = vaccineMapper.toEntity(dto);
+        Vaccine savedVaccine = vaccineRepository.save(vaccine);
+
+        return vaccineMapper.toResponseDTO(savedVaccine);
+    }
+
+    @Override
+    @Transactional
+    public VaccineResponseDTO updateVaccine(UUID id, UpdateVaccineDTO dto) {
+        Vaccine vaccine = vaccineRepository.findById(id)
+                .orElseThrow(VaccineNotFoundException::new);
+
+        if (vaccineRepository.existsByNameIgnoreCaseAndIdNot(dto.name(), id)) {
+            throw new VaccineConflictException();
+        }
+
+        vaccine.updateName(dto.name());
+        Vaccine updatedVaccine = vaccineRepository.save(vaccine);
+
+        return vaccineMapper.toResponseDTO(updatedVaccine);
+    }
+
+    @Override
+    @Transactional
+    public void deleteVaccine(UUID id) {
+        if (!vaccineRepository.existsById(id)) {
+            throw new VaccineNotFoundException();
+        }
+
+        if (patientRepository.isVaccineInUse(id)) {
+            throw new VaccineInUseException();
+        }
+
+        vaccineRepository.deleteById(id);
+        vaccineRepository.flush();
     }
 }

--- a/apps/api/src/main/java/br/org/apae/api/patient/application/mappers/VaccineMapper.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/application/mappers/VaccineMapper.java
@@ -1,5 +1,6 @@
 package br.org.apae.api.patient.application.mappers;
 
+import br.org.apae.api.common.dto.patient.request.vaccine.CreateVaccineDTO;
 import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
 import br.org.apae.api.patient.domain.model.Vaccine;
 
@@ -25,5 +26,8 @@ public class VaccineMapper {
         return vaccines.stream()
                 .map(this::toResponseDTO)
                 .collect(Collectors.toSet());
+    }
+    public Vaccine toEntity(CreateVaccineDTO dto) {
+        return new Vaccine(dto.name());
     }
 }

--- a/apps/api/src/main/java/br/org/apae/api/patient/domain/exceptions/VaccineConflictException.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/domain/exceptions/VaccineConflictException.java
@@ -1,0 +1,11 @@
+package br.org.apae.api.patient.domain.exceptions;
+
+public class VaccineConflictException extends RuntimeException {
+    public VaccineConflictException(String message) {
+        super(message);
+    }
+
+    public VaccineConflictException() {
+        super("Já existe uma vacina cadastrada com este nome.");
+    }
+}

--- a/apps/api/src/main/java/br/org/apae/api/patient/domain/exceptions/VaccineInUseException.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/domain/exceptions/VaccineInUseException.java
@@ -1,0 +1,11 @@
+package br.org.apae.api.patient.domain.exceptions;
+
+public class VaccineInUseException extends RuntimeException {
+    public VaccineInUseException(String message) {
+        super(message);
+    }
+
+    public VaccineInUseException() {
+        super("A vacina não pode ser excluída pois está vinculada a um paciente.");
+    }
+}

--- a/apps/api/src/main/java/br/org/apae/api/patient/domain/repository/VaccineRepository.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/domain/repository/VaccineRepository.java
@@ -14,4 +14,8 @@ public interface VaccineRepository extends JpaRepository<Vaccine, UUID> {
     Optional<Vaccine> findByName(String name);
 
     Set<Vaccine> findByNameInIgnoreCase(Collection<String> names);
+
+    boolean existsByNameIgnoreCase(String name);
+
+    boolean existsByNameIgnoreCaseAndIdNot(String name, UUID id);
 }

--- a/apps/api/src/main/java/br/org/apae/api/patient/interfaces/controllers/VaccineController.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/interfaces/controllers/VaccineController.java
@@ -1,10 +1,13 @@
 package br.org.apae.api.patient.interfaces.controllers;
 
+import br.org.apae.api.common.dto.patient.request.vaccine.CreateVaccineDTO;
+import br.org.apae.api.common.dto.patient.request.vaccine.UpdateVaccineDTO;
 import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
@@ -36,4 +39,32 @@ public interface VaccineController {
         })
         @GetMapping("/search/by-name")
         ResponseEntity<VaccineResponseDTO> findByName(@RequestParam String name);
+
+        @Operation(summary = "Criar nova vacina", description = "Cadastra uma nova vacina no sistema.")
+        @ApiResponses(value = {
+                @ApiResponse(responseCode = "201", description = "Vacina criada com sucesso"),
+                @ApiResponse(responseCode = "400", description = "Dados de entrada inválidos"),
+                @ApiResponse(responseCode = "409", description = "Já existe uma vacina com esse nome")
+        })
+        @PostMapping
+        ResponseEntity<VaccineResponseDTO> create(@Valid @RequestBody CreateVaccineDTO dto);
+
+        @Operation(summary = "Atualizar vacina existente", description = "Atualiza os dados de uma vacina pelo seu ID.")
+        @ApiResponses(value = {
+                @ApiResponse(responseCode = "200", description = "Vacina atualizada com sucesso"),
+                @ApiResponse(responseCode = "400", description = "Dados de entrada inválidos"),
+                @ApiResponse(responseCode = "404", description = "Vacina não encontrada"),
+                @ApiResponse(responseCode = "409", description = "Já existe uma vacina com esse nome")
+        })
+        @PutMapping("/{id}")
+        ResponseEntity<VaccineResponseDTO> update(@PathVariable UUID id, @Valid @RequestBody UpdateVaccineDTO dto);
+
+        @Operation(summary = "Excluir vacina", description = "Remove uma vacina do sistema pelo seu ID.")
+        @ApiResponses(value = {
+                @ApiResponse(responseCode = "204", description = "Vacina excluída com sucesso"),
+                @ApiResponse(responseCode = "404", description = "Vacina não encontrada"),
+                @ApiResponse(responseCode = "409", description = "Vacina está em uso e não pode ser excluída")
+        })
+        @DeleteMapping("/{id}")
+        ResponseEntity<Void> delete(@PathVariable UUID id);
 }


### PR DESCRIPTION
# O que mudou?

Este PR implementa o CRUD completo de vacinas, tanto no backend (API) quanto no frontend (APAE). Antes da mudança, as vacinas só podiam ser listadas e consultadas; agora é possível criar, editar e excluir registros de vacinas, com validações e tratamento de conflitos.

## Issue Relacionadas

Closes #954

## Mudanças Realizadas

* **API — Criação, edição e exclusão de vacinas**: novos endpoints `POST /vaccines`, `PUT /vaccines/{id}` e `DELETE /vaccines/{id}` com DTOs de entrada validados (`CreateVaccineDTO`, `UpdateVaccineDTO`), lógica de negócio no `VaccineApplicationServiceImpl`, mapeamento e métodos no repositório (`existsByNameIgnoreCaseAndIdNot`).
* **API — Exceções e tratamento de erros**: novas exceções `VaccineConflictException` (nome duplicado) e `VaccineInUseException` (vacina vinculada a pacientes), tratadas no `PatientExceptionHandler` com status `409 Conflict` e `404 Not Found` para vacina inexistente.
* **Frontend — Páginas de criação e edição**: novas rotas `/vaccines/new` e `/vaccines/[id]/edit`, com formulários e hooks (`use-vaccine-create`, `use-vaccine-edit`), schemas Zod de validação e campos com capitalização automática.
* **Frontend — Ações na listagem**: botão "Adicionar" na listagem de vacinas, e ações de editar/excluir em cada item da lista, com modal de confirmação para exclusão e bloqueio (com tooltip) para vacinas associadas a pacientes.
* **Frontend — Integração com a API**: funções `fetchVaccineApi`, `createVaccineApi`, `updateVaccineApi` e `deleteVaccineApi`, além das rotas proxy do Next.js (`POST /api/vaccines` e `/api/vaccines/[id]`).

## Evidências

As evidências estão registradas e documentadas na issue .
