### PR TITLE
[TREINAMENTO] CRUD de Vacinas — João Augusto

### DIFF
--- a/apps/apae/src/app/api/vaccines/[id]/route.ts
+++ b/apps/apae/src/app/api/vaccines/[id]/route.ts
@@ -1,0 +1,54 @@
+import { createBaseApi } from "@/lib/axios";
+import { updateVaccineSchema } from "@/domains/vaccines/vaccines.schema";
+import { NextResponse } from "next/server";
+import { AxiosError } from "axios";
+
+interface IParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function GET(request: Request, { params }: IParams) {
+  try {
+    const { id } = await params;
+    const api = await createBaseApi();
+    const { data } = await api.get(`/vaccines/${id}`);
+    return NextResponse.json(data);
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      return new NextResponse(JSON.stringify(error.response?.data || { message: error.message }), { status: error.response?.status || 500 });
+    }
+    return new NextResponse(JSON.stringify({ message: "Erro ao buscar dados." }), { status: 500 });
+  }
+}
+
+export async function PUT(request: Request, { params }: IParams) {
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const validation = updateVaccineSchema.safeParse(body);
+    if (!validation.success) return NextResponse.json({ errors: validation.error.flatten() }, { status: 400 });
+
+    const api = await createBaseApi();
+    const { data } = await api.put(`/vaccines/${id}`, validation.data);
+    return NextResponse.json(data);
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      return new NextResponse(JSON.stringify(error.response?.data || { message: error.message }), { status: error.response?.status || 500 });
+    }
+    return new NextResponse(JSON.stringify({ message: "Erro ao atualizar dados." }), { status: 500 });
+  }
+}
+
+export async function DELETE(request: Request, { params }: IParams) {
+  try {
+    const { id } = await params;
+    const api = await createBaseApi();
+    const { data } = await api.delete(`/vaccines/${id}`);
+    return NextResponse.json(data);
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      return new NextResponse(JSON.stringify(error.response?.data || { message: error.message }), { status: error.response?.status || 500 });
+    }
+    return new NextResponse(JSON.stringify({ message: "Erro ao excluir dados." }), { status: 500 });
+  }
+}

--- a/apps/apae/src/app/api/vaccines/route.ts
+++ b/apps/apae/src/app/api/vaccines/route.ts
@@ -13,3 +13,17 @@ export async function GET() {
         );
     }
 }
+
+export async function POST(request: Request) {
+    try {
+        const body = await request.json();
+        const api = await createBaseApi();
+        const { data } = await api.post("/vaccines", body);
+        return NextResponse.json(data, { status: 201 });
+    } catch (error) {
+        const message = error instanceof Error ? error.message : "Erro desconhecido";
+        console.error("Erro ao criar vacina:", message);
+        return NextResponse.json({ message: "Erro ao criar a vacina." }, { status: 500 });
+    }
+}
+

--- a/apps/apae/src/app/api/vaccines/route.ts
+++ b/apps/apae/src/app/api/vaccines/route.ts
@@ -1,5 +1,6 @@
 import { createBaseApi } from "@/lib/axios";
 import { NextResponse } from "next/server";
+import { AxiosError } from "axios";
 
 export async function GET() {
     try {
@@ -7,10 +8,15 @@ export async function GET() {
         const { data } = await api.get("/vaccines");
         return NextResponse.json(data);
     } catch (error) {
-        const message = error instanceof Error ? error.message : "Erro desconhecido";
-        console.error("Erro ao buscar vacinas:", message);
-        return NextResponse.json({ message: "Erro ao buscar a lista de vacinas." }, { status: 500 }
-        );
+        if (error instanceof AxiosError) {
+            return NextResponse.json(
+                error.response?.data || { message: error.message },
+                { status: error.response?.status || 500 }
+            );
+        }
+
+        console.error("Erro ao buscar vacinas:", error);
+        return NextResponse.json({ message: "Erro ao buscar a lista de vacinas." }, { status: 500 });
     }
 }
 
@@ -21,9 +27,14 @@ export async function POST(request: Request) {
         const { data } = await api.post("/vaccines", body);
         return NextResponse.json(data, { status: 201 });
     } catch (error) {
-        const message = error instanceof Error ? error.message : "Erro desconhecido";
-        console.error("Erro ao criar vacina:", message);
+        if (error instanceof AxiosError) {
+            return NextResponse.json(
+                error.response?.data || { message: error.message },
+                { status: error.response?.status || 500 }
+            );
+        }
+
+        console.error("Erro ao criar vacina:", error);
         return NextResponse.json({ message: "Erro ao criar a vacina." }, { status: 500 });
     }
 }
-

--- a/apps/apae/src/app/vaccines/[id]/edit/page.tsx
+++ b/apps/apae/src/app/vaccines/[id]/edit/page.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { VaccineEditForm } from "@/domains/vaccines/edit/vaccine-form";
+
+export default function EditVaccinePage() {
+  const params = useParams();
+  const id = typeof params.id === "string" ? params.id : "";
+  return <VaccineEditForm id={id} />;
+}

--- a/apps/apae/src/app/vaccines/new/page.tsx
+++ b/apps/apae/src/app/vaccines/new/page.tsx
@@ -1,0 +1,5 @@
+import { VaccineCreateForm } from "@/domains/vaccines/create/vaccine-form";
+
+export default function NewVaccinePage() {
+  return <VaccineCreateForm />;
+}

--- a/apps/apae/src/domains/vaccines/create/use-vaccine-create.ts
+++ b/apps/apae/src/domains/vaccines/create/use-vaccine-create.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "react-toastify";
+import { createVaccineApi } from "../vaccines.api";
+import type { CreateVaccineParams } from "../vaccines.types";
+
+export function useVaccineCreate() {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const router = useRouter();
+
+  const createVaccine = async (params: CreateVaccineParams) => {
+    try {
+      setIsSubmitting(true);
+      await createVaccineApi(params);
+      toast.success("Vacina criada com sucesso.");
+      router.push("/vaccines");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Erro ao criar vacina.";
+      toast.error(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return { createVaccine, isSubmitting };
+}

--- a/apps/apae/src/domains/vaccines/create/vaccine-form.tsx
+++ b/apps/apae/src/domains/vaccines/create/vaccine-form.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ArrowLeft } from "lucide-react";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { createVaccineSchema, type CreateVaccineFormData } from "../vaccines.schema";
+import { useVaccineCreate } from "./use-vaccine-create";
+
+export function VaccineCreateForm() {
+  const router = useRouter();
+  const { createVaccine, isSubmitting } = useVaccineCreate();
+
+  const form = useForm<CreateVaccineFormData>({
+    resolver: zodResolver(createVaccineSchema),
+    mode: "onChange",
+    defaultValues: { name: "" },
+  });
+
+  const onSubmit = async (data: CreateVaccineFormData) => {
+    await createVaccine(data);
+  };
+
+  return (
+    <div className="!bg-slate-100 min-h-screen">
+      <main className="container mx-auto p-4 md:p-6">
+        <div className="bg-white rounded-xl shadow-md border-2 p-6 mb-4">
+          <Button variant="ghost" onClick={() => router.back()} className="mb-4 text-sm text-[#003B93] hover:bg-blue-50">
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Voltar
+          </Button>
+
+          <h1 className="text-2xl font-bold mb-6 text-[#003B93]">Nova Vacina</h1>
+
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel className="font-semibold text-[#003B93]">Nome da Vacina</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="Ex: Influenza"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <div className="flex justify-end gap-2 pt-4">
+                <Button type="button" variant="outline" onClick={() => router.back()}>Cancelar</Button>
+                <Button type="submit" disabled={isSubmitting} className="!bg-[#0D4F97] !hover:bg-[#0b427d] text-white">
+                  {isSubmitting ? "Salvando..." : "Salvar"}
+                </Button>
+              </div>
+            </form>
+          </Form>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/apae/src/domains/vaccines/edit/use-vaccine-edit.ts
+++ b/apps/apae/src/domains/vaccines/edit/use-vaccine-edit.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "react-toastify";
+import { fetchVaccineApi, updateVaccineApi } from "../vaccines.api";
+import type { Vaccine, UpdateVaccineParams } from "../vaccines.types";
+
+export function useVaccineEdit(id: string) {
+  const [vaccine, setVaccine] = useState<Vaccine | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!id) return;
+    const load = async () => {
+      try {
+        const data = await fetchVaccineApi(id);
+        setVaccine(data);
+      } catch {
+        toast.error("Erro ao carregar a vacina.");
+        router.push("/vaccines");
+      }
+    };
+    load();
+  }, [id, router]);
+
+  const updateVaccine = async (params: UpdateVaccineParams) => {
+    try {
+      setIsSubmitting(true);
+      await updateVaccineApi(params);
+      toast.success("Vacina atualizada com sucesso.");
+      router.push("/vaccines");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Erro ao atualizar vacina.";
+      toast.error(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return { vaccine, updateVaccine, isSubmitting };
+}

--- a/apps/apae/src/domains/vaccines/edit/vaccine-form.tsx
+++ b/apps/apae/src/domains/vaccines/edit/vaccine-form.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ArrowLeft, Loader2 } from "lucide-react";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { updateVaccineSchema, type UpdateVaccineFormData } from "../vaccines.schema";
+import { useVaccineEdit } from "./use-vaccine-edit";
+
+interface VaccineEditFormProps {
+  id: string;
+}
+
+export function VaccineEditForm({ id }: VaccineEditFormProps) {
+  const router = useRouter();
+  const { vaccine, updateVaccine, isSubmitting } = useVaccineEdit(id);
+
+  const form = useForm<UpdateVaccineFormData>({
+    resolver: zodResolver(updateVaccineSchema),
+    mode: "onChange",
+    defaultValues: { name: "" },
+  });
+
+  useEffect(() => {
+    if (vaccine) form.reset({ name: vaccine.name });
+  }, [vaccine, form]);
+
+  const onSubmit = async (data: UpdateVaccineFormData) => {
+    await updateVaccine({ id, name: data.name });
+  };
+
+  if (!vaccine) {
+    return (
+      <div className="flex justify-center items-center p-10">
+        <Loader2 className="h-8 w-8 animate-spin text-gray-500" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="!bg-slate-100 min-h-screen">
+      <main className="container mx-auto p-4 md:p-6">
+        <div className="bg-white rounded-xl shadow-md border-2 p-6 mb-4">
+          <Button variant="ghost" onClick={() => router.back()} className="mb-4 text-sm text-[#003B93] hover:bg-blue-50">
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Voltar
+          </Button>
+
+          <h1 className="text-2xl font-bold mb-6 text-[#003B93]">Editar Vacina</h1>
+
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel className="font-semibold text-[#003B93]">Nome da Vacina</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="Ex: Influenza"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <div className="flex justify-end gap-2 pt-4">
+                <Button type="button" variant="outline" onClick={() => router.back()}>Cancelar</Button>
+                <Button type="submit" disabled={isSubmitting} className="!bg-[#0D4F97] !hover:bg-[#0b427d] text-white">
+                  {isSubmitting ? "Atualizando..." : "Atualizar"}
+                </Button>
+              </div>
+            </form>
+          </Form>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/apae/src/domains/vaccines/list/use-vaccines-list.ts
+++ b/apps/apae/src/domains/vaccines/list/use-vaccines-list.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "react-toastify";
-import { fetchVaccinesApi } from "../vaccines.api";
+import { fetchVaccinesApi, deleteVaccineApi } from "../vaccines.api";
 import type { Vaccine } from "../vaccines.types";
 
 export function useVaccinesList() {
@@ -22,9 +22,20 @@ export function useVaccinesList() {
     }
   }, []);
 
+  const deleteVaccine = useCallback(async (id: string) => {
+    try {
+      await deleteVaccineApi({ id });
+      toast.success("Vacina excluída com sucesso.");
+      await loadVaccines();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Erro ao excluir vacina.";
+      toast.error(message);
+    }
+  }, [loadVaccines]);
+
   useEffect(() => {
     loadVaccines();
   }, [loadVaccines]);
 
-  return { vaccines, loading };
+  return { vaccines, loading, deleteVaccine };
 }

--- a/apps/apae/src/domains/vaccines/list/vaccines-list.tsx
+++ b/apps/apae/src/domains/vaccines/list/vaccines-list.tsx
@@ -1,16 +1,17 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { SearchFilters } from "@/components/search-filters";
-import { ArrowLeft, Loader2 } from "lucide-react";
+import { ArrowLeft, Loader2, Plus } from "lucide-react";
 import { VaccineListItem } from "../shared/vaccine-list-item";
 import { useVaccinesList } from "./use-vaccines-list";
 
 export function VaccinesList() {
   const [searchName, setSearchName] = useState("");
-  const { vaccines, loading } = useVaccinesList();
+  const { vaccines, loading, deleteVaccine } = useVaccinesList();
   const router = useRouter();
 
   const filtered = vaccines.filter((v) =>
@@ -35,6 +36,9 @@ export function VaccinesList() {
         <section className="relative md:bg-white md:rounded-xl md:shadow-md md:border-2 md:p-6">
           <div className="hidden md:flex justify-between items-center mb-4">
             <h2 className="text-xl font-bold text-[#003B93]">Vacinas Cadastradas</h2>
+            <Button asChild className="!bg-[#0D4F97] !hover:bg-[#0b427d] text-white">
+              <Link href="/vaccines/new">Adicionar</Link>
+            </Button>
           </div>
 
           <div className="mb-4 md:hidden">
@@ -57,6 +61,8 @@ export function VaccinesList() {
                   <VaccineListItem
                     key={vaccine.id}
                     vaccine={vaccine}
+                    onEdit={() => router.push(`/vaccines/${vaccine.id}/edit`)}
+                    onDelete={() => deleteVaccine(vaccine.id)}
                   />
                 ))}
               </div>
@@ -64,6 +70,16 @@ export function VaccinesList() {
           )}
         </section>
       </main>
+
+      <Button
+        asChild
+        className="fixed bottom-6 right-6 h-[53px] w-[53px] rounded-full shadow-lg md:hidden bg-[#0D4F97] hover:bg-[#0b427d]"
+      >
+        <Link href="/vaccines/new">
+          <Plus className="h-7 w-7" />
+          <span className="sr-only">Adicionar Vacina</span>
+        </Link>
+      </Button>
     </div>
   );
 }

--- a/apps/apae/src/domains/vaccines/shared/vaccine-list-item.tsx
+++ b/apps/apae/src/domains/vaccines/shared/vaccine-list-item.tsx
@@ -1,17 +1,67 @@
 "use client";
 
+import { Button } from "@/components/ui/button";
+import { ConfirmModal } from "@/components/ui/confirm-modal";
+import { Edit, Trash2 } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@radix-ui/react-tooltip";
 import type { Vaccine } from "../vaccines.types";
 
 interface VaccineListItemProps {
   vaccine: Vaccine;
+  onEdit: () => void;
+  onDelete: () => void;
 }
 
-export function VaccineListItem({ vaccine }: VaccineListItemProps) {
+export function VaccineListItem({ vaccine, onEdit, onDelete }: VaccineListItemProps) {
   return (
-    <div className="flex items-center p-4 border-b hover:bg-gray-50 transition-colors">
+    <div className="flex items-center justify-between p-4 border-b hover:bg-gray-50 transition-colors">
       <div className="flex-1">
         <h3 className="font-bold text-base text-[#003B93]">{vaccine.name}</h3>
+      </div>
+      <div className="flex items-center gap-2 ml-4">
+        <Button variant="outline" size="icon" className="h-8 w-8" onClick={onEdit} aria-label="Editar">
+          <Edit className="h-4 w-4" />
+        </Button>
+
+        {vaccine.hasPatient ? (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="cursor-not-allowed">
+                  <Button variant="outline" size="icon" disabled className="opacity-50 pointer-events-none h-8 w-8">
+                    <Trash2 className="h-4 w-4 text-red-500" />
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="top" className="bg-slate-800 text-white p-2 rounded shadow-lg">
+                <p>Não é possível excluir uma vacina associada a um paciente!</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ) : (
+          <ConfirmModal
+            title="Tem certeza?"
+            description={
+              <>
+                Essa ação não pode ser desfeita. Isso irá excluir permanentemente a vacina{" "}
+                <strong>{vaccine.name}</strong>.
+              </>
+            }
+            onConfirm={onDelete}
+            trigger={
+              <Button variant="outline" size="icon" className="h-8 w-8 hover:bg-red-50">
+                <Trash2 className="h-4 w-4 text-red-500" />
+              </Button>
+            }
+          />
+        )}
       </div>
     </div>
   );
 }
+

--- a/apps/apae/src/domains/vaccines/vaccines.api.ts
+++ b/apps/apae/src/domains/vaccines/vaccines.api.ts
@@ -1,4 +1,4 @@
-import type { Vaccine } from "./vaccines.types";
+import type { Vaccine, CreateVaccineParams, UpdateVaccineParams, DeleteVaccineParams } from "./vaccines.types";
 
 const BASE_URL = "/apae-geral/api/vaccines";
 
@@ -6,4 +6,41 @@ export async function fetchVaccinesApi(): Promise<Vaccine[]> {
   const response = await fetch(BASE_URL);
   if (!response.ok) throw new Error("Ocorreu um erro ao carregar as vacinas.");
   return response.json();
+}
+
+export async function fetchVaccineApi(id: string): Promise<Vaccine> {
+  const response = await fetch(`${BASE_URL}/${id}`);
+  if (!response.ok) throw new Error("Ocorreu um erro ao carregar a vacina.");
+  return response.json();
+}
+
+export async function createVaccineApi(params: CreateVaccineParams): Promise<Vaccine> {
+  const response = await fetch(BASE_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(params),
+  });
+  if (!response.ok) throw new Error("Ocorreu um erro ao criar a vacina.");
+  return response.json();
+}
+
+export async function updateVaccineApi(params: UpdateVaccineParams): Promise<Vaccine> {
+  const { id, ...body } = params;
+  const response = await fetch(`${BASE_URL}/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) throw new Error("Ocorreu um erro ao atualizar a vacina.");
+  return response.json();
+}
+
+export async function deleteVaccineApi(params: DeleteVaccineParams): Promise<void> {
+  const response = await fetch(`${BASE_URL}/${params.id}`, {
+    method: "DELETE",
+  });
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => null);
+    throw new Error(errorData?.message || "Ocorreu um erro ao excluir a vacina.");
+  }
 }

--- a/apps/apae/src/domains/vaccines/vaccines.api.ts
+++ b/apps/apae/src/domains/vaccines/vaccines.api.ts
@@ -20,7 +20,10 @@ export async function createVaccineApi(params: CreateVaccineParams): Promise<Vac
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(params),
   });
-  if (!response.ok) throw new Error("Ocorreu um erro ao criar a vacina.");
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => null);
+    throw new Error(errorData?.message || "Ocorreu um erro ao criar a vacina.");
+  }
   return response.json();
 }
 
@@ -31,7 +34,10 @@ export async function updateVaccineApi(params: UpdateVaccineParams): Promise<Vac
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
-  if (!response.ok) throw new Error("Ocorreu um erro ao atualizar a vacina.");
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => null);
+    throw new Error(errorData?.message || "Ocorreu um erro ao atualizar a vacina.");
+  }
   return response.json();
 }
 

--- a/apps/apae/src/domains/vaccines/vaccines.schema.ts
+++ b/apps/apae/src/domains/vaccines/vaccines.schema.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const createVaccineSchema = z.object({
+  name: z.string().min(1, "O nome da vacina é obrigatório.").max(100, "O nome deve ter no máximo 100 caracteres."),
+});
+
+export const updateVaccineSchema = z.object({
+  name: z.string().min(1, "O nome da vacina é obrigatório.").max(100, "O nome deve ter no máximo 100 caracteres."),
+});
+
+export type CreateVaccineFormData = z.infer<typeof createVaccineSchema>;
+export type UpdateVaccineFormData = z.infer<typeof updateVaccineSchema>;

--- a/apps/apae/src/domains/vaccines/vaccines.schema.ts
+++ b/apps/apae/src/domains/vaccines/vaccines.schema.ts
@@ -1,11 +1,11 @@
 import { z } from "zod";
 
 export const createVaccineSchema = z.object({
-  name: z.string().min(1, "O nome da vacina é obrigatório.").max(100, "O nome deve ter no máximo 100 caracteres."),
+  name: z.string().min(2, "O nome da vacina deve ter pelo menos 2 caracteres.").max(100, "O nome deve ter no máximo 100 caracteres."),
 });
 
 export const updateVaccineSchema = z.object({
-  name: z.string().min(1, "O nome da vacina é obrigatório.").max(100, "O nome deve ter no máximo 100 caracteres."),
+  name: z.string().min(2, "O nome da vacina deve ter pelo menos 2 caracteres.").max(100, "O nome deve ter no máximo 100 caracteres."),
 });
 
 export type CreateVaccineFormData = z.infer<typeof createVaccineSchema>;

--- a/apps/apae/src/domains/vaccines/vaccines.types.ts
+++ b/apps/apae/src/domains/vaccines/vaccines.types.ts
@@ -3,3 +3,16 @@ export type Vaccine = Readonly<{
   name: string;
   hasPatient: boolean;
 }>;
+
+export type CreateVaccineParams = Readonly<{
+  name: string;
+}>;
+
+export type UpdateVaccineParams = Readonly<{
+  id: string;
+  name: string;
+}>;
+
+export type DeleteVaccineParams = Readonly<{
+  id: string;
+}>;

--- a/apps/api/src/main/java/br/org/apae/api/common/dto/patient/request/vaccine/CreateVaccineDTO.java
+++ b/apps/api/src/main/java/br/org/apae/api/common/dto/patient/request/vaccine/CreateVaccineDTO.java
@@ -1,0 +1,8 @@
+package br.org.apae.api.common.dto.patient.request.vaccine;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreateVaccineDTO(
+        @NotBlank(message = "O nome da vacina é obrigatório.") @Size(min = 2, max = 100, message = "O nome da vacina deve ter entre 2 e 100 caracteres.") String name) {
+}

--- a/apps/api/src/main/java/br/org/apae/api/common/dto/patient/request/vaccine/UpdateVaccineDTO.java
+++ b/apps/api/src/main/java/br/org/apae/api/common/dto/patient/request/vaccine/UpdateVaccineDTO.java
@@ -1,0 +1,8 @@
+package br.org.apae.api.common.dto.patient.request.vaccine;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdateVaccineDTO(
+        @NotBlank(message = "O nome da vacina é obrigatório.") @Size(min = 2, max = 100, message = "O nome da vacina deve ter entre 2 e 100 caracteres.") String name) {
+}

--- a/apps/api/src/main/java/br/org/apae/api/controllers/vaccine/VaccineControllerImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/controllers/vaccine/VaccineControllerImpl.java
@@ -1,9 +1,13 @@
 package br.org.apae.api.controllers.vaccine;
 
-import br.org.apae.api.patient.application.interfaces.VaccineApplicationService;
+import br.org.apae.api.common.dto.patient.request.vaccine.CreateVaccineDTO;
+import br.org.apae.api.common.dto.patient.request.vaccine.UpdateVaccineDTO;
 import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
+import br.org.apae.api.patient.application.interfaces.VaccineApplicationService;
 import br.org.apae.api.patient.interfaces.controllers.VaccineController;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +21,12 @@ public class VaccineControllerImpl implements VaccineController {
     @Autowired
     public VaccineControllerImpl(VaccineApplicationService vaccineService) {
         this.vaccineService = vaccineService;
+    }
+
+    @Override
+    public ResponseEntity<VaccineResponseDTO> createVaccine(@Valid CreateVaccineDTO dto) {
+        VaccineResponseDTO createdVaccine = vaccineService.createVaccine(dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdVaccine);
     }
 
     @Override
@@ -35,5 +45,17 @@ public class VaccineControllerImpl implements VaccineController {
     public ResponseEntity<VaccineResponseDTO> findByName(String name) {
         VaccineResponseDTO vaccine = vaccineService.findVaccineByName(name);
         return ResponseEntity.ok(vaccine);
+    }
+
+    @Override
+    public ResponseEntity<VaccineResponseDTO> updateVaccine(UUID id, @Valid UpdateVaccineDTO dto) {
+        VaccineResponseDTO updatedVaccine = vaccineService.updateVaccine(id, dto);
+        return ResponseEntity.ok(updatedVaccine);
+    }
+
+    @Override
+    public ResponseEntity<Void> deleteVaccine(UUID id) {
+        vaccineService.deleteVaccine(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/apps/api/src/main/java/br/org/apae/api/patient/application/exceptions/PatientExceptionHandler.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/application/exceptions/PatientExceptionHandler.java
@@ -13,6 +13,8 @@ import br.org.apae.api.patient.domain.exceptions.PatientConflictException;
 import br.org.apae.api.patient.domain.exceptions.PatientNotFoundException;
 import br.org.apae.api.patient.domain.exceptions.RegistryNotFoundException;
 import br.org.apae.api.patient.domain.exceptions.RegistryOwnershipException;
+import br.org.apae.api.patient.domain.exceptions.VaccineConflictException;
+import br.org.apae.api.patient.domain.exceptions.VaccineInUseException;
 import br.org.apae.api.patient.domain.exceptions.VaccineMismatchException;
 import br.org.apae.api.patient.domain.exceptions.VaccineNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -146,6 +148,36 @@ public class PatientExceptionHandler {
     );
 
     return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(VaccineConflictException.class)
+  public ResponseEntity<ErrorResponse> handleVaccineConflict(
+          VaccineConflictException ex,
+          HttpServletRequest request
+  ) {
+    ErrorResponse error = new ErrorResponse(
+            HttpStatus.CONFLICT.value(),
+            HttpStatus.CONFLICT.getReasonPhrase(),
+            ex.getMessage(),
+            request.getRequestURI()
+    );
+
+    return new ResponseEntity<>(error, HttpStatus.CONFLICT);
+  }
+
+  @ExceptionHandler(VaccineInUseException.class)
+  public ResponseEntity<ErrorResponse> handleVaccineInUse(
+          VaccineInUseException ex,
+          HttpServletRequest request
+  ) {
+    ErrorResponse error = new ErrorResponse(
+            HttpStatus.CONFLICT.value(),
+            HttpStatus.CONFLICT.getReasonPhrase(),
+            ex.getMessage(),
+            request.getRequestURI()
+    );
+
+    return new ResponseEntity<>(error, HttpStatus.CONFLICT);
   }
 
   @ExceptionHandler(DisorderConflictException.class)

--- a/apps/api/src/main/java/br/org/apae/api/patient/application/interfaces/VaccineApplicationService.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/application/interfaces/VaccineApplicationService.java
@@ -4,10 +4,14 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import br.org.apae.api.common.dto.patient.request.vaccine.CreateVaccineDTO;
+import br.org.apae.api.common.dto.patient.request.vaccine.UpdateVaccineDTO;
 import br.org.apae.api.common.dto.patient.request.vaccine.VaccineNameDTO;
 import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
 
 public interface VaccineApplicationService {
+  VaccineResponseDTO createVaccine(CreateVaccineDTO dto);
+
   VaccineResponseDTO findVaccineById(UUID id);
 
   List<VaccineResponseDTO> findAllVaccines();
@@ -15,4 +19,8 @@ public interface VaccineApplicationService {
   VaccineResponseDTO findVaccineByName(String name);
 
   Set<VaccineResponseDTO> findVaccines(Set<VaccineNameDTO> vaccineNames);
+
+  VaccineResponseDTO updateVaccine(UUID id, UpdateVaccineDTO dto);
+
+  void deleteVaccine(UUID id);
 }

--- a/apps/api/src/main/java/br/org/apae/api/patient/application/internal/VaccineApplicationServiceImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/application/internal/VaccineApplicationServiceImpl.java
@@ -1,22 +1,26 @@
 package br.org.apae.api.patient.application.internal;
 
+import br.org.apae.api.common.dto.patient.request.vaccine.CreateVaccineDTO;
+import br.org.apae.api.common.dto.patient.request.vaccine.UpdateVaccineDTO;
+import br.org.apae.api.common.dto.patient.request.vaccine.VaccineNameDTO;
+import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
+import br.org.apae.api.patient.application.interfaces.VaccineApplicationService;
+import br.org.apae.api.patient.application.mappers.VaccineMapper;
+import br.org.apae.api.patient.domain.exceptions.VaccineConflictException;
+import br.org.apae.api.patient.domain.exceptions.VaccineInUseException;
 import br.org.apae.api.patient.domain.exceptions.VaccineMismatchException;
 import br.org.apae.api.patient.domain.exceptions.VaccineNotFoundException;
 import br.org.apae.api.patient.domain.model.Vaccine;
 import br.org.apae.api.patient.domain.repository.PatientRepository;
 import br.org.apae.api.patient.domain.repository.VaccineRepository;
-import br.org.apae.api.common.dto.patient.request.vaccine.VaccineNameDTO;
-import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Set;
-
-import br.org.apae.api.patient.application.interfaces.VaccineApplicationService;
-import br.org.apae.api.patient.application.mappers.VaccineMapper;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -35,12 +39,26 @@ public class VaccineApplicationServiceImpl implements VaccineApplicationService 
     }
 
     @Override
+    @Transactional
+    public VaccineResponseDTO createVaccine(CreateVaccineDTO dto) {
+        if (vaccineRepository.findByNameIgnoreCase(dto.name()).isPresent()) {
+            throw new VaccineConflictException(dto.name());
+        }
+
+        Vaccine vaccine = vaccineMapper.toEntity(dto);
+        Vaccine savedVaccine = vaccineRepository.save(vaccine);
+
+        return new VaccineResponseDTO(savedVaccine.getId(), savedVaccine.getName(), false);
+    }
+
+    @Override
     @Transactional(readOnly = true)
     public VaccineResponseDTO findVaccineById(UUID id) {
         Vaccine vaccine = vaccineRepository.findById(id)
                 .orElseThrow(VaccineNotFoundException::new);
 
-        return vaccineMapper.toResponseDTO(vaccine);
+        boolean inUse = patientRepository.isVaccineInUse(id);
+        return new VaccineResponseDTO(vaccine.getId(), vaccine.getName(), inUse);
     }
 
     @Override
@@ -50,7 +68,8 @@ public class VaccineApplicationServiceImpl implements VaccineApplicationService 
                 .orElseThrow(
                         () -> new VaccineNotFoundException(name));
 
-        return vaccineMapper.toResponseDTO(vaccine);
+        boolean inUse = patientRepository.isVaccineInUse(vaccine.getId());
+        return new VaccineResponseDTO(vaccine.getId(), vaccine.getName(), inUse);
     }
 
     @Override
@@ -77,5 +96,43 @@ public class VaccineApplicationServiceImpl implements VaccineApplicationService 
         }
 
         return vaccineMapper.toResponseDTOSet(vaccines);
+    }
+
+    @Override
+    @Transactional
+    public VaccineResponseDTO updateVaccine(UUID id, UpdateVaccineDTO dto) {
+        Vaccine vaccine = vaccineRepository.findById(id)
+                .orElseThrow(VaccineNotFoundException::new);
+
+        if (dto.name() != null && !dto.name().isEmpty()) {
+            if (vaccineRepository.existsByNameIgnoreCaseAndIdNot(dto.name(), id)) {
+                throw new VaccineConflictException(dto.name());
+            }
+            vaccine.setName(dto.name());
+        }
+
+        Vaccine updatedVaccine = vaccineRepository.save(vaccine);
+        boolean inUse = patientRepository.isVaccineInUse(id);
+
+        return new VaccineResponseDTO(updatedVaccine.getId(), updatedVaccine.getName(), inUse);
+    }
+
+    @Override
+    @Transactional
+    public void deleteVaccine(UUID id) {
+        if (!vaccineRepository.existsById(id)) {
+            throw new VaccineNotFoundException();
+        }
+
+        if (patientRepository.isVaccineInUse(id)) {
+            throw new VaccineInUseException();
+        }
+
+        try {
+            vaccineRepository.deleteById(id);
+            vaccineRepository.flush();
+        } catch (DataIntegrityViolationException e) {
+            throw new VaccineInUseException();
+        }
     }
 }

--- a/apps/api/src/main/java/br/org/apae/api/patient/application/internal/VaccineApplicationServiceImpl.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/application/internal/VaccineApplicationServiceImpl.java
@@ -108,7 +108,7 @@ public class VaccineApplicationServiceImpl implements VaccineApplicationService 
             if (vaccineRepository.existsByNameIgnoreCaseAndIdNot(dto.name(), id)) {
                 throw new VaccineConflictException(dto.name());
             }
-            vaccine.setName(dto.name());
+            vaccine.updateName(dto.name());
         }
 
         Vaccine updatedVaccine = vaccineRepository.save(vaccine);

--- a/apps/api/src/main/java/br/org/apae/api/patient/application/mappers/VaccineMapper.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/application/mappers/VaccineMapper.java
@@ -1,5 +1,6 @@
 package br.org.apae.api.patient.application.mappers;
 
+import br.org.apae.api.common.dto.patient.request.vaccine.CreateVaccineDTO;
 import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
 import br.org.apae.api.patient.domain.model.Vaccine;
 
@@ -10,6 +11,16 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class VaccineMapper {
+
+    public Vaccine toEntity(CreateVaccineDTO dto) {
+        return new Vaccine(dto.name());
+    }
+
+    public Set<Vaccine> toEntitySet(Set<CreateVaccineDTO> dtos) {
+        return dtos.stream()
+                .map(this::toEntity)
+                .collect(Collectors.toSet());
+    }
 
     public Set<Vaccine> toEntitySetFromResponse(Set<VaccineResponseDTO> responseDTOs) {
         return responseDTOs.stream()

--- a/apps/api/src/main/java/br/org/apae/api/patient/domain/exceptions/VaccineConflictException.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/domain/exceptions/VaccineConflictException.java
@@ -1,0 +1,13 @@
+package br.org.apae.api.patient.domain.exceptions;
+
+public class VaccineConflictException extends RuntimeException {
+    private static final String MESSAGE = "Vacina já existe.";
+
+    public VaccineConflictException() {
+        super(MESSAGE);
+    }
+
+    public VaccineConflictException(String name) {
+        super("Já existe uma vacina com o nome: " + name);
+    }
+}

--- a/apps/api/src/main/java/br/org/apae/api/patient/domain/exceptions/VaccineInUseException.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/domain/exceptions/VaccineInUseException.java
@@ -1,0 +1,13 @@
+package br.org.apae.api.patient.domain.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class VaccineInUseException extends RuntimeException {
+    private static final String MESSAGE = "Não é possível excluir esta vacina, pois ela está vinculada a um ou mais pacientes.";
+
+    public VaccineInUseException() {
+        super(MESSAGE);
+    }
+}

--- a/apps/api/src/main/java/br/org/apae/api/patient/domain/repository/VaccineRepository.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/domain/repository/VaccineRepository.java
@@ -13,5 +13,9 @@ import java.util.UUID;
 public interface VaccineRepository extends JpaRepository<Vaccine, UUID> {
     Optional<Vaccine> findByName(String name);
 
+    Optional<Vaccine> findByNameIgnoreCase(String name);
+
     Set<Vaccine> findByNameInIgnoreCase(Collection<String> names);
+
+    boolean existsByNameIgnoreCaseAndIdNot(String name, UUID id);
 }

--- a/apps/api/src/main/java/br/org/apae/api/patient/interfaces/controllers/VaccineController.java
+++ b/apps/api/src/main/java/br/org/apae/api/patient/interfaces/controllers/VaccineController.java
@@ -1,7 +1,11 @@
 package br.org.apae.api.patient.interfaces.controllers;
 
+import br.org.apae.api.common.dto.patient.request.vaccine.CreateVaccineDTO;
+import br.org.apae.api.common.dto.patient.request.vaccine.UpdateVaccineDTO;
 import br.org.apae.api.common.dto.patient.response.vaccine.VaccineResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -11,8 +15,17 @@ import java.util.List;
 import java.util.UUID;
 
 @RequestMapping("/vaccines")
-@Tag(name = "Vaccines", description = "Endpoints para consulta de vacinas")
+@Tag(name = "Vaccines", description = "Endpoints para consulta e gerenciamento de vacinas")
 public interface VaccineController {
+
+        @Operation(summary = "Criar vacina", description = "Cria uma nova vacina no sistema. Falha se o nome já existir.")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "201", description = "Vacina criada com sucesso"),
+                        @ApiResponse(responseCode = "400", description = "Dados inválidos"),
+                        @ApiResponse(responseCode = "409", description = "Conflito: Vacina com este nome já existe")
+        })
+        @PostMapping
+        ResponseEntity<VaccineResponseDTO> createVaccine(@RequestBody CreateVaccineDTO dto);
 
         @Operation(summary = "Buscar vacina por ID", description = "Retorna os dados de uma vacina específica pelo seu ID.")
         @ApiResponses(value = {
@@ -36,4 +49,22 @@ public interface VaccineController {
         })
         @GetMapping("/search/by-name")
         ResponseEntity<VaccineResponseDTO> findByName(@RequestParam String name);
+
+        @Operation(summary = "Atualizar vacina", description = "Atualiza o nome de uma vacina existente.")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "Vacina atualizada com sucesso"),
+                        @ApiResponse(responseCode = "404", description = "Vacina não encontrada"),
+                        @ApiResponse(responseCode = "409", description = "Conflito: Nome já existe")
+        })
+        @PutMapping("/{id}")
+        ResponseEntity<VaccineResponseDTO> updateVaccine(@PathVariable UUID id, @RequestBody UpdateVaccineDTO dto);
+
+        @Operation(summary = "Excluir vacina", description = "Remove uma vacina pelo seu identificador (UUID).")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "204", description = "Vacina excluída com sucesso"),
+                        @ApiResponse(responseCode = "404", description = "Vacina não encontrada"),
+                        @ApiResponse(responseCode = "409", description = "Conflito: Vacina está vinculada a pacientes")
+        })
+        @DeleteMapping("/{id}")
+        ResponseEntity<Void> deleteVaccine(@PathVariable UUID id);
 }


### PR DESCRIPTION
# O que mudou?

Implementação do CRUD de vacinas com backend e front-end funcionais dentro dos requisitos da issue #906.

## Issue Relacionada

Closes https://github.com/IFPBEsp/APAE/issues/906

## Mudanças Realizadas

- `/vaccines` lista vacinas com filtro por nome
- `/vaccines/new` permite criar vacina
- `/vaccines/[id]/edit` permite editar vacina
- Listagem permite excluir vacina com confirmação
- Vacinas vinculadas a pacientes não podem ser excluídas
- Backend expõe endpoints `POST`, `PUT`, `DELETE`
- Todos os endpoints `GET` mantidos
- Nenhuma alteração em schema/tabela/migration/dados

