### PR TITLE
fix: remove log de SQL do perfil padrão e corrige Hibernate (#914)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,8 @@ MINIO_DATA_PATH=/home/seu-usuario/minio/data
 # API - SPRING
 # =========================
 API_PORT=8090
+# Ativa o perfil de desenvolvimento (log de SQL). Não usar em produção.
+SPRING_PROFILES_ACTIVE=dev
 DB_URL=jdbc:postgresql://localhost:5200/apae
 DB_USERNAME=user
 DB_PASSWORD=pass

--- a/apps/api/src/main/resources/application-dev.yaml
+++ b/apps/api/src/main/resources/application-dev.yaml
@@ -1,0 +1,12 @@
+spring:
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+logging:
+  level:
+    org:
+      hibernate:
+        SQL: DEBUG

--- a/apps/api/src/main/resources/application-dev.yaml
+++ b/apps/api/src/main/resources/application-dev.yaml
@@ -1,6 +1,5 @@
 spring:
   jpa:
-    show-sql: true
     properties:
       hibernate:
         format_sql: true

--- a/apps/api/src/main/resources/application.yaml
+++ b/apps/api/src/main/resources/application.yaml
@@ -2,6 +2,19 @@ spring:
   application:
     name: api
 
+# Importa o arquivo .env como fonte de properties, permitindo executar a
+# aplicacao pela IDE ou via `pnpm dev:backend` sem exportar variaveis de
+# ambiente manualmente. E dele que vem tambem SPRING_PROFILES_ACTIVE=dev,
+# que ativa o application-dev.yaml (log de SQL) fora de producao.
+# Os dois caminhos cobrem a execucao a partir do modulo (apps/api) e da
+# raiz do monorepo, e ambos sao opcionais: em container o arquivo nao
+# existe e as variaveis de ambiente do SO, de maior precedencia,
+# fornecem os valores.
+  config:
+    import:
+      - optional:file:./.env[.properties]
+      - optional:file:../../.env[.properties]
+
   autoconfigure:
     exclude:
       - org.springframework.boot.actuate.autoconfigure.mail.MailHealthContributorAutoConfiguration

--- a/apps/api/src/main/resources/application.yaml
+++ b/apps/api/src/main/resources/application.yaml
@@ -15,11 +15,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
-    show-sql: true
     properties:
       hibernate:
         default_schema: apae_geral
-        format_sql: true
 
   flyway:
     enabled: true
@@ -50,15 +48,7 @@ spring:
           starttls:
             enable: true
 
-logging:
-  level:
-    org:
-      hibernate:
-        SQL: DEBUG
-        type:
-          descriptor:
-            sql:
-              BasicBinder: TRACE
+
 
 app:
   token:


### PR DESCRIPTION
# O que mudou?
Este PR resolve a exposição indevida de logs SQL em ambiente de produção (evitando lentidão e o vazamento de dados sensíveis de pacientes) e remove configurações obsoletas do Hibernate.

## Tarefas Relacionadas
* Issue: Resolves #914
* Outras dependências: N/A

## Mudanças Realizadas
* Remoção das configurações `show-sql` e `format_sql` do arquivo principal `application.yaml`.
* Remoção definitiva da propriedade defasada `BasicBinder`.
* Criação do perfil isolado `application-dev.yaml` com as configurações de log ativas exclusivamente para desenvolvimento.

## Evidências

Requisição enviada via terminal forçando uma consulta ao banco:
<img width="1920" height="1048" alt="P1" src="https://github.com/user-attachments/assets/662b5468-a0f9-4864-9c16-4057c261908a" />

Log do Spring Boot processando a exceção do login sem vazar a instrução SQL:
<img width="1024" height="576" alt="P2" src="https://github.com/user-attachments/assets/725b79da-c93f-43d5-b18d-b3ac0c895784" />


## Verificações
- [x] O build local do backend inicializou com sucesso.