### PR TITLE
fix: correcao do retorno 401

### DIFF
--- a/apps/apae/src/lib/axios-client.ts
+++ b/apps/apae/src/lib/axios-client.ts
@@ -1,0 +1,18 @@
+import axios from "axios";
+
+export const clientApi = axios.create({
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+clientApi.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401 && typeof window !== "undefined") {
+      window.location.href = "/apae-geral/auth/login";
+    }
+
+    return Promise.reject(error);
+  },
+);

--- a/apps/apae/src/lib/axios.ts
+++ b/apps/apae/src/lib/axios.ts
@@ -6,7 +6,6 @@ import axios, {
   AxiosResponse,
   InternalAxiosRequestConfig,
 } from "axios";
-import { redirect } from "next/navigation";
 import { getTokenFromCookie, removeSessionCookie } from "./cookies";
 
 const LOCAL_API_BASE_URL = "http://localhost:8090/apae-geral/api";
@@ -16,8 +15,6 @@ function trimTrailingSlash(baseURL?: string) {
 }
 
 function getBaseApiURL() {
-  // Atualizado para englobar a lógica da branch fix:
-  // Tenta primeiro a URL absoluta do servidor, depois a pública, e cai no fallback
   return (
     trimTrailingSlash(process.env.API_URL) ||
     trimTrailingSlash(process.env.NEXT_PUBLIC_API_URL) ||
@@ -77,11 +74,7 @@ const makeInterceptors = (api: AxiosInstance) => {
     async (error: AxiosError) => {
       if (error.response?.status === 401) {
         console.warn("Token expirado ou inválido. Removendo sessão...");
-
         await removeSessionCookie();
-        if (typeof window === "undefined") {
-          redirect("/apae-geral/auth/login");
-        }
       }
 
       return Promise.reject(error);
@@ -97,9 +90,6 @@ export const createDocumentsAPI = async () => {
 };
 
 export const createBaseApi = async () => {
-  // Esta função roda no servidor ("use server"). Em produção/container o
-  // backend é alcançado por uma URL absoluta (API_URL), pois NEXT_PUBLIC_API_URL
-  // é relativa (/apae-geral/api) e o axios server-side não resolve URL relativa.
   const api = createAxiosInstance(getBaseApiURL());
 
   return makeInterceptors(api);

--- a/apps/apae/src/services/profissional-service.ts
+++ b/apps/apae/src/services/profissional-service.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { clientApi } from "@/lib/axios-client";
 
 export async function getAllProfessionals(active?: boolean) {
   const url =
@@ -7,15 +8,8 @@ export async function getAllProfessionals(active?: boolean) {
       : `/apae-geral/api/professionals?ativo=${active}`;
 
   console.log("[getAllProfessionals] ativo:", active, "| url:", url);
-  return axios.get(url);
+  return clientApi.get(url);
 }
-
-/*export async function deleteProfessional(id: string) {
-  const response = await fetch(API_URL + `/professionals/${id}`, {
-    method: "DELETE",
-  });
-  return response;
-}*/
 
 export async function inactivateProfessional(id: string) {
   const response = await fetch(`/apae-geral/api/professionals/${id}/inactivate`, {
@@ -54,7 +48,7 @@ export async function updateProfessional(id: string, data: unknown) {
 
 export async function getProfessionalById(id: string) {
   try {
-    const response = await axios.get(`/apae-geral/api/professionals/${id}`);
+    const response = await clientApi.get(`/apae-geral/api/professionals/${id}`);
     return response.data;
   } catch (error) {
     if (axios.isAxiosError(error)) {
@@ -66,7 +60,7 @@ export async function getProfessionalById(id: string) {
 
 export async function getProfessionalDocuments(id: string) {
   try {
-    const response = await axios.get(`/apae-geral/api/professionals/${id}/documents`);
+    const response = await clientApi.get(`/apae-geral/api/professionals/${id}/documents`);
     return response.data || [];
   } catch (error) {
     if (axios.isAxiosError(error)) {
@@ -75,7 +69,6 @@ export async function getProfessionalDocuments(id: string) {
     throw error;
   }
 }
-
 
 export async function updateProfessionalDocuments(id: string, formData: FormData) {
   return fetch(`/apae-geral/api/professionals/${id}/documents`, {

--- a/apps/api/src/main/java/br/org/apae/api/auth/infrastructure/security/CustomAuthenticationEntryPoint.java
+++ b/apps/api/src/main/java/br/org/apae/api/auth/infrastructure/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,37 @@
+package br.org.apae.api.auth.infrastructure.security;
+
+import java.io.IOException;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import br.org.apae.api.common.exceptions.types.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+  private final ObjectMapper objectMapper;
+
+  public CustomAuthenticationEntryPoint(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public void commence(HttpServletRequest request, HttpServletResponse response,
+      AuthenticationException authException) throws IOException {
+    var errorResponse = new ErrorResponse(
+        HttpServletResponse.SC_UNAUTHORIZED,
+        "Unauthorized",
+        "Autenticação necessária.",
+        request.getRequestURI());
+
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    response.setContentType("application/json");
+    response.setCharacterEncoding("UTF-8");
+    response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+  }
+}

--- a/apps/api/src/main/java/br/org/apae/api/auth/infrastructure/security/SecurityConfiguration.java
+++ b/apps/api/src/main/java/br/org/apae/api/auth/infrastructure/security/SecurityConfiguration.java
@@ -22,9 +22,12 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @EnableWebSecurity
 public class SecurityConfiguration {
     private final SecurityFilter securityFilter;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
 
-    public SecurityConfiguration(SecurityFilter securityFilter) {
+    public SecurityConfiguration(SecurityFilter securityFilter,
+            CustomAuthenticationEntryPoint authenticationEntryPoint) {
         this.securityFilter = securityFilter;
+        this.authenticationEntryPoint = authenticationEntryPoint;
     }
 
     @Bean
@@ -34,6 +37,8 @@ public class SecurityConfiguration {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
 
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(authenticationEntryPoint))
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(
                                 "/auth/**"

--- a/apps/api/src/main/java/br/org/apae/api/auth/infrastructure/security/SecurityFilter.java
+++ b/apps/api/src/main/java/br/org/apae/api/auth/infrastructure/security/SecurityFilter.java
@@ -8,7 +8,10 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import br.org.apae.api.auth.application.internal.UserService;
+import br.org.apae.api.common.exceptions.types.ErrorResponse;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -18,10 +21,12 @@ import jakarta.servlet.http.HttpServletResponse;
 public class SecurityFilter extends OncePerRequestFilter {
   JwtProvider jwtProvider;
   UserService userService;
+  ObjectMapper objectMapper;
 
-  public SecurityFilter(JwtProvider jwtProvider, UserService userService) {
+  public SecurityFilter(JwtProvider jwtProvider, UserService userService, ObjectMapper objectMapper) {
     this.jwtProvider = jwtProvider;
     this.userService = userService;
+    this.objectMapper = objectMapper;
   }
 
   private String recoverToken(HttpServletRequest request) {
@@ -40,13 +45,32 @@ public class SecurityFilter extends OncePerRequestFilter {
     var token = this.recoverToken(request);
 
     if (token != null) {
-      var username = jwtProvider.validateToken(token);
-      UserDetails user = userService.findUserByUsername(username);
+      try {
+        var username = jwtProvider.validateToken(token);
+        UserDetails user = userService.findUserByUsername(username);
 
-      var authentication = new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
-      SecurityContextHolder.getContext().setAuthentication(authentication);
+        var authentication = new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+      } catch (Exception ex) {
+        this.sendUnauthorized(request, response, "Token inválido ou expirado.");
+        return;
+      }
     }
 
     filterChain.doFilter(request, response);
+  }
+
+  private void sendUnauthorized(HttpServletRequest request, HttpServletResponse response, String message)
+      throws IOException {
+    var errorResponse = new ErrorResponse(
+        HttpServletResponse.SC_UNAUTHORIZED,
+        "Unauthorized",
+        message,
+        request.getRequestURI());
+
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    response.setContentType("application/json");
+    response.setCharacterEncoding("UTF-8");
+    response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
   }
 }


### PR DESCRIPTION
## O que foi feito

Corrige o `SecurityFilter` para devolver `401` (em vez de `403` com corpo vazio) quando a requisição não tem token ou o token é inválido, no formato `ErrorResponse` já adotado no projeto.

A issue original presumia que "nenhuma alteração no frontend é necessária", mas durante o teste manual isso não se confirmou: o frontend não tinha nenhum tratamento de 401 no lado do cliente. Este PR também inclui as correções de frontend necessárias para o fluxo funcionar de ponta a ponta.

## Mudanças

**Backend**
- `SecurityFilter.java`: responde `401` no formato `ErrorResponse` para token ausente/inválido, sem deixar a exceção escapar até o `DispatcherServlet`

**Frontend**
- `lib/axios.ts`: removido `redirect()` do interceptor (não funciona em Route Handlers, causava `500` genérico)
- `lib/axios-client.ts` **(novo)**: instância de axios client-side com interceptor que redireciona para `/auth/login` em 401
- `services/profissional-service.ts`: chamadas GET migradas para usar essa nova instância

## Por que o frontend precisou de mudanças

A issue original assumia que o interceptor do frontend já tratava 401 e que bastava a correção do backend. Na validação, constatamos que:
- Não existia nenhum interceptor client-side no projeto (busca por `window.location` e `axios.interceptors` não retornou nenhum resultado fora do `lib/axios.ts`, que roda só no servidor)
- O hook `use-fetch-profissional.ts` apenas armazenava a mensagem de erro em estado local, sem verificar o status ou redirecionar

## Como testar

1. `curl` sem token / com token inválido em `/professionals` → confirma `401` com corpo `ErrorResponse`
2. Login válido → editar cookie `session` no DevTools para token inválido → recarregar → confirma redirecionamento ao login

## Critérios de Aceite

- [x] Sem `Authorization` → 401
- [x] Token inválido → 401
- [x] Corpo no formato `ErrorResponse`
- [x] Sem stack trace ERROR
- [x] Sessão expirada redireciona ao login

## Observação

Chamadas via `fetch` direto (não-axios) em `profissional-service.ts` e outros `services/*.ts` ainda não passam pelo novo interceptor — fica como débito técnico para follow-up.

## Evidências

Inclua imagens, vídeos, prints de logs, ou qualquer evidência que comprove que a funcionalidade está funcionando conforme o esperado.
