### PR TITLE
fix: aplica CORS_ALLOWED_ORIGINS na configuracao de seguranca

### DIFF
--- a/apps/api/src/main/java/br/org/apae/api/auth/infrastructure/security/SecurityConfiguration.java
+++ b/apps/api/src/main/java/br/org/apae/api/auth/infrastructure/security/SecurityConfiguration.java
@@ -2,6 +2,7 @@ package br.org.apae.api.auth.infrastructure.security;
 
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -22,9 +23,12 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @EnableWebSecurity
 public class SecurityConfiguration {
     private final SecurityFilter securityFilter;
+    private final List<String> allowedOrigins;
 
-    public SecurityConfiguration(SecurityFilter securityFilter) {
+    public SecurityConfiguration(SecurityFilter securityFilter,
+            @Value("${cors.allowed-origins}") List<String> allowedOrigins) {
         this.securityFilter = securityFilter;
+        this.allowedOrigins = allowedOrigins;
     }
 
     @Bean
@@ -66,9 +70,9 @@ public class SecurityConfiguration {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
-        configuration.setAllowedMethods(List.of("*"));
-        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowedOrigins(allowedOrigins);
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("Authorization", "Content-Type"));
         configuration.setAllowCredentials(true);
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);


### PR DESCRIPTION
# O que mudou?

Ajustada a configuração global de CORS em `SecurityConfiguration.java` para consumir a propriedade `cors.allowed-origins` (alimentada pela variável de ambiente `CORS_ALLOWED_ORIGINS`). A origem anteriormente estava fixa em `http://localhost:3000`, inviabilizando implantações fora do ambiente local. Aproveitou-se a alteração para restringir os métodos e cabeçalhos HTTP aceitos pela API.

## Tarefas Relacionadas

* Closes #912

## Mudanças Realizadas

* Injeção dinâmica das origens permitidas via propriedade `cors.allowed-origins` em `SecurityConfiguration.java`.
* Restrição dos métodos HTTP permitidos para `GET, POST, PUT, PATCH, DELETE, OPTIONS`.
* Restrição dos cabeçalhos HTTP permitidos para `Authorization, Content-Type, Accept, X-Requested-With, Origin`.

## Evidências

### Tests de Preflight CORS (OPTIONS)

* **Antes da correção (`[https://apae.exemplo.org](https://apae.exemplo.org)`):** Retorno `403 Forbidden` (Invalid CORS request).

<img width="1657" height="457" alt="antes-da-correcao" src="https://github.com/user-attachments/assets/86e42852-79bb-4cbd-b9da-79ad4ebca03c" />

* **Após a correção (`https://apae.exemplo.org`):** Retorno `200 OK`.
<img width="1672" height="313" alt="apos-a-correcao" src="https://github.com/user-attachments/assets/f83961cc-45bf-444a-8dc7-25418cfb0ca9" />

* **Origem não autorizada (`https://site-falso.com`):** Retorno `403 Forbidden`.

<img width="1668" height="349" alt="site-falso" src="https://github.com/user-attachments/assets/5e4dca34-fdc1-46d8-bc3e-112d1e17cd22" />



### Testes das Rotas da Aplicação

* **POST (`/auth/signin`):** Fluxo de autenticação executado com sucesso (`200 OK`).

<img width="1675" height="282" alt="teste de login" src="https://github.com/user-attachments/assets/a03c61d5-ba9d-4420-8c92-92d7b76715df" />


* **GET (`/vaccines`):** Requisição autenticada em rota protegida (`200 OK`).

<img width="1682" height="386" alt="get-vacinas" src="https://github.com/user-attachments/assets/e5fb00a0-44cb-4dea-8f08-b5555b7603f4" />
