### PR TITLE
[CHORE] Padronizar e refatorar Dockerfiles dos projetos APAE

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -86,6 +86,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             NEXT_PUBLIC_API_URL=/apae-geral/api
+            APP_VERSION=${{ steps.meta.outputs.version }}
+            VCS_REF=${{ github.sha }}
           cache-from: type=gha,scope=frontend
           cache-to: type=gha,mode=max,scope=frontend
 
@@ -134,5 +136,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APP_VERSION=${{ steps.meta.outputs.version }}
+            VCS_REF=${{ github.sha }}
           cache-from: type=gha,scope=backend
           cache-to: type=gha,mode=max,scope=backend

--- a/apps/apae/.dockerignore
+++ b/apps/apae/.dockerignore
@@ -1,35 +1,14 @@
-# Dependências e artefatos de build
-node_modules
-.next
-out
-build
-coverage
+**
+!package.json
+!package-lock.json
+!next.config.ts
+!tsconfig.json
+!postcss.config.mjs
+!components.json
+!eslint.config.mjs
 
-# Logs
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-.pnpm-debug.log*
+!public/
+!public/**
 
-# Ambiente local
-.env
-.env.*
-!.env.example
-
-# Git / IDE / SO
-.git
-.gitignore
-.vscode
-.idea
-.DS_Store
-Thumbs.db
-
-# Docker
-Dockerfile
-.dockerignore
-
-# Misc
-*.tsbuildinfo
-next-env.d.ts
-.vercel
-README.md
+!src/
+!src/**

--- a/apps/apae/Dockerfile
+++ b/apps/apae/Dockerfile
@@ -1,10 +1,8 @@
 # syntax=docker/dockerfile:1.7
 
-# dependências
-FROM node:20-alpine AS deps
-WORKDIR /app
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS builder
 
-RUN apk add --no-cache libc6-compat
+WORKDIR /app
 
 COPY package.json ./
 COPY package-lock.json* ./
@@ -15,21 +13,28 @@ RUN if [ -f package-lock.json ]; then \
       npm install --no-audit --no-fund; \
     fi
 
-# build
-FROM node:20-alpine AS builder
-WORKDIR /app
+COPY . .
 
 ARG NEXT_PUBLIC_API_URL=/apae-geral/api
-ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
-ENV NEXT_TELEMETRY_DISABLED=1
 
-COPY --from=deps /app/node_modules ./node_modules
-COPY . .
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+ENV NEXT_TELEMETRY_DISABLED=1
 
 RUN npm run build
 
-# ---------- Stage 3: runtime ----------
-FROM node:20-alpine AS runner
+
+FROM gcr.io/distroless/nodejs20-debian13:nonroot@sha256:c8da1b6cccb5c6cc4b8826c67353f31c5f7b2719c5517b1312d191b337d8bd99 AS runner
+
+ARG APP_VERSION
+ARG VCS_REF
+
+LABEL org.opencontainers.image.title="APAE Geral Frontend" \
+      org.opencontainers.image.description="Frontend do sistema APAE" \
+      org.opencontainers.image.source="https://github.com/IFPBEsp/APAE" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.version=$APP_VERSION \
+      org.opencontainers.image.revision=$VCS_REF
+
 WORKDIR /app
 
 ENV NODE_ENV=production
@@ -37,19 +42,12 @@ ENV NEXT_TELEMETRY_DISABLED=1
 ENV PORT=3000
 ENV HOSTNAME=0.0.0.0
 
-RUN apk add --no-cache wget \
- && addgroup -S -g 1001 appgroup \
- && adduser  -S -u 1001 -G appgroup appuser
+COPY --from=builder --chown=65532:65532 /app/public ./public
+COPY --from=builder --chown=65532:65532 /app/.next/standalone ./
+COPY --from=builder --chown=65532:65532 /app/.next/static ./.next/static
 
-COPY --from=builder --chown=appuser:appgroup /app/public         ./public
-COPY --from=builder --chown=appuser:appgroup /app/.next/standalone ./
-COPY --from=builder --chown=appuser:appgroup /app/.next/static    ./.next/static
-
-USER appuser
+USER 65532:65532
 
 EXPOSE 3000
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-  CMD wget -qO- http://127.0.0.1:3000/apae-geral >/dev/null 2>&1 || exit 1
-
-CMD ["node", "server.js"]
+CMD ["server.js"]

--- a/apps/api/.dockerignore
+++ b/apps/api/.dockerignore
@@ -1,40 +1,4 @@
-# Artefatos de build
-target/
-**/target/
-*.jar
-*.war
-
-# Wrapper Maven (usamos a imagem maven oficial)
-.mvn/wrapper/maven-wrapper.jar
-
-# IDEs e Sistema
-.idea
-.vscode
-.settings
-.classpath
-.project
-.factorypath
-*.iml
-*.iws
-*.ipr
-.DS_Store
-Thumbs.db
-
-# Git
-.git
-.gitignore
-.gitattributes
-
-# Docker
-Dockerfile
-.dockerignore
-
-# Ambiente local
-.env
-.env.*
-!.env.example
-
-# Logs e relatórios
-*.log
-HELP.md
-README.md
+**
+!pom.xml
+!src/
+!src/**

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,35 +1,38 @@
 # syntax=docker/dockerfile:1.7
 
-# build
-FROM maven:3.9-eclipse-temurin-21-alpine AS builder
+FROM maven:3.9-eclipse-temurin-21-alpine@sha256:65353f527c86cb23187c8233475713e15067e8d36220d18863c379680698fe85 AS builder
+
 WORKDIR /workspace
 
-COPY pom.xml ./
-RUN mvn -B -q dependency:go-offline
-
+COPY pom.xml .
 COPY src ./src
-RUN mvn -B -q clean package -Dmaven.test.skip=true \
- && cp target/*.jar /workspace/app.jar
 
-# runtime
-FROM eclipse-temurin:21-jre-alpine AS runner
+RUN --mount=type=cache,id=apae-backend-m2,target=/root/.m2 \
+    mvn -B -q package -Dmaven.test.skip=true \
+    && cp target/*.jar /workspace/app.jar
+
+
+FROM gcr.io/distroless/java21-debian13:nonroot@sha256:bb0b3c7edc4417acdf76ea0f52bb5fae28881fe05aae6cc55af4cc4cb0200d2d AS runner
+
+ARG APP_VERSION
+ARG VCS_REF
+
+LABEL org.opencontainers.image.title="APAE Geral Backend" \
+      org.opencontainers.image.description="Backend do sistema APAE" \
+      org.opencontainers.image.source="https://github.com/IFPBEsp/APAE" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.version=$APP_VERSION \
+      org.opencontainers.image.revision=$VCS_REF
+
 WORKDIR /app
 
-RUN apk add --no-cache wget \
- && addgroup -S -g 1001 appgroup \
- && adduser  -S -u 1001 -G appgroup appuser
-
-COPY --from=builder --chown=appuser:appgroup /workspace/app.jar ./app.jar
+COPY --from=builder --chown=65532:65532 /workspace/app.jar ./app.jar
 
 ENV API_PORT=8080
-ENV JAVA_OPTS=""
 
-USER appuser
+USER 65532:65532
 
 EXPOSE 8080
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \
-  CMD wget -qO- http://127.0.0.1:8080/apae-geral/actuator/health 2>/dev/null \
-      | grep -q '"status":"UP"' || exit 1
-
-ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar /app/app.jar"]
+ENTRYPOINT ["/usr/bin/java"]
+CMD ["-jar", "/app/app.jar"]

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -34,5 +34,4 @@ USER 65532:65532
 
 EXPOSE 8080
 
-ENTRYPOINT ["/usr/bin/java"]
-CMD ["-jar", "/app/app.jar"]
+CMD ["/app/app.jar"]


### PR DESCRIPTION
# O que mudou?

Este PR refatora as imagens Docker do backend e frontend do APAE Geral, padronizando o processo de build e os runtimes conforme a estratégia adotada nos demais produtos APAE.

As alterações têm como objetivo reduzir a superfície de ataque, melhorar o tempo de build, diminuir o tamanho das imagens, tornar os builds mais reproduzíveis e preparar os serviços para publicação no GHCR e execução em Kubernetes/K3s.

## Tarefas Relacionadas

* Issue: IFPBEsp/APAE-INFRA#25
* Outras dependências: N/A

## Mudanças Realizadas

* Refatoração do Dockerfile do backend:
  * remoção de `dependency:go-offline`;
  * adoção de cache Maven com BuildKit em `/root/.m2`;
  * remoção de `clean` no build;
  * migração do runtime Alpine para Distroless Java 21 Debian;
  * remoção de `wget`, `apk`, shell e Docker `HEALTHCHECK`;
  * execução direta do Java;
  * padronização do runtime com `USER 65532:65532`;
  * pinning das imagens base por digest;
  * inclusão de labels OCI;
  * adoção de `.dockerignore` em allowlist.

* Refatoração do Dockerfile do frontend:
  * simplificação dos stages `deps` e `builder` para um único builder;
  * manutenção do Next.js `standalone`;
  * migração do runtime Alpine para Distroless Node.js 20 Debian;
  * remoção de `npm`, `npx`, `wget`, `apk`, shell e Docker `HEALTHCHECK` do runtime;
  * padronização do runtime com `USER 65532:65532`;
  * pinning das imagens base por digest;
  * inclusão de labels OCI;
  * adoção de `.dockerignore` em allowlist.

* Mantida compatibilidade com o estado atual do frontend, que não possui `package-lock.json` versionado:
  * utiliza `npm ci` quando o lockfile existir;
  * utiliza `npm install --no-audit --no-fund` como fallback.

## Evidências

### Backend

#### Build

| Cenário | Antes | Depois |
|---|---:|---:|
| Build limpo | 224,04 s | 78,01 s |
| Build cacheado | 3,79 s | 2,46 s |
| Alteração em código | 14,62 s | 6,82 s |

Principais resultados:

```text
Build limpo:   224,04 s → 78,01 s
Source-change: 14,62 s → 6,82 s
```

#### Tamanho

| Métrica | Antes | Depois |
|---|---:|---:|
| Disk Usage | 452 MB | 423 MB |
| Content Size | 151 MB | 140 MB |

#### Vulnerabilidades

Sistema operacional:

```text
HIGH:     3 → 1
CRITICAL: 0 → 0
```

Dependências Java:

```text
HIGH:     21 → 21
CRITICAL: 5 → 5
```

Os findings Java permaneceram inalterados por pertencerem às dependências da aplicação e não à imagem base.

Runtime final:

```text
Distroless Java 21 Debian
USER 65532:65532
```

---

### Frontend

#### Build

| Cenário | Antes | Depois |
|---|---:|---:|
| Build limpo | 366,91 s | 208,25 s |
| Build cacheado | 3,90 s | 5,14 s |
| Alteração em código | 26,92 s | 26,66 s |

Principal resultado:

```text
Build limpo: 366,91 s → 208,25 s
```

#### Tamanho

| Métrica | Antes | Depois |
|---|---:|---:|
| Disk Usage | 262 MB | 243 MB |
| Content Size | 63,7 MB | 60,4 MB |

#### Vulnerabilidades

Sistema operacional:

```text
HIGH:     4 → 2
CRITICAL: 0 → 0
```

Dependências Node.js:

```text
HIGH:     31 → 12
CRITICAL: 1 → 0
```

Runtime final:

```text
Distroless Node.js 20 Debian
USER 65532:65532
```

---

Os builds finais de backend e frontend foram executados e validados com sucesso após as alterações.