### PR TITLE
fix: corrige o calculo de expiracao do jwt (resolves #917)

### DIFF
--- a/apps/api/src/main/java/br/org/apae/api/auth/infrastructure/security/JwtProvider.java
+++ b/apps/api/src/main/java/br/org/apae/api/auth/infrastructure/security/JwtProvider.java
@@ -1,8 +1,7 @@
 package br.org.apae.api.auth.infrastructure.security;
 
+import java.time.Duration;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -25,8 +24,11 @@ public class JwtProvider implements TokenProvider {
   @Value("${app.token.issuer}")
   private String ISSUER;
 
+  @Value("${app.token.expiration-hours}")
+  private long expirationHours;
+
   private Instant genExpirationDate() {
-    return LocalDateTime.now().plusHours(24).toInstant(ZoneOffset.of("-03:00"));
+    return Instant.now().plus(Duration.ofHours(expirationHours));
   }
 
   @Override

--- a/apps/api/src/main/resources/application.yaml
+++ b/apps/api/src/main/resources/application.yaml
@@ -67,6 +67,7 @@ app:
   token:
     secret: ${JWT_SECRET}
     issuer: apae-api
+    expiration-hours: ${JWT_EXPIRATION_HOURS:24}
   frontend:
     reset-password-url: ${APP_FRONTEND_RESET_PASSWORD_URL:http://localhost:3000/apae-geral/auth/reset-password}
 


### PR DESCRIPTION
# O que mudou?

Corrige o cálculo de expiração do JWT, que sofria um recuo de 3 horas em ambientes com fuso UTC (padrão de contêineres) por causa do uso de `LocalDateTime.now()` combinado com um `ZoneOffset` fixo de `-03:00`. Também passa a ler a variável de ambiente `JWT_EXPIRATION_HOURS`, que já era injetada pelo compose mas não tinha nenhum código lendo o valor

## Tarefas Relacionadas

* Issue: Resolves #917
* Outras dependências: N/A

## Mudanças Realizadas

* Refatoração do método `genExpirationDate()` no `JwtProvider.java`, substituindo `LocalDateTime` e `ZoneOffset` por `Instant.now().plus(Duration.ofHours())`.
* Injeção dinâmica do tempo de expiração na classe `JwtProvider` utilizando a anotação `@Value`.
* Adição da propriedade `app.token.expiration-hours: ${JWT_EXPIRATION_HOURS:24}` no arquivo `application.yaml`, garantindo a leitura da variável injetada na infraestrutura com um valor de fallback seguro de 24h.

## Evidências

Testado subindo a API duas vezes no mesmo ambiente (banco resetado do zero), uma com `TZ=America/Sao_Paulo` e outra com `TZ=UTC`, medindo a validade do token retornado no login em cada caso:

* `TZ=America/Sao_Paulo` → validade do token: `1 day, 0:00:00`
* `TZ=UTC` → validade do token: `1 day, 0:00:00`

Os dois valores batem exatamente — o token não perde mais as 3 horas em ambiente UTC.

**Print 1:** boot da API em `TZ=America/Sao_Paulo` (timestamp `-03:00`)
<img width="967" height="1017" alt="P1" src="https://github.com/user-attachments/assets/f9177beb-72cb-4081-aadb-0a2615424c12" />

**Print 2:** boot da API em `TZ=UTC` (timestamp `Z`)
<img width="967" height="1017" alt="P2" src="https://github.com/user-attachments/assets/6be26b59-ef2f-4d67-92ad-ac4c4be3aae9" />

**Print 3:** as duas medições de `validade` lado a lado
<img width="959" height="380" alt="P3" src="https://github.com/user-attachments/assets/54ed0c7b-25e8-4cb5-bca1-988cfb6df96a" />